### PR TITLE
extract: no synchronization

### DIFF
--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -100,6 +100,7 @@ def_method "allocate"
 # Type conversion
 
 def_method "extract"
+def_method "extract_to_cpu"
 def_method "new_dim0"
 
 def_method "store" do

--- a/ext/cumo/narray/gen/tmpl/extract.c
+++ b/ext/cumo/narray/gen/tmpl/extract.c
@@ -8,18 +8,5 @@
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
-    volatile VALUE v;
-    char *ptr;
-    narray_t *na;
-    GetNArray(self,na);
-
-    if (na->ndim==0) {
-        ptr = na_get_pointer_for_read(self) + na_get_offset(self);
-        SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-        v = m_extract(ptr);
-        na_release_lock(self);
-        return v;
-    }
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl/extract_to_cpu.c
+++ b/ext/cumo/narray/gen/tmpl/extract_to_cpu.c
@@ -5,26 +5,21 @@
   --- Extract element value as Ruby Object if self is a dimensionless NArray,
   otherwise returns self.
 */
-
-// TODO(sonots): Return Cumo::Bit instead of ruby built-in object to avoid synchronization
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
-    BIT_DIGIT *ptr, val;
-    size_t pos;
+    volatile VALUE v;
+    char *ptr;
     narray_t *na;
     GetNArray(self,na);
 
     if (na->ndim==0) {
-        pos = na_get_offset(self);
-        ptr = (BIT_DIGIT*)na_get_pointer_for_read(self);
-
+        ptr = na_get_pointer_for_read(self) + na_get_offset(self);
         SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
-        val = ((*((ptr)+(pos)/NB)) >> ((pos)%NB)) & 1u;
+        v = m_extract(ptr);
         na_release_lock(self);
-        return INT2FIX(val);
+        return v;
     }
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl_bit/bit_count.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_count.c
@@ -84,5 +84,5 @@ static VALUE
 
     reduce = na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
     v = na_ndloop(&ndf, 3, self, reduce, INT2FIX(0));
-    return rb_funcall(v,rb_intern("extract"),0);
+    return rb_funcall(v,rb_intern("extract_to_cpu"),0);
 }

--- a/ext/cumo/narray/gen/tmpl_bit/extract_to_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/extract_to_cpu.c
@@ -6,7 +6,6 @@
   otherwise returns self.
 */
 
-// TODO(sonots): Return Cumo::Bit instead of ruby built-in object to avoid synchronization
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1239,39 +1239,40 @@ ndfunc_write_back(ndfunc_t *nf, na_md_loop_t *lp, VALUE orig_args, VALUE results
 static VALUE
 ndloop_extract(VALUE results, ndfunc_t *nf)
 {
-    long n, i;
-    VALUE x, y;
-    narray_t *na;
+    // long n, i;
+    // VALUE x, y;
+    // narray_t *na;
 
     // extract result objects
     switch(nf->nout) {
     case 0:
         return Qnil;
     case 1:
-        x = RARRAY_AREF(results,0);
-        if (NDF_TEST(nf,NDF_EXTRACT)) {
-            if (IsNArray(x)){
-                GetNArray(x,na);
-                if (NA_NDIM(na)==0) {
-                    x = rb_funcall(x, id_extract, 0);
-                }
-            }
-        }
-        return x;
+        return RARRAY_AREF(results,0);
+        // x = RARRAY_AREF(results,0);
+        // if (NDF_TEST(nf,NDF_EXTRACT)) {
+        //     if (IsNArray(x)){
+        //         GetNArray(x,na);
+        //         if (NA_NDIM(na)==0) {
+        //             x = rb_funcall(x, id_extract, 0);
+        //         }
+        //     }
+        // }
+        // return x;
     }
-    if (NDF_TEST(nf,NDF_EXTRACT)) {
-        n = RARRAY_LEN(results);
-        for (i=0; i<n; i++) {
-            x = RARRAY_AREF(results,i);
-            if (IsNArray(x)){
-                GetNArray(x,na);
-                if (NA_NDIM(na)==0) {
-                    y = rb_funcall(x, id_extract, 0);
-                    RARRAY_ASET(results,i,y);
-                }
-            }
-        }
-    }
+    // if (NDF_TEST(nf,NDF_EXTRACT)) {
+    //     n = RARRAY_LEN(results);
+    //     for (i=0; i<n; i++) {
+    //         x = RARRAY_AREF(results,i);
+    //         if (IsNArray(x)){
+    //             GetNArray(x,na);
+    //             if (NA_NDIM(na)==0) {
+    //                 y = rb_funcall(x, id_extract, 0);
+    //                 RARRAY_ASET(results,i,y);
+    //             }
+    //         }
+    //     }
+    // }
     return results;
 }
 

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -194,7 +194,7 @@ nst_field(VALUE self, VALUE idx)
     obj = nst_field_view(self,idx);
     GetNArrayView(obj,nv);
     if (nv->base.ndim==0) {
-        obj = rb_funcall(obj,rb_intern("extract"),0);
+        obj = rb_funcall(obj,rb_intern("extract_to_cpu"),0);
     }
     return obj;
 }
@@ -407,7 +407,7 @@ iter_nstruct_to_a(na_loop_t *const lp)
         GetNArrayView(elmt,ne);
         ne->offset = pos + ofs;
         if (ne->base.ndim==0) {
-            velm = rb_funcall(elmt,rb_intern("extract"),0);
+            velm = rb_funcall(elmt,rb_intern("extract_to_cpu"),0);
         } else {
             velm = rb_funcall(elmt,rb_intern("to_a"),0);
         }


### PR DESCRIPTION
`extract` now always returns Cumo NArray not to synchronize.
The one with original behavior is prepared as `extract_to_cpu`.