### PR TITLE
Improve performance of binary kernel by introducing own indexer

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -4,8 +4,6 @@
 /* Add cumo_ prefix */
 #define na_indexer_t cumo_na_indexer_t
 #define na_iarray_t cumo_na_iarray_t
-#define na_make_indexer cumo_na_make_indexer
-#define na_make_iarray cumo_na_make_iarray
 
 #ifndef __CUDACC__
 #include "cumo/narray.h"
@@ -38,7 +36,7 @@ typedef struct {
 #ifndef __CUDACC__
 // Note that you, then, have to call na_indexer_set to create index[]
 static na_indexer_t
-na_make_indexer(na_loop_args_t* arg)
+cumo_na_make_indexer(na_loop_args_t* arg)
 {
     na_indexer_t indexer;
     indexer.ndim = arg->ndim;
@@ -51,7 +49,7 @@ na_make_indexer(na_loop_args_t* arg)
 }
 
 static na_iarray_t
-na_make_iarray(na_loop_args_t* arg)
+cumo_na_make_iarray(na_loop_args_t* arg)
 {
     na_iarray_t iarray;
     iarray.ptr = arg->ptr + arg->iter[0].pos;

--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -62,6 +62,8 @@ na_make_iarray(na_loop_args_t* arg)
 }
 #endif  // #ifndef __CUDACC__
 
+#define CUMO_NA_INDEXER_OPTIMIZED_NDIM 4
+
 #ifdef __CUDACC__
 
 __host__ __device__

--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -1,0 +1,131 @@
+#ifndef CUMO_INDEXER_H
+#define CUMO_INDEXER_H
+
+/* Add cumo_ prefix */
+#define na_indexer_t cumo_na_indexer_t
+#define na_iarray_t cumo_na_iarray_t
+#define na_make_indexer cumo_na_make_indexer
+#define na_make_iarray cumo_na_make_iarray
+
+#ifndef __CUDACC__
+#include "cumo/narray.h"
+#include "cumo/ndloop.h"
+#else
+#include "cumo/narray_kernel.h"
+#endif
+
+/* A structure to get indices for each dimension.
+ *
+ * Note that shapes of each argument NArray are typically equivalent, and
+ * thus indexer would point the same indicies for all NArrays.
+ */
+typedef struct {
+    unsigned char ndim;               // # of dimensions
+    size_t total_size;                // # of total elements
+    size_t shape[NA_MAX_DIMENSION];   // # of elements for each dimension
+    uint64_t index[NA_MAX_DIMENSION]; // indicies for each dimension
+} na_indexer_t;
+
+/* A structure to get data address with indexer.
+ *
+ * Note that strides would be different for each NArray although indexer points same indicies.
+ */
+typedef struct {
+    char* ptr;
+    ssize_t step[NA_MAX_DIMENSION]; // or strides
+} na_iarray_t;
+
+#ifndef __CUDACC__
+// Note that you, then, have to call na_indexer_set to create index[]
+static na_indexer_t
+na_make_indexer(na_loop_args_t* arg)
+{
+    na_indexer_t indexer;
+    indexer.ndim = arg->ndim;
+    indexer.total_size = 1;
+    for (int i = 0; i < arg->ndim; ++i) {
+        indexer.shape[i] = arg->shape[i];
+        indexer.total_size *= arg->shape[i];
+    }
+    return indexer;
+}
+
+static na_iarray_t
+na_make_iarray(na_loop_args_t* arg)
+{
+    na_iarray_t iarray;
+    iarray.ptr = arg->ptr + arg->iter[0].pos;
+    for (int idim = arg->ndim; --idim >= 0;) {
+        iarray.step[idim] = arg->iter[idim].step;
+    }
+    return iarray;
+}
+#endif  // #ifndef __CUDACC__
+
+#ifdef __CUDACC__
+
+__host__ __device__
+static void
+cumo_na_indexer_set_dim(na_indexer_t* indexer, size_t i) {
+    for (int j = indexer->ndim; --j >= 0;) {
+        indexer->index[j] = i % indexer->shape[j];
+        i /= indexer->shape[j];
+    }
+}
+
+// Let compiler optimize
+#define CUMO_NA_INDEXER_SET(NDIM) \
+__host__ __device__ \
+static void \
+cumo_na_indexer_set_dim##NDIM(na_indexer_t* indexer, size_t i) { \
+    for (int j = NDIM; --j >= 0;) { \
+        indexer->index[j] = i % indexer->shape[j]; \
+        i /= indexer->shape[j]; \
+    } \
+}
+
+CUMO_NA_INDEXER_SET(4)
+CUMO_NA_INDEXER_SET(3)
+CUMO_NA_INDEXER_SET(2)
+
+__host__ __device__
+static inline void
+cumo_na_indexer_set_dim1(na_indexer_t* indexer, size_t i) {
+    indexer->index[0] = i;
+}
+
+__host__ __device__
+static char*
+cumo_na_iarray_at_dim(na_iarray_t* iarray, na_indexer_t* indexer) {
+    char* ptr = iarray->ptr;
+    for (int idim = 0; idim < indexer->ndim; ++idim) {
+        ptr += iarray->step[idim] * indexer->index[idim];
+    }
+    return ptr;
+}
+
+// Let compiler optimize
+#define CUMO_NA_IARRAY_AT(NDIM) \
+__host__ __device__ \
+static char* \
+cumo_na_iarray_at_dim##NDIM(na_iarray_t* iarray, na_indexer_t* indexer) { \
+    char* ptr = iarray->ptr; \
+    for (int idim = 0; idim < NDIM; ++idim) { \
+        ptr += iarray->step[idim] * indexer->index[idim]; \
+    } \
+    return ptr; \
+}
+
+CUMO_NA_IARRAY_AT(4)
+CUMO_NA_IARRAY_AT(3)
+CUMO_NA_IARRAY_AT(2)
+
+__host__ __device__
+static inline char*
+cumo_na_iarray_at_dim1(na_iarray_t* iarray, na_indexer_t* indexer) {
+    return iarray->ptr + iarray->step[0] * indexer->index[0];
+}
+
+#endif // #ifdef __CUDACC__
+
+#endif // CUMO_INDEXER_H

--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -87,6 +87,7 @@ cumo_na_indexer_set_dim##NDIM(na_indexer_t* indexer, size_t i) { \
 CUMO_NA_INDEXER_SET(4)
 CUMO_NA_INDEXER_SET(3)
 CUMO_NA_INDEXER_SET(2)
+CUMO_NA_INDEXER_SET(0)
 
 __host__ __device__
 static inline void
@@ -119,6 +120,7 @@ cumo_na_iarray_at_dim##NDIM(na_iarray_t* iarray, na_indexer_t* indexer) { \
 CUMO_NA_IARRAY_AT(4)
 CUMO_NA_IARRAY_AT(3)
 CUMO_NA_IARRAY_AT(2)
+CUMO_NA_IARRAY_AT(0)
 
 __host__ __device__
 static inline char*

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -395,7 +395,8 @@ _na_get_narray_t(VALUE obj, unsigned char na_type)
 #define NUM2REAL(v)  NUM2DBL( rb_funcall((v),na_id_real,0) )
 #define NUM2IMAG(v)  NUM2DBL( rb_funcall((v),na_id_imag,0) )
 
-#define NA_MAX_DIMENSION (int)(sizeof(VALUE)*8-2)
+//#define NA_MAX_DIMENSION (int)(sizeof(VALUE)*8-2)
+#define NA_MAX_DIMENSION 8
 #define NA_MAX_ELMSZ     65535
 
 typedef unsigned int BIT_DIGIT;
@@ -415,6 +416,7 @@ typedef unsigned int BIT_DIGIT;
 #define IS_INTEGER_CLASS(c) ((c)==rb_cFixnum||(c)==rb_cBignum)
 #endif
 
+#include "cumo/indexer.h"
 #include "cumo/ndloop.h"
 #include "cumo/intern.h"
 

--- a/ext/cumo/include/cumo/narray_kernel.h
+++ b/ext/cumo/include/cumo/narray_kernel.h
@@ -122,7 +122,8 @@ extern int na_debug_flag;
 #define NARRAY_VIEW_T     0x2
 #define NARRAY_FILEMAP_T  0x3
 
-#define NA_MAX_DIMENSION (int)(sizeof(VALUE)*8-2)
+//#define NA_MAX_DIMENSION (int)(sizeof(VALUE)*8-2)
+#define NA_MAX_DIMENSION 8
 #define NA_MAX_ELMSZ     65535
 
 typedef unsigned int BIT_DIGIT;
@@ -135,6 +136,7 @@ typedef unsigned int BIT_DIGIT;
 #define ELEMENT_BYTE_SIZE "ELEMENT_BYTE_SIZE"
 #define CONTIGUOUS_STRIDE "CONTIGUOUS_STRIDE"
 
+#include "cumo/indexer.h"
 #include "cumo/intern_kernel.h"
 
 #if defined(__cplusplus)

--- a/ext/cumo/include/cumo/ndloop.h
+++ b/ext/cumo/include/cumo/ndloop.h
@@ -21,7 +21,7 @@ typedef struct NA_LOOP_ARGS {
 // pass this structure to user iterator
 typedef struct NA_LOOP {
     int  narg;
-    int  ndim;             // n of user dimention  - required for each iterator.
+    int  ndim;             // n of user dimention used at user function.
     size_t *n;             // n of elements for each dim (=shape)
     na_loop_args_t *args;  // for each arg
     VALUE  option;

--- a/ext/cumo/include/cumo/ndloop.h
+++ b/ext/cumo/include/cumo/ndloop.h
@@ -43,6 +43,8 @@ typedef struct NA_LOOP {
 #define NDF_EXTRACT             (1<<7)
 #define NDF_CUM                 (1<<8)
 
+#define NDF_INDEXER_LOOP        (1<<9) // Cumo custom. Use cumo own indexer.
+
 #define FULL_LOOP       (NDF_HAS_LOOP|NDF_STRIDE_LOOP|NDF_INDEX_LOOP|NDF_INPLACE)
 #define FULL_LOOP_NIP   (NDF_HAS_LOOP|NDF_STRIDE_LOOP|NDF_INDEX_LOOP)
 #define STRIDE_LOOP     (NDF_HAS_LOOP|NDF_STRIDE_LOOP|NDF_INPLACE)

--- a/ext/cumo/narray/gen/cogen_kernel.rb
+++ b/ext/cumo/narray/gen/cogen_kernel.rb
@@ -41,6 +41,8 @@ code = DefLib.new do
   set type_name: type_name
   set lib_name: "cumo_"+type_name
 
+  set opt_indexer_ndim: File.read(File.expand_path("../../../include/cumo/indexer.h", __FILE__)).match(/CUMO_NA_INDEXER_OPTIMIZED_NDIM (\d+)/)[1].to_i
+
   def_class do
     extend NArrayMethod
     extend NArrayType

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -112,10 +112,10 @@ static void
     }
     <% else %>
     {
-        na_iarray_t a1 = na_make_iarray(&lp->args[0]);
-        na_iarray_t a2 = na_make_iarray(&lp->args[1]);
-        na_iarray_t a3 = na_make_iarray(&lp->args[2]);
-        na_indexer_t indexer = na_make_indexer(&lp->args[0]);
+        na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
         <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
     }

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -1,29 +1,31 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(char *p1, char *p2, char *p3, uint64_t n)
+
+<% ((1..4).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(na_iarray_t a1, na_iarray_t a2, na_iarray_t a3, na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        *(dtype*)(p3) = m_<%=name%>(*(dtype*)(p1),*(dtype*)(p2));
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(na_iarray_t* a1, na_iarray_t* a2, na_iarray_t* a3, na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p3+(i*s3)) = m_<%=name%>(*(dtype*)(p1+(i*s1)),*(dtype*)(p2+(i*s2)));
+    size_t gridDim = get_gridDim(indexer->total_size);
+    size_t blockDim = get_blockDim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (1..4).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<gridDim, blockDim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<gridDim, blockDim>>>(*a1,*a2,*a3,*indexer);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, char *p3, uint64_t n)
-{
-    size_t gridDim = get_gridDim(n);
-    size_t blockDim = get_blockDim(n);
-    <%="cumo_#{c_iter}_contiguous_kernel"%><<<gridDim, blockDim>>>(p1,p2,p3,n);
-}
-
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
-{
-    size_t gridDim = get_gridDim(n);
-    size_t blockDim = get_blockDim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<gridDim, blockDim>>>(p1,p2,p3,s1,s2,s3,n);
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -1,6 +1,6 @@
 <% unless type_name == 'robject' %>
 
-<% ((1..4).to_a << '').each do |idim| %>
+<% ((0..4).to_a << '').each do |idim| %>
 __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(na_iarray_t a1, na_iarray_t a2, na_iarray_t a3, na_indexer_t indexer)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
@@ -18,7 +18,7 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(na_iarray_t* a1, na_iarray_t* a2, na_ia
     size_t gridDim = get_gridDim(indexer->total_size);
     size_t blockDim = get_blockDim(indexer->total_size);
     switch (indexer->ndim) {
-    <% (1..4).each do |idim| %>
+    <% (0..4).each do |idim| %>
     case <%=idim%>:
         <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<gridDim, blockDim>>>(*a1,*a2,*a3,*indexer);
         break;

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -1,6 +1,6 @@
 <% unless type_name == 'robject' %>
 
-<% ((0..4).to_a << '').each do |idim| %>
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
 __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(na_iarray_t a1, na_iarray_t a2, na_iarray_t a3, na_indexer_t indexer)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
@@ -18,7 +18,7 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(na_iarray_t* a1, na_iarray_t* a2, na_ia
     size_t gridDim = get_gridDim(indexer->total_size);
     size_t blockDim = get_blockDim(indexer->total_size);
     switch (indexer->ndim) {
-    <% (0..4).each do |idim| %>
+    <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
         <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<gridDim, blockDim>>>(*a1,*a2,*a3,*indexer);
         break;


### PR DESCRIPTION
Now, cumo does not use ndloop for binary kernels for performance.

Before:

```
ruby bench/broadcast_fp32.rb
                           user     system      total        real
x.inplace + y          0.040000   0.000000   0.040000 (  0.038616)
x + y                  0.150000   0.560000   0.710000 (  0.753237)
x.inplace + 1.0        0.050000   0.010000   0.060000 (  0.061182)
x.inplace + z          4.610000   0.010000   4.620000 (  4.619116)
x.inplace - y          0.040000   0.000000   0.040000 (  0.038450)
x.inplace - 1.0        0.060000   0.000000   0.060000 (  0.069196)
x.inplace - z          4.590000   0.000000   4.590000 (  4.602641)
x.inplace * y          0.030000   0.010000   0.040000 (  0.037717)
x.inplace * 1.0        0.060000   0.000000   0.060000 (  0.070531)
x.inplace * z          4.560000   0.000000   4.560000 (  4.563376)
x.inplace / y          0.040000   0.000000   0.040000 (  0.038379)
x.inplace / 1.0        0.070000   0.000000   0.070000 (  0.067117)
x.inplace / z          4.870000   0.000000   4.870000 (  4.872269)
```

After:

```
ruby bench/broadcast_fp32.rb
                           user     system      total        real
x.inplace + y          0.040000   0.000000   0.040000 (  0.038527)
x + y                  0.110000   0.530000   0.640000 (  0.669329)
x.inplace + 1.0        0.040000   0.000000   0.040000 (  0.037446)
x.inplace + z          0.070000   0.010000   0.080000 (  0.081368)
x.inplace - y          0.030000   0.010000   0.040000 (  0.039065)
x.inplace - 1.0        0.040000   0.010000   0.050000 (  0.049983)
x.inplace - z          0.070000   0.010000   0.080000 (  0.082928)
x.inplace * y          0.040000   0.010000   0.050000 (  0.038360)
x.inplace * 1.0        0.040000   0.000000   0.040000 (  0.047472)
x.inplace * z          0.070000   0.020000   0.090000 (  0.082124)
x.inplace / y          0.040000   0.000000   0.040000 (  0.039504)
x.inplace / 1.0        0.050000   0.000000   0.050000 (  0.047914)
x.inplace / z          0.080000   0.010000   0.090000 (  0.085547)
```

See the `x.inplace + z`!