### PR TITLE
unary_s (math module function) kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl/module_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/module_kernel.cu
@@ -1,0 +1,1 @@
+<%= method_code %>

--- a/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
@@ -1,0 +1,58 @@
+<% unless type_name == 'robject' %>
+__global__ void <%="#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, size_t n)
+{
+    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    }
+}
+
+__global__ void <%="#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, size_t n)
+{
+    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    }
+}
+
+__global__ void <%="#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, size_t n)
+{
+    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
+    }
+}
+
+__global__ void <%="#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t n)
+{
+    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
+    }
+}
+
+void <%="#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, size_t n)
+{
+    size_t gridDim = get_gridDim(n);
+    size_t blockDim = get_blockDim(n);
+    <%="#{c_iter}_index_index_kernel"%><<<gridDim, blockDim>>>(p1,p2,idx1,idx2,n);
+}
+
+void <%="#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, size_t n)
+{
+    size_t gridDim = get_gridDim(n);
+    size_t blockDim = get_blockDim(n);
+    <%="#{c_iter}_index_stride_kernel"%><<<gridDim, blockDim>>>(p1,p2,idx1,s2,n);
+}
+
+void <%="#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, size_t n)
+{
+    size_t gridDim = get_gridDim(n);
+    size_t blockDim = get_blockDim(n);
+    <%="#{c_iter}_stride_index_kernel"%><<<gridDim, blockDim>>>(p1,p2,s1,idx2,n);
+}
+
+void <%="#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t n)
+{
+    size_t gridDim = get_gridDim(n);
+    size_t blockDim = get_blockDim(n);
+    <%="#{c_iter}_stride_stride_kernel"%><<<gridDim, blockDim>>>(p1,p2,s1,s2,n);
+}
+
+<% end %>


### PR DESCRIPTION
```
  math "sqrt"
  math "cbrt"
  math "log"
  math "log2"
  math "log10"
  math "exp"
  math "exp2"
  math "exp10"
  math "sin"
  math "cos"
  math "tan"
  math "asin"
  math "acos"
  math "atan"
  math "sinh"
  math "cosh"
  math "tanh"
  math "asinh"
  math "acosh"
  math "atanh"
  math "sinc"
    # math "atan2",2
    # math "hypot",2
    math "erf"
    math "erfc"
    math "log1p"
    math "expm1"
    # math "ldexp",2
    math "frexp",1,"frexp"
```