### PR TITLE
bug: replace CLASS_OF with rb_obj_class to return correct class. (#113)

### DIFF
--- a/ext/cumo/narray/array.c
+++ b/ext/cumo/narray/array.c
@@ -101,7 +101,7 @@ static VALUE
         return type;
 
     default:
-        if (CLASS_OF(v) == rb_const_get( rb_cObject, cumo_id_Complex )) {
+        if (rb_obj_class(v) == rb_const_get( rb_cObject, cumo_id_Complex )) {
             return CUMO_NA_DCOMPLEX;
         }
     }
@@ -227,9 +227,9 @@ cumo_na_mdai_investigate(cumo_na_mdai_t *mdai, int ndim)
             }
             // type
             if (NIL_P(mdai->na_type)) {
-                mdai->na_type = CLASS_OF(v);
+                mdai->na_type = rb_obj_class(v);
             } else {
-                mdai->na_type = cumo_na_upcast(CLASS_OF(v), mdai->na_type);
+                mdai->na_type = cumo_na_upcast(rb_obj_class(v), mdai->na_type);
             }
         } else {
             mdai->type = cumo_na_mdai_object_type(mdai->type, v);
@@ -418,7 +418,7 @@ cumo_na_composition3(VALUE obj, VALUE *ptype, VALUE *pshape, VALUE *pnary)
         cumo_narray_t *na;
         CumoGetNArray(obj,na);
         ndim = na->ndim;
-        dtype = update_type(ptype, CLASS_OF(obj));
+        dtype = update_type(ptype, rb_obj_class(obj));
         if (pshape) {
             dshape = rb_ary_new2(ndim);
             for (i=0; i<ndim; i++) {
@@ -431,7 +431,7 @@ cumo_na_composition3(VALUE obj, VALUE *ptype, VALUE *pshape, VALUE *pnary)
         }
     } else {
         rb_raise(rb_eTypeError,"invalid type for NArray: %s",
-                 rb_class2name(CLASS_OF(obj)));
+                 rb_class2name(rb_obj_class(obj)));
     }
 }
 
@@ -534,7 +534,7 @@ cumo_na_mdai_for_struct(cumo_na_mdai_t *mdai, int ndim)
 
     //fpintf(stderr,"val = ");    rb_p(val);
 
-    if (CLASS_OF(val) == mdai->na_type) {
+    if (rb_obj_class(val) == mdai->na_type) {
         CumoGetNArray(val,na);
         if ( ndim+na->ndim > mdai->capa ) {
             abort();

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -462,7 +462,7 @@ cumo_na_flatten_dim(VALUE self, int sd)
     shape[sd] = size;
 
     // new object
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view, na2);
 
@@ -685,7 +685,7 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
     shape[k] = diag_size;
 
     // new object
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view, na2);
 
@@ -798,7 +798,7 @@ cumo_na_new_dimension_for_dot(VALUE self, int pos, int len, bool transpose)
     CumoGetNArray(self,na);
     nd = na->ndim;
 
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
 
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view, na2);

--- a/ext/cumo/narray/gen/tmpl/accum_binary.c
+++ b/ext/cumo/narray/gen/tmpl/accum_binary.c
@@ -110,7 +110,7 @@ static VALUE
     //<% if is_object %>
     return <%=c_func%>_self(argc, argv, self);
     //<% else %>
-    klass = cumo_na_upcast(CLASS_OF(self),CLASS_OF(argv[0]));
+    klass = cumo_na_upcast(rb_obj_class(self),rb_obj_class(argv[0]));
     if (klass==cT) {
         return <%=c_func%>_self(argc, argv, self);
     } else {

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -151,7 +151,7 @@ static VALUE
     <% else %>
     VALUE klass, v;
 
-    klass = cumo_na_upcast(CLASS_OF(self),CLASS_OF(other));
+    klass = cumo_na_upcast(rb_obj_class(self),rb_obj_class(other));
     if (klass==cT) {
         return <%=c_func%>_self(self, other);
     } else {

--- a/ext/cumo/narray/gen/tmpl/binary2.c
+++ b/ext/cumo/narray/gen/tmpl/binary2.c
@@ -59,7 +59,7 @@ static VALUE
     return <%=c_func%>_self(self, other);
     <% else %>
     VALUE klass, v;
-    klass = cumo_na_upcast(CLASS_OF(self),CLASS_OF(other));
+    klass = cumo_na_upcast(rb_obj_class(self),rb_obj_class(other));
     if (klass==cT) {
         return <%=c_func%>_self(self, other);
     } else {

--- a/ext/cumo/narray/gen/tmpl/bincount.c
+++ b/ext/cumo/narray/gen/tmpl/bincount.c
@@ -171,7 +171,7 @@ static VALUE
             return <%=c_func%>_32(self, length);
         }
     } else {
-        wclass = CLASS_OF(weight);
+        wclass = rb_obj_class(weight);
         if (wclass == cumo_cSFloat) {
             return <%=c_func%>_sf(self, weight, length);
         } else {

--- a/ext/cumo/narray/gen/tmpl/cast.c
+++ b/ext/cumo/narray/gen/tmpl/cast.c
@@ -17,7 +17,7 @@ static VALUE
     cumo_narray_t *na;
     dtype x;
 
-    if (CLASS_OF(obj)==cT) {
+    if (rb_obj_class(obj)==cT) {
         return obj;
     }
     if (RTEST(rb_obj_is_kind_of(obj,rb_cNumeric))) {

--- a/ext/cumo/narray/gen/tmpl/cond_binary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_binary.c
@@ -57,7 +57,7 @@ static VALUE
     return <%=c_func%>_self(self, other);
     <% else %>
     VALUE klass, v;
-    klass = cumo_na_upcast(CLASS_OF(self),CLASS_OF(other));
+    klass = cumo_na_upcast(rb_obj_class(self),rb_obj_class(other));
     if (klass==cT) {
         return <%=c_func%>_self(self, other);
     } else {

--- a/ext/cumo/narray/gen/tmpl/extract_data.c
+++ b/ext/cumo/narray/gen/tmpl/extract_data.c
@@ -19,7 +19,7 @@ static dtype
         if (na->size != 1) {
             rb_raise(cumo_na_eShapeError,"narray size should be 1");
        }
-        klass = CLASS_OF(obj);
+        klass = rb_obj_class(obj);
         ptr = cumo_na_get_pointer_for_read(obj);
         pos = cumo_na_get_offset(obj);
         <% find_tmpl("store").definitions.select{|x| x.class==Store}.each do |x| %>
@@ -31,14 +31,14 @@ static dtype
 
         // coerce
         r = rb_funcall(obj, rb_intern("coerce_cast"), 1, cT);
-        if (CLASS_OF(r)==cT) {
+        if (rb_obj_class(r)==cT) {
             return <%=c_func%>(r);
         }
         <% if is_object %>
         return obj;
         <% else %>
         rb_raise(cumo_na_eCastError, "unknown conversion from %s to %s",
-                 rb_class2name(CLASS_OF(obj)),
+                 rb_class2name(rb_obj_class(obj)),
                  rb_class2name(cT));
         <% end %>
     }

--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -27,7 +27,7 @@
 #define COL_SIZE(na) ((na)->shape[(na)->ndim-1])
 
 #define CHECK_NARRAY_TYPE(x,t)                                 \
-    if (CLASS_OF(x)!=(t)) {                                    \
+    if (rb_obj_class(x)!=(t)) {                                    \
         rb_raise(rb_eTypeError,"invalid NArray type (class)"); \
     }
 
@@ -93,7 +93,7 @@
 
 #define COPY_OR_CAST_TO(a,T)                            \
     {                                                   \
-        if (CLASS_OF(a) == (T)) {                       \
+        if (rb_obj_class(a) == (T)) {                       \
             if (!CUMO_TEST_INPLACE(a)) {                     \
                 a = cumo_na_copy(a);                    \
             }                                           \

--- a/ext/cumo/narray/gen/tmpl/pow.c
+++ b/ext/cumo/narray/gen/tmpl/pow.c
@@ -86,7 +86,7 @@ static VALUE
     return <%=c_func%>_self(self,other);
     <% else %>
     VALUE klass, v;
-    klass = cumo_na_upcast(CLASS_OF(self),CLASS_OF(other));
+    klass = cumo_na_upcast(rb_obj_class(self),rb_obj_class(other));
     if (klass==cT) {
         return <%=c_func%>_self(self,other);
     } else {

--- a/ext/cumo/narray/gen/tmpl/store.c
+++ b/ext/cumo/narray/gen/tmpl/store.c
@@ -13,7 +13,7 @@ static VALUE
 {
     VALUE r, klass;
 
-    klass = CLASS_OF(obj);
+    klass = rb_obj_class(obj);
 
     <% definitions.each do |x| %>
     if (<%=x.condition("klass")%>) {
@@ -24,7 +24,7 @@ static VALUE
 
     if (CumoIsNArray(obj)) {
         r = rb_funcall(obj, rb_intern("coerce_cast"), 1, cT);
-        if (CLASS_OF(r)==cT) {
+        if (rb_obj_class(r)==cT) {
             <%=c_func%>(self,r);
             return self;
         }
@@ -34,8 +34,8 @@ static VALUE
     robject_store_numeric(self,obj);
     <% else %>
     rb_raise(cumo_na_eCastError, "unknown conversion from %s to %s",
-             rb_class2name(CLASS_OF(obj)),
-             rb_class2name(CLASS_OF(self)));
+             rb_class2name(rb_obj_class(obj)),
+             rb_class2name(rb_obj_class(self)));
     <% end %>
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -107,7 +107,7 @@ static VALUE
     g.idx0 = NULL;
     cumo_na_ndloop3(&ndf, &g, 2, mask, val);
 
-    view = cumo_na_s_allocate_view(CLASS_OF(val));
+    view = cumo_na_s_allocate_view(rb_obj_class(val));
     CumoGetNArrayView(view, nv);
     cumo_na_setup_shape((cumo_narray_t*)nv, 1, &n_1);
 

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -576,7 +576,7 @@ VALUE cumo_na_aref_md_protected(VALUE data_value)
     } else {
         ndim_new = cumo_na_ndim_new_narray(ndim, q);
     }
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
 
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view,na2);
@@ -652,7 +652,7 @@ cumo_na_aref_md(int argc, VALUE *argv, VALUE self, int keep_dim, int result_nd, 
         if (rb_obj_is_kind_of(idx, cumo_cNArray)) {
             CumoGetNArray(idx,nidx);
             if (CUMO_NA_NDIM(nidx)>1) {
-                store = cumo_na_new(CLASS_OF(self),CUMO_NA_NDIM(nidx),CUMO_NA_SHAPE(nidx));
+                store = cumo_na_new(rb_obj_class(self),CUMO_NA_NDIM(nidx),CUMO_NA_SHAPE(nidx));
                 idx = cumo_na_flatten(idx);
                 RARRAY_ASET(args,0,idx);
             }
@@ -703,7 +703,7 @@ cumo_na_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result_nd,
         return rb_funcall(self,cumo_id_dup,0);
     }
     if (nidx==1) {
-        if (CLASS_OF(*idx)==cumo_cBit) {
+        if (rb_obj_class(*idx)==cumo_cBit) {
             return rb_funcall(*idx,cumo_id_mask,1,self);
         }
     }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -105,7 +105,7 @@ cumo_na_debug_info(VALUE self)
     cumo_narray_t *na;
     CumoGetNArray(self,na);
 
-    printf("%s:\n",rb_class2name(CLASS_OF(self)));
+    printf("%s:\n",rb_class2name(rb_obj_class(self)));
     printf("  id     = 0x%"PRI_VALUE_PREFIX"x\n", self);
     printf("  type   = %d\n", na->type);
     printf("  flag   = [%d,%d]\n", na->flag[0], na->flag[1]);
@@ -890,7 +890,7 @@ cumo_na_make_view(VALUE self)
     CumoGetNArray(self,na);
     nd = na->ndim;
 
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
 
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view, na2);
@@ -1021,7 +1021,7 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
     CumoGetNArray(self,na);
     nd = na->ndim;
 
-    view = cumo_na_s_allocate_view(CLASS_OF(self));
+    view = cumo_na_s_allocate_view(rb_obj_class(self));
 
     cumo_na_copy_flags(self, view);
     CumoGetNArrayView(view, na2);
@@ -1121,7 +1121,7 @@ cumo_na_coerce(VALUE x, VALUE y)
 {
     VALUE type;
 
-    type = cumo_na_upcast(CLASS_OF(x), CLASS_OF(y));
+    type = cumo_na_upcast(rb_obj_class(x), rb_obj_class(y));
     y = rb_funcall(type,cumo_id_cast,1,y);
     return rb_assoc_new(y , x);
 }
@@ -1138,7 +1138,7 @@ cumo_na_byte_size(VALUE self)
     cumo_narray_t *na;
 
     CumoGetNArray(self,na);
-    velmsz = rb_const_get(CLASS_OF(self), cumo_id_element_byte_size);
+    velmsz = rb_const_get(rb_obj_class(self), cumo_id_element_byte_size);
     if (FIXNUM_P(velmsz)) {
         return SIZET2NUM(NUM2SIZET(velmsz) * na->size);
     }
@@ -1261,7 +1261,7 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
 
     CumoGetNArray(self,na);
     size = CUMO_NA_SIZE(na);
-    velmsz = rb_const_get(CLASS_OF(self), cumo_id_element_byte_size);
+    velmsz = rb_const_get(rb_obj_class(self), cumo_id_element_byte_size);
     if (FIXNUM_P(velmsz)) {
         byte_size = size * NUM2SIZET(velmsz);
     } else {
@@ -1325,7 +1325,7 @@ cumo_na_marshal_dump(VALUE self)
     rb_ary_push(a, INT2FIX(1));     // version
     rb_ary_push(a, cumo_na_shape(self));
     rb_ary_push(a, INT2FIX(CUMO_NA_FLAG0(self)));
-    if (CLASS_OF(self) == cumo_cRObject) {
+    if (rb_obj_class(self) == cumo_cRObject) {
         cumo_narray_t *na;
         VALUE *ptr;
         size_t offset=0;
@@ -1371,7 +1371,7 @@ cumo_na_marshal_load(VALUE self, VALUE a)
     cumo_na_initialize(self,RARRAY_AREF(a,1));
     CUMO_NA_FL0_SET(self,FIX2INT(RARRAY_AREF(a,2)));
     v = RARRAY_AREF(a,3);
-    if (CLASS_OF(self) == cumo_cRObject) {
+    if (rb_obj_class(self) == cumo_cRObject) {
         cumo_narray_t *na;
         char *ptr;
         if (TYPE(v) != T_ARRAY) {
@@ -1779,7 +1779,7 @@ cumo_na_equal(VALUE self, volatile VALUE other)
     CumoGetNArray(self,na1);
 
     if (!rb_obj_is_kind_of(other,cNArray)) {
-        other = rb_funcall(CLASS_OF(self), cumo_id_cast, 1, other);
+        other = rb_funcall(rb_obj_class(self), cumo_id_cast, 1, other);
     }
 
     CumoGetNArray(other,na2);

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -214,7 +214,7 @@ ndloop_func_loop_spec(cumo_ndfunc_t *nf, int user_ndim)
 static int
 ndloop_cast_required(VALUE type, VALUE value)
 {
-    return CASTABLE(type) && type != CLASS_OF(value);
+    return CASTABLE(type) && type != rb_obj_class(value);
 }
 
 static int
@@ -664,7 +664,7 @@ ndloop_check_inplace(VALUE type, int cumo_na_ndim, size_t *cumo_na_shape, VALUE 
     cumo_narray_t *na;
 
     // type check
-    if (type != CLASS_OF(v)) {
+    if (type != rb_obj_class(v)) {
         return 0;
     }
     CumoGetNArray(v,na);
@@ -731,7 +731,7 @@ ndloop_get_arg_type(cumo_ndfunc_t *nf, VALUE args, VALUE t)
         t = nf->ain[i].type;
         // if i-th type is Qnil, get the type of i-th input value
         if (!CASTABLE(t)) {
-            t = CLASS_OF(RARRAY_AREF(args,i));
+            t = rb_obj_class(RARRAY_AREF(args,i));
         }
     }
     return t;
@@ -1628,7 +1628,7 @@ cumo_na_info_str(VALUE ary)
     CumoGetNArray(ary,na);
     nd = na->ndim;
 
-    buf = rb_str_new2(rb_class2name(CLASS_OF(ary)));
+    buf = rb_str_new2(rb_class2name(rb_obj_class(ary)));
     if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
         rb_str_cat(buf,"(view)",6);
     }
@@ -1778,8 +1778,8 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
     int *dim_map;
     VALUE a_type;
 
-    a_type = CLASS_OF(LARG(lp,0).value);
-    if (CLASS_OF(a) != a_type) {
+    a_type = rb_obj_class(LARG(lp,0).value);
+    if (rb_obj_class(a) != a_type) {
         a = rb_funcall(a_type, cumo_id_cast, 1, a);
     }
     CumoGetNArray(a,na);

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -20,7 +20,7 @@ nst_allocate(VALUE self)
     case CUMO_NARRAY_DATA_T:
         ptr = CUMO_NA_DATA_PTR(na);
         if (na->size > 0 && ptr == NULL) {
-            velmsz = rb_const_get(CLASS_OF(self), rb_intern("element_byte_size"));
+            velmsz = rb_const_get(rb_obj_class(self), rb_intern("element_byte_size"));
             ptr = cumo_cuda_runtime_malloc(NUM2SIZET(velmsz) * na->size);
             CUMO_NA_DATA_PTR(na) = ptr;
         }
@@ -48,7 +48,7 @@ static VALUE
 nst_definition(VALUE nst, VALUE idx)
 {
     long i;
-    VALUE def = nst_definitions(CLASS_OF(nst));
+    VALUE def = nst_definitions(rb_obj_class(nst));
     long  len = RARRAY_LEN(def);
 
     if (TYPE(idx) == T_STRING || TYPE(idx) == T_SYMBOL) {
@@ -102,7 +102,7 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
         for (j=na->ndim,k=0; j<ndim; j++,k++) {
             shape[j] = nt->shape[k];
         }
-        klass = CLASS_OF(dtype);
+        klass = rb_obj_class(dtype);
         stridx = ALLOC_N(cumo_stridx_t, ndim);
         stride = cumo_na_dtype_element_stride(klass);
         for (j=ndim,k=nt->ndim; k; ) {
@@ -115,7 +115,7 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
         for (j=0; j<ndim; j++) {
             shape[j] = na->shape[j];
         }
-        klass = CLASS_OF(self);
+        klass = rb_obj_class(self);
         if (TYPE(dtype)==T_CLASS) {
             if (RTEST(rb_class_inherited_p(dtype,cNArray))) {
                 klass = dtype;
@@ -178,7 +178,7 @@ nst_field_view(VALUE self, VALUE idx)
     if (!RTEST(def)) {
         idx = rb_funcall(idx, rb_intern("to_s"), 0);
         rb_raise(rb_eTypeError, "Invalid field: '%s' for struct %s",
-                 StringValuePtr(idx), rb_class2name(CLASS_OF(self)));
+                 StringValuePtr(idx), rb_class2name(rb_obj_class(self)));
     }
     type = RARRAY_AREF(def,1);
     ofs  = RARRAY_AREF(def,2);
@@ -350,7 +350,7 @@ nstruct_add_type(VALUE type, int argc, VALUE *argv, VALUE nst)
     if (rb_obj_is_kind_of(type,cNArray)) {
         cumo_narray_t *na;
         CumoGetNArray(type,na);
-        type = CLASS_OF(type);
+        type = rb_obj_class(type);
         ndim = na->ndim;
         shape = na->shape;
     }
@@ -358,7 +358,7 @@ nstruct_add_type(VALUE type, int argc, VALUE *argv, VALUE nst)
     CumoGetNArrayView(type,nt);
 
     nt->stridx = ALLOC_N(cumo_stridx_t,ndim);
-    stride = cumo_na_dtype_element_stride(CLASS_OF(type));
+    stride = cumo_na_dtype_element_stride(rb_obj_class(type));
     for (j=ndim; j--; ) {
         CUMO_SDX_SET_STRIDE(nt->stridx[j], stride);
         stride *= shape[j];
@@ -438,7 +438,7 @@ nst_create_member_views(VALUE self)
     long  i, len;
     cumo_narray_view_t *ne;
 
-    defs = nst_definitions(CLASS_OF(self));
+    defs = nst_definitions(rb_obj_class(self));
     len = RARRAY_LEN(defs);
     types = rb_ary_new2(len);
     //ofsts = rb_ary_new2(len);
@@ -528,7 +528,7 @@ nst_check_compatibility(VALUE nst, VALUE ary)
     cumo_narray_t *nt;
 
     if (TYPE(ary) != T_ARRAY) {
-        if (nst==CLASS_OF(ary)) { // same Struct
+        if (nst==rb_obj_class(ary)) { // same Struct
             return Qtrue;
         }
         return Qfalse;
@@ -601,7 +601,7 @@ iter_nstruct_from_a(cumo_na_loop_t *const lp)
 
     len = RARRAY_LEN(types);
     ary = lp->args[1].value;
-    //rb_p(CLASS_OF(ary));rb_p(ary);
+    //rb_p(rb_obj_class(ary));rb_p(ary);
 
     for (i=0; i<len; i++) {
         def  = RARRAY_AREF(defs,i);
@@ -630,7 +630,7 @@ cumo_na_struct_cast_array(VALUE klass, VALUE rary)
     cumo_ndfunc_t ndf = {iter_nstruct_from_a, CUMO_NO_LOOP, 3, 0, ain, 0};
 
     //fprintf(stderr,"rary:");rb_p(rary);
-    //fprintf(stderr,"class_of(rary):");rb_p(CLASS_OF(rary));
+    //fprintf(stderr,"class_of(rary):");rb_p(rb_obj_class(rary));
 
     //vnc = cumo_na_ary_composition_for_struct(klass, rary);
     //Data_Get_Struct(vnc, cumo_na_compose_t, nc);
@@ -716,7 +716,7 @@ cumo_na_struct_store_struct(VALUE self, VALUE obj)
 static inline VALUE
 cumo_na_struct_store_array(VALUE self, VALUE obj)
 {
-    return cumo_na_struct_store_struct(self, cumo_na_struct_cast_array(CLASS_OF(self),obj));
+    return cumo_na_struct_store_struct(self, cumo_na_struct_cast_array(rb_obj_class(self),obj));
 }
 
 /*
@@ -732,13 +732,13 @@ cumo_na_struct_store(VALUE self, VALUE obj)
         cumo_na_struct_store_array(self,obj);
         return self;
     }
-    if (CLASS_OF(self) == CLASS_OF(obj)) {
+    if (rb_obj_class(self) == rb_obj_class(obj)) {
         cumo_na_struct_store_struct(self,obj);
         return self;
     }
     rb_raise(cumo_na_eCastError, "unknown conversion from %s to %s",
-             rb_class2name(CLASS_OF(obj)),
-             rb_class2name(CLASS_OF(self)));
+             rb_class2name(rb_obj_class(obj)),
+             rb_class2name(rb_obj_class(self)));
     return self;
 }
 


### PR DESCRIPTION
backport https://github.com/ruby-numo/numo-narray/commit/ac172753be9bb7b0aad9e9deead907ec6e4b6aeb