### PR TITLE
gemm: support transa and transb options

### DIFF
--- a/ext/cumo/cuda/cublas.c
+++ b/ext/cumo/cuda/cublas.c
@@ -9,14 +9,14 @@
 //static char *blas_prefix = 0;
 
 VALUE
-cumo_cublas_option_value(VALUE order, VALUE default_value)
+cumo_cublas_option_value(VALUE value, VALUE default_value)
 {
-    switch(TYPE(order)) {
+    switch(TYPE(value)) {
     case T_NIL:
     case T_UNDEF:
         return default_value;
     }
-    return order;
+    return value;
 }
 
 //enum CBLAS_ORDER

--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -39,9 +39,9 @@ static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     dtype *a, *b;
-    //int    lda, ldb;
+    int    lda, ldb;
     dtype *c;
-    //int    ldc;
+    int    ldc;
     args_t *g;
 
     a = (dtype*)NDL_PTR(lp,0);
@@ -49,11 +49,11 @@ static void
     c = (dtype*)NDL_PTR(lp,2);
     g = (args_t*)(lp->opt_ptr);
 
-    //lda = NDL_STEP(lp,0) / sizeof(dtype);
-    //ldb = NDL_STEP(lp,1) / sizeof(dtype);
-    //ldc = NDL_STEP(lp,2) / sizeof(dtype);
+    lda = NDL_STEP(lp,0) / sizeof(dtype);
+    ldb = NDL_STEP(lp,1) / sizeof(dtype);
+    ldc = NDL_STEP(lp,2) / sizeof(dtype);
 
-    //printf("transa=%d transb=%d m=%d n=%d k=%d\n",g->transa,g->transb,g->m,g->n,g->k);
+    //printf("transa=%d transb=%d m=%d n=%d k=%d lda=%d ldb=%d ldc=%d\n",g->transa,g->transb,g->m,g->n,g->k,lda,ldb,ldc);
 
     // Note that cuBLAS uses the column major matrix representation.
     // We use technic which following site describes:
@@ -68,7 +68,7 @@ static void
    
     cublasHandle_t handle;
     cublasCreate(&handle);
-    cublas<%=func_prefix%>gemm(handle, g->transb, g->transa, g->n, g->m, g->k, (<%=cutype%>*)(&g->alpha), (<%=cutype%>*)b, g->n, (<%=cutype%>*)a, g->k, (<%=cutype%>*)(&g->beta), (<%=cutype%>*)c, g->n);
+    cublas<%=func_prefix%>gemm(handle, g->transb, g->transa, g->n, g->m, g->k, (<%=cutype%>*)(&g->alpha), (<%=cutype%>*)b, ldb, (<%=cutype%>*)a, lda, (<%=cutype%>*)(&g->beta), (<%=cutype%>*)c, ldc);
     cublasDestroy(handle);
 }
 
@@ -137,7 +137,7 @@ static VALUE
     args_t g;
     VALUE kw_hash = Qnil;
     ID kw_table[4] = {rb_intern("alpha"),rb_intern("beta"),rb_intern("transa"),rb_intern("transb")};
-    VALUE opts[6] = {Qundef,Qundef,Qundef,Qundef,Qundef,Qundef};
+    VALUE opts[4] = {Qundef,Qundef,Qundef,Qundef};
 
     rb_scan_args(argc, argv, "11:", &b, &c, &kw_hash);
     rb_get_kwargs(kw_hash, kw_table, 0, 4, opts);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -267,6 +267,23 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
 
+    if [Cumo::DComplex, Cumo::SComplex, Cumo::DFloat, Cumo::SFloat].include?(dtype)
+      sub_test_case "#{dtype}, #gemm" do
+        test "matrix.gemm(matrix) with trans options" do
+          a = dtype[1..6].reshape(2,3)
+          b = dtype[1..6].reshape(2,3)
+          assert { a.gemm(b.transpose) == a.gemm(b, transb: true) } # trans option is faster
+          assert { a.transpose.gemm(b) == a.gemm(b, transa: true) }
+        end
+        test "matrix.gemm(matrix) with alpha" do
+          a = dtype[1..6].reshape(2,3)
+          b = dtype[1..6].reshape(2,3)
+          alpha = [Cumo::DComplex, Cumo::SComplex].include?(dtype) ? Complex(3) : 3
+          assert { a.gemm(b.transpose) * alpha == a.gemm(b, transb: true, alpha: alpha) }
+        end
+      end
+    end
+
     test "#{dtype},eye" do
       assert { dtype.new(3, 3).eye(1) == [[1,0,0],[0,1,0],[0,0,1]] }
       assert { dtype.new(3, 3).eye(2) == [[2,0,0],[0,2,0],[0,0,2]] }


### PR DESCRIPTION
This does not fix https://github.com/sonots/cumo/issues/35, but enables users to write `a.gemm(b.transpose)` as `a.gemm(b, transb: true)` with fast.