### PR TITLE
aref[]: no synchronization

### DIFF
--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -125,7 +125,7 @@ void cumo_nary_step_sequence(VALUE self, size_t *plen, double *pbeg, double *pst
 #define na_get_result_dimension cumo_nary_get_result_dimension
 int cumo_nary_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);
 #define na_aref_main cumo_nary_aref_main
-VALUE cumo_nary_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int nd);
+VALUE cumo_nary_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result_nd, size_t pos);
 
 // defined in array, used in math
 #define na_ary_composition_dtype cumo_na_ary_composition_dtype

--- a/ext/cumo/narray/gen/tmpl/aref.c
+++ b/ext/cumo/narray/gen/tmpl/aref.c
@@ -13,6 +13,8 @@
   Ruby numeric object as Numo::NArray does to avoid synchronization
   between GPU and CPU.
 
+  Use "aref_cpu" instead to get a Ruby numeric object for 0-dimensional NArray as Numo/NArray's one.
+
   @example
       a = Cumo::DFloat.new(4,5).seq
       => Cumo::DFloat#shape=[4,5]

--- a/ext/cumo/narray/gen/tmpl/aref.c
+++ b/ext/cumo/narray/gen/tmpl/aref.c
@@ -2,12 +2,16 @@
   Array element referenece or slice view.
   @overload [](dim0,...,dimL)
   @param [Numeric,Range,etc] dim0,...,dimL  Multi-dimensional Index.
-  @return [Numeric,NArray::<%=class_name%>] Element object or NArray view.
+  @return [NArray::<%=class_name%>] NArray view.
 
   --- Returns the element at +dim0+, +dim1+, ... are Numeric indices
   for each dimension, or returns a NArray View as a sliced subarray if
   +dim0+, +dim1+, ... includes other than Numeric index, e.g., Range
   or Array or true.
+
+  Note that Cumo::NArray always returns NArray and does not return a
+  Ruby numeric object as Numo::NArray does to avoid synchronization
+  between GPU and CPU.
 
   @example
       a = Cumo::DFloat.new(4,5).seq
@@ -17,8 +21,13 @@
        [10, 11, 12, 13, 14],
        [15, 16, 17, 18, 19]]
 
+      a[7]
+      => Cumo::DFloat#shape=[]
+      6.0
+
       a[1,1]
-      => 6.0
+      => Cumo::DFloat#shape=[]
+      6.0
 
       a[1..3,1]
       => Cumo::DFloat#shape=[3]
@@ -35,22 +44,19 @@
        [5, 6, 99, 8, 9],
        [10, 11, 99, 13, 14],
        [15, 16, 99, 18, 19]]
- */
++ */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
 {
-    int nd;
+    int result_nd;
     size_t pos;
-    char *ptr;
 
-    nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
-    if (nd) {
-        return na_aref_main(argc, argv, self, 0, nd);
-    } else {
-        // TODO(sonots): Return 0-dimensional narray rather than Synchronize()
-        ptr = na_get_pointer_for_read(self) + pos;
-        SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>[] (0-dimension)", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-        return m_extract(ptr);
-    }
+    // if (nd) {
+    //     return na_aref_main(argc, argv, self, 0, nd);
+    // } else {
+    //     ptr = na_get_pointer_for_read(self) + pos;
+    //     return m_extract(ptr);
+    // }
+    result_nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
+    return na_aref_main(argc, argv, self, 0, result_nd, pos);
 }

--- a/ext/cumo/narray/gen/tmpl/aset.c
+++ b/ext/cumo/narray/gen/tmpl/aset.c
@@ -54,7 +54,7 @@ static VALUE
     } else {
         nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
         if (nd) {
-            a = na_aref_main(argc, argv, self, 0, nd);
+            a = na_aref_main(argc, argv, self, 0, nd, pos);
             <%=c_func.sub(/_aset/,"_store")%>(a, argv[argc]);
         } else {
             x = <%=type_name%>_extract_data(argv[argc]);

--- a/ext/cumo/narray/gen/tmpl_bit/aref.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aref.c
@@ -46,7 +46,7 @@ static VALUE
 
     nd = na_get_result_dimension(self, argc, argv, 1, &pos);
     if (nd) {
-        return na_aref_main(argc, argv, self, 0, nd);
+        return na_aref_main(argc, argv, self, 0, nd, pos);
     } else {
         // TODO(sonots): Return 0-dimensional narray rather than Synchronize()
         ptr = na_get_pointer_for_read(self);

--- a/ext/cumo/narray/gen/tmpl_bit/aset.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aset.c
@@ -52,7 +52,7 @@ static VALUE
     } else {
         nd = na_get_result_dimension(self, argc, argv, 1, &pos);
         if (nd) {
-            a = na_aref_main(argc, argv, self, 0, nd);
+            a = na_aref_main(argc, argv, self, 0, nd, pos);
             <%=c_func.sub(/_aset/,"_store")%>(a, argv[argc]);
         } else {
             x = <%=type_name%>_extract_data(argv[argc]);

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -590,6 +590,7 @@ VALUE na_aref_md_protected(VALUE data_value)
     case NARRAY_FILEMAP_T:
         if (ndim == 0) {
             na2->offset = data->pos;
+            na2->base.size = 1;
         } else {
             na_index_aref_nadata((narray_data_t *)na1,na2,q,elmsz,ndim,keep_dim);
         }
@@ -599,6 +600,7 @@ VALUE na_aref_md_protected(VALUE data_value)
         if (ndim == 0) {
             na2->offset = ((narray_view_t *)na1)->offset + data->pos;
             na2->data = ((narray_view_t *)na1)->data;
+            na2->base.size = 1;
         } else {
             na2->offset = ((narray_view_t *)na1)->offset;
             na2->data = ((narray_view_t *)na1)->data;

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -154,6 +154,10 @@ module Cumo
       end
     end
 
+    def aref_cpu(*idx)
+      self[*idx].extract_cpu
+    end
+
     # Convert the argument to an narray if not an narray.
     def self.cast(a)
       a.kind_of?(NArray) ? a : NArray.array_type(a).cast(a)

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -129,8 +129,7 @@ module Cumo
 
     def to_i
       if size==1
-        Cumo::CUDA::Runtime.cudaDeviceSynchronize
-        self[0].to_i
+        self.extract_cpu.to_i
       else
         # convert to Int?
         raise TypeError, "can't convert #{self.class} into Integer"
@@ -139,8 +138,7 @@ module Cumo
 
     def to_f
       if size==1
-        Cumo::CUDA::Runtime.cudaDeviceSynchronize
-        self[0].to_f
+        self.extract_cpu.to_f
       else
         # convert to DFloat?
         raise TypeError, "can't convert #{self.class} into Float"
@@ -149,8 +147,7 @@ module Cumo
 
     def to_c
       if size==1
-        Cumo::CUDA::Runtime.cudaDeviceSynchronize
-        Complex(self[0])
+        Complex(self.extract_cpu)
       else
         # convert to DComplex?
         raise TypeError, "can't convert #{self.class} into Complex"

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -67,6 +67,7 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.eq([1,1,3,3,7,7]) == [1,0,1,0,1,0] }
         assert { a[3..4] == [5,7] }
         assert { a[5] == 11 }
+        assert { a[5].size == 1 }
         assert { a[-1] == 11 }
         assert { a[[4,3,0,1,5,2]] == [7,5,1,2,11,3] }
         assert { a.sum == 29 }


### PR DESCRIPTION
`[]` now always returns Cumo NArray not to synchronize.
The one of original behavior is prepared as `aref_cpu`.