### PR TITLE
Avoid cudaStreamAddCallback to make new_dim0 asynchronously

### DIFF
--- a/ext/cumo/narray/gen/tmpl/new_dim0.c
+++ b/ext/cumo/narray/gen/tmpl/new_dim0.c
@@ -1,8 +1,4 @@
-static void CUDART_CB
-<%=c_func(:nodef)%>_stream_callback(cudaStream_t stream, cudaError_t status, void *data)
-{
-    xfree(data);
-}
+void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x);
 
 static VALUE
 <%=c_func(:nodef)%>(dtype x)
@@ -12,21 +8,7 @@ static VALUE
 
     v = nary_new(cT, 0, NULL);
     ptr = (dtype*)na_get_pointer_for_write(v);
-
-    // To copy stack value into cuda memory asynchronously, we do
-    // 1. copy to heap
-    // 2. cudaMemcpyAsync from heap to cuda memory
-    // 3. run callback to free the heap memory after memcpy finished
-    //
-    // FYI: We may have to care of cuda stream callback serializes stream execution when we support stream.
-    // https://devtalk.nvidia.com/default/topic/822942/why-does-cudastreamaddcallback-serialize-kernel-execution-and-break-concurrency-/
-    {
-        cudaStream_t stream = 0;
-        dtype* heap_x = ALLOC(dtype);
-        *heap_x = x;
-        cumo_cuda_runtime_check_status(cudaMemcpyAsync(ptr, heap_x, sizeof(dtype), cudaMemcpyHostToDevice, stream));
-        cumo_cuda_runtime_check_status(cudaStreamAddCallback(stream, <%=c_func(:nodef)%>_stream_callback, heap_x, 0));
-    }
+    <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(ptr, x);
 
     na_release_lock(v);
     return v;

--- a/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
@@ -1,0 +1,8 @@
+__global__ void <%="cumo_#{c_func(:nodef)}_kernel"%>(dtype *ptr, dtype x)
+{
+    *ptr = x;
+}
+void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x)
+{
+    <%="cumo_#{c_func(:nodef)}_kernel"%><<<1,1>>>(ptr,x);
+}


### PR DESCRIPTION
This implementation was faster.

```ruby
NUM = 30000
a = Cumo::SFloat.new(4, 4).seq(0)
NUM.times do |i|
  a + 1
end
```

Before: 3.96s
After: 2.42s

