### PR TITLE
Provide Cumo.enable_compatible_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ An example:
 
 ### How to switch from Numo to Cumo
 
-Basically, `find . -type f | xargs sed -i -e 's/Numo/Cumo/g' -e 's/numo/cumo/g'` should make it work.
+Basically, following command should make it work with Cumo.
+
+```
+find . -type f | xargs sed -i -e 's/Numo/Cumo/g' -e 's/numo/cumo/g'
+```
 
 If you want to switch Numo and Cumo dynamically, following snippets should work:
 
@@ -81,6 +85,31 @@ end
 
 a = Xumo::DFloat.new(3,5).seq
 ```
+
+### Incompatibility With Numo
+
+Following methods behave incompatible with Numo.
+
+* `extract`
+* `[]`
+
+Numo returns a Ruby numeric object for 0-dimensional NArray, but Cumo returns the 0-dimensional NArray instead of a Ruby numeric object.
+This is to avoid synchnoziation between CPU and GPU for performance.
+
+You can use following methods which behaves as Numo NArray's methods:
+
+* `extract_cpu`
+* `aref_cpu(*idx)`
+
+Or, you may use
+
+```
+require 'cumo'
+Cumo.enable_compatible_mode
+```
+
+to make Cumo NArray behaves compatbile with Numo NArray.
+Use `Cumo.disable_compatible_mode` to disable, and `Cumo.compatible_mode_enabled?` to check the current state.
 
 ### Select a GPU device ID
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ a = Xumo::DFloat.new(3,5).seq
 
 ### Incompatibility With Numo
 
-Following methods behave incompatible with Numo.
+Following methods behave incompatibly with Numo.
 
 * `extract`
 * `[]`
@@ -108,7 +108,7 @@ require 'cumo'
 Cumo.enable_compatible_mode
 ```
 
-to make Cumo NArray behaves compatbile with Numo NArray.
+to make Cumo NArray behaves compatibly with Numo NArray.
 Use `Cumo.disable_compatible_mode` to disable, and `Cumo.compatible_mode_enabled?` to check the current state.
 
 ### Select a GPU device ID

--- a/cumo.gemspec
+++ b/cumo.gemspec
@@ -1,11 +1,19 @@
 # coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "cumo/version"
+
+open("ext/cumo/include/cumo.h") do |f|
+  f.each_line do |l|
+    if /CUMO_VERSION "([\d.]+)"/ =~ l
+      CUMO_VERSION = $1
+      break
+    end
+  end
+end
 
 Gem::Specification.new do |spec|
   spec.name          = "cumo"
-  spec.version       = Cumo::VERSION
+  spec.version       = CUMO_VERSION
   spec.authors       = ["Naotoshi Seo"]
   spec.email         = ["sonots@gmail.com"]
 

--- a/ext/cumo/cumo.c
+++ b/ext/cumo/cumo.c
@@ -97,6 +97,8 @@ Init_cumo()
 {
     VALUE mCumo = rb_define_module("Cumo");
 
+    rb_define_const(mCumo, "VERSION", rb_str_new2(CUMO_VERSION));
+
     rb_define_singleton_method(mCumo, "enable_compatible_mode", RUBY_METHOD_FUNC(rb_enable_compatible_mode), 0);
     rb_define_singleton_method(mCumo, "disable_compatible_mode", RUBY_METHOD_FUNC(rb_disable_compatible_mode), 0);
     rb_define_singleton_method(mCumo, "compatible_mode_enabled?", RUBY_METHOD_FUNC(rb_compatible_mode_enabled_p), 0);

--- a/ext/cumo/cumo.c
+++ b/ext/cumo/cumo.c
@@ -1,7 +1,9 @@
 #define CUMO_C
 #include <ruby.h>
 #include <assert.h>
+#include <stdlib.h>
 #include "cumo.h"
+#include "cumo/narray.h"
 
 void Init_cumo();
 void Init_cumo_narray();
@@ -38,11 +40,70 @@ cumo_debug_breakpoint(void)
     /* */
 }
 
+static bool cumo_compatible_mode_enabled;
+
+bool cumo_compatible_mode_enabled_p()
+{
+    return cumo_compatible_mode_enabled;
+}
+
+/*
+  Enable Numo NArray compatible mode.
+
+  Cumo returns 0-dimensional NArray instead of ruby numeric object
+  for some methods such as `extract`, and `[]` not to synchronize
+  between CPU and GPU for performance as default.
+
+  Enabling the compatible mode makes Cumo behave as Numo. But, please
+  note that it makes Cumo slow.
+
+  @return [Boolean] Returns previous state (true if enabled)
+ */
+static VALUE
+rb_enable_compatible_mode(VALUE self)
+{
+    VALUE ret = (cumo_compatible_mode_enabled ? Qtrue : Qfalse);
+    cumo_compatible_mode_enabled = true;
+    return ret;
+}
+
+/*
+  Disable Numo NArray compatible mode.
+
+  @return [Boolean] Returns previous state (true if enabled)
+ */
+static VALUE
+rb_disable_compatible_mode(VALUE self)
+{
+    VALUE ret = (cumo_compatible_mode_enabled ? Qtrue : Qfalse);
+    cumo_compatible_mode_enabled = false;
+    return ret;
+}
+
+/*
+  Returns whether Numo NArray compatible mode is enabled or not.
+
+  @return [Boolean] Returns the state (true if enabled)
+ */
+static VALUE
+rb_compatible_mode_enabled_p(VALUE self)
+{
+    return (cumo_compatible_mode_enabled ? Qtrue : Qfalse);
+}
+
 /* initialization of Cumo Module */
 void
 Init_cumo()
 {
-    rb_define_module("Cumo");
+    VALUE mCumo = rb_define_module("Cumo");
+
+    rb_define_singleton_method(mCumo, "enable_compatible_mode", RUBY_METHOD_FUNC(rb_enable_compatible_mode), 0);
+    rb_define_singleton_method(mCumo, "disable_compatible_mode", RUBY_METHOD_FUNC(rb_disable_compatible_mode), 0);
+    rb_define_singleton_method(mCumo, "compatible_mode_enabled?", RUBY_METHOD_FUNC(rb_compatible_mode_enabled_p), 0);
+
+    // default is false
+    char* env = getenv("CUMO_NARRAY_COMPATIBLE_MODE");
+    cumo_compatible_mode_enabled = (env != NULL && strcmp(env, "OFF") != 0 && strcmp(env, "0") != 0 && strcmp(env, "NO") != 0);
 
     Init_cumo_narray();
 

--- a/ext/cumo/include/cumo.h
+++ b/ext/cumo/include/cumo.h
@@ -1,12 +1,16 @@
 #ifndef CUMO_H
 #define CUMO_H
 
+#include "cumo/narray.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
 } /* satisfy cc-mode */
 #endif
 #endif
+
+bool cumo_compatible_mode_enabled_p();
 
 #if defined(__cplusplus)
 #if 0

--- a/ext/cumo/include/cumo.h
+++ b/ext/cumo/include/cumo.h
@@ -10,6 +10,9 @@ extern "C" {
 #endif
 #endif
 
+#define CUMO_VERSION "0.1.0"
+#define CUMO_VERSION_CODE 10
+
 bool cumo_compatible_mode_enabled_p();
 
 #if defined(__cplusplus)

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -8,9 +8,6 @@ extern "C" {
 #endif
 #endif
 
-#define NARRAY_VERSION "0.9.0.9"
-#define NARRAY_VERSION_CODE 909
-
 #include <math.h>
 #include "cumo/compat.h"
 #include "cumo/template.h"

--- a/ext/cumo/include/cumo/narray_kernel.h
+++ b/ext/cumo/include/cumo/narray_kernel.h
@@ -8,9 +8,6 @@ extern "C" {
 #endif
 #endif
 
-#define NARRAY_VERSION "0.9.0.9"
-#define NARRAY_VERSION_CODE 909
-
 #include <math.h>
 //#include "cumo/compat.h"
 #include "cumo/template_kernel.h"

--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -131,6 +131,7 @@ def_method "cast_array"
 def_singleton_method "cast"
 
 def_method "aref", op:"[]"
+def_method "aref_cpu"
 def_method "aset", op:"[]="
 
 def_method "coerce_cast"

--- a/ext/cumo/narray/gen/tmpl/aref.c
+++ b/ext/cumo/narray/gen/tmpl/aref.c
@@ -16,7 +16,7 @@ static VALUE
   Ruby numeric object as Numo::NArray does to avoid synchronization
   between GPU and CPU for performance.
 
-  Call Cumo.enable_compatible_mode to make ths method behave compatible
+  Call Cumo.enable_compatible_mode to make ths method behave compatibly
   with Numo, or you can use `aref_cpu(*idx)` method instead.
 
   @example

--- a/ext/cumo/narray/gen/tmpl/aref_cpu.c
+++ b/ext/cumo/narray/gen/tmpl/aref_cpu.c
@@ -1,24 +1,13 @@
-static VALUE
-<%=c_func(-1)%>_cpu(int argc, VALUE *argv, VALUE self);
-
 /*
   Array element referenece or slice view.
   @overload [](dim0,...,dimL)
   @param [Numeric,Range,etc] dim0,...,dimL  Multi-dimensional Index.
-  @return [NArray::<%=class_name%>] NArray view.
-
+  @return [Numeric,NArray::<%=class_name%>] Element object or NArray view.
   --- Returns the element at +dim0+, +dim1+, ... are Numeric indices
   for each dimension, or returns a NArray View as a sliced subarray if
   +dim0+, +dim1+, ... includes other than Numeric index, e.g., Range
   or Array or true.
-
-  Note that Cumo::NArray always returns NArray and does not return a
-  Ruby numeric object as Numo::NArray does to avoid synchronization
-  between GPU and CPU for performance.
-
-  Call Cumo.enable_compatible_mode to make ths method behave compatible
-  with Numo, or you can use `aref_cpu(*idx)` method instead.
-
+  This method is compatible with Numo NArray's [] method.
   @example
       a = Cumo::DFloat.new(4,5).seq
       => Cumo::DFloat#shape=[4,5]
@@ -26,23 +15,14 @@ static VALUE
        [5, 6, 7, 8, 9],
        [10, 11, 12, 13, 14],
        [15, 16, 17, 18, 19]]
-
-      a[7]
-      => Cumo::DFloat#shape=[]
-      6.0
-
       a[1,1]
-      => Cumo::DFloat#shape=[]
-      6.0
-
+      => 6.0
       a[1..3,1]
       => Cumo::DFloat#shape=[3]
       [6, 11, 16]
-
       a[1,[1,3,4]]
       => Cumo::DFloat#shape=[3]
       [6, 8, 9]
-
       a[true,2].fill(99)
       a
       => Cumo::DFloat#shape=[4,5]
@@ -54,13 +34,17 @@ static VALUE
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
 {
-    if (cumo_compatible_mode_enabled_p()) {
-        return <%=c_func(-1)%>_cpu(argc, argv, self);
-    } else {
-        int result_nd;
-        size_t pos;
+    int result_nd;
+    size_t pos;
+    char *ptr;
 
-        result_nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
+    result_nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
+    if (result_nd) {
         return na_aref_main(argc, argv, self, 0, result_nd, pos);
+    } else {
+        ptr = na_get_pointer_for_read(self) + pos;
+        SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        return m_extract(ptr);
     }
 }

--- a/ext/cumo/narray/gen/tmpl/extract.c
+++ b/ext/cumo/narray/gen/tmpl/extract.c
@@ -1,12 +1,22 @@
+static VALUE
+<%=c_func(0)%>_cpu(VALUE self);
+
 /*
   Returns self.
   @overload extract
   @return [Cumo::NArray]
-  --- This method always returns self unlike Numo/NArray to avoid synchronization between GPU and CPU.
-  Use "extract_cpu" instead to get a Ruby numeric object for 0-dimensional NArray as Numo/NArray's extract.
+  --- Note that Cumo::NArray always returns NArray and does not
+  return a Ruby numeric object as Numo::NArray does to avoid
+  synchronization between CPU and GPU for performance.
+
+  Call `Cumo.enable_compatible_mode` to make this method behave
+  compatible with Numo, or you can use `extract_cpu` method instead.
 */
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
+    if (cumo_compatible_mode_enabled_p()) {
+        return <%=c_func(0)%>_cpu(self);
+    }
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl/extract_cpu.c
+++ b/ext/cumo/narray/gen/tmpl/extract_cpu.c
@@ -4,6 +4,7 @@
   @return [Numeric,Cumo::NArray]
   --- Extract element value as Ruby Object if self is a dimensionless NArray,
   otherwise returns self.
+  This method is compatible with Numo NArray's `extract` method.
 */
 static VALUE
 <%=c_func(0)%>(VALUE self)

--- a/ext/cumo/narray/gen/tmpl/lib.c
+++ b/ext/cumo/narray/gen/tmpl/lib.c
@@ -9,6 +9,7 @@
 
 #include <ruby.h>
 #include <assert.h>
+#include "cumo.h"
 #include "cumo/narray.h"
 #include "cumo/template.h"
 #include "SFMT.h"

--- a/ext/cumo/narray/gen/tmpl_bit/aref_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aref_cpu.c
@@ -1,23 +1,13 @@
-static VALUE
-<%=c_func(-1)%>_cpu(int argc, VALUE *argv, VALUE self);
-
 /*
   Array element referenece or slice view.
   @overload [](dim0,...,dimL)
   @param [Numeric,Range,etc] dim0,...,dimL  Multi-dimensional Index.
-  @return [NArray::<%=class_name%>] NArray view.
+  @return [Numeric,NArray::<%=class_name%>] Element object or NArray view.
 
   --- Returns the element at +dim0+, +dim1+, ... are Numeric indices
   for each dimension, or returns a NArray View as a sliced subarray if
   +dim0+, +dim1+, ... includes other than Numeric index, e.g., Range
   or Array or true.
-
-  Note that Cumo::NArray always returns NArray and does not return a
-  Ruby numeric object as Numo::NArray does to avoid synchronization
-  between GPU and CPU for performance.
-
-  Call Cumo.enable_compatible_mode to make ths method behave compatible
-  with Numo, or you can use `aref_cpu(*idx)` method instead.
 
   @example
       a = Cumo::DFloat.new(4,5).seq
@@ -27,13 +17,8 @@ static VALUE
        [10, 11, 12, 13, 14],
        [15, 16, 17, 18, 19]]
 
-      a[7]
-      => Cumo::DFloat#shape=[]
-      6.0
-
       a[1,1]
-      => Cumo::DFloat#shape=[]
-      6.0
+      => 6.0
 
       a[1..3,1]
       => Cumo::DFloat#shape=[3]
@@ -54,13 +39,19 @@ static VALUE
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
 {
-    if (cumo_compatible_mode_enabled_p()) {
-        return <%=c_func(-1)%>_cpu(argc, argv, self);
-    } else {
-        int result_nd;
-        size_t pos;
+    int nd;
+    size_t pos;
+    char *ptr;
+    dtype x;
 
-        result_nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
-        return na_aref_main(argc, argv, self, 0, result_nd, pos);
+    nd = na_get_result_dimension(self, argc, argv, 1, &pos);
+    if (nd) {
+        return na_aref_main(argc, argv, self, 0, nd, pos);
+    } else {
+        ptr = na_get_pointer_for_read(self);
+        SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        LOAD_BIT(ptr,pos,x);
+        return m_data_to_num(x);
     }
 }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1,6 +1,7 @@
 #define CUMO_NARRAY_C
 #include <ruby.h>
 #include <assert.h>
+#include "cumo.h"
 #include "cumo/narray.h"
 #include "cumo/cuda/memory_pool.h"
 #include "cumo/cuda/runtime.h"
@@ -1839,7 +1840,7 @@ Init_cumo_narray()
     rb_cComplex = rb_const_get(rb_cObject, rb_intern("Complex"));
 #endif
 
-    rb_define_const(cNArray, "VERSION", rb_str_new2(NARRAY_VERSION));
+    rb_define_const(cNArray, "VERSION", rb_str_new2(CUMO_VERSION));
 
     nary_eCastError = rb_define_class_under(cNArray, "CastError", rb_eStandardError);
     nary_eShapeError = rb_define_class_under(cNArray, "ShapeError", rb_eStandardError);

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -154,10 +154,6 @@ module Cumo
       end
     end
 
-    def aref_cpu(*idx)
-      self[*idx].extract_cpu
-    end
-
     # Convert the argument to an narray if not an narray.
     def self.cast(a)
       a.kind_of?(NArray) ? a : NArray.array_type(a).cast(a)

--- a/lib/cumo/version.rb
+++ b/lib/cumo/version.rb
@@ -1,3 +1,0 @@
-module Cumo
-  VERSION = "0.1.0"
-end

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -18,4 +18,8 @@ class CumoTest < Test::Unit::TestCase
     Cumo.disable_compatible_mode
     assert { !Cumo.compatible_mode_enabled? }
   end
+
+  def test_version
+    assert_nothing_raised { Cumo::VERSION }
+  end
 end

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -1,0 +1,21 @@
+require_relative "test_helper"
+
+class CumoTest < Test::Unit::TestCase
+  def setup
+    @orig_compatible_mode = Cumo.compatible_mode_enabled?
+  end
+
+  def teardown
+    @orig_compatible_mode ? Cumo.enable_compatible_mode : Cumo.disable_compatible_mode
+  end
+
+  def test_enable_compatible_mode
+    Cumo.enable_compatible_mode
+    assert { Cumo.compatible_mode_enabled? }
+  end
+
+  def test_disable_compatible_mode
+    Cumo.disable_compatible_mode
+    assert { !Cumo.compatible_mode_enabled? }
+  end
+end


### PR DESCRIPTION
to make `extract` and `[]` behave compatibly with Numo.