### PR TITLE
Add CUMO_NVCC_GENERATE_CODE environment variable to configure nvcc --generate-code option

### DIFF
--- a/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
+++ b/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
@@ -32,7 +32,19 @@ module MakeMakefileCuda
     # TODO(sonots): Make it possible to configure "nvcc" and additional arguments
     def nvcc_command
       s = MakeMakefileCuda::Nvcc.generate(argv)
-      ["nvcc " << s << " -arch=sm_35"]
+      cmd = "nvcc " << s
+      if ENV['CUMO_NVCC_GENERATE_CODE']
+        cmd << " --generate-code=#{ENV['CUMO_NVCC_GENERATE_CODE']}"
+      elsif ENV['DEBUG']
+        cmd << " -arch=sm_35"
+      else
+        cmd << " --generate-code=arch=compute_35,code=sm_35"
+        cmd << " --generate-code=arch=compute_50,code=sm_50"
+        cmd << " --generate-code=arch=compute_60,code=sm_60"
+        cmd << " --generate-code=arch=compute_70,code=sm_70"
+        cmd << " --generate-code=arch=compute_70,code=compute_70"
+      end
+      cmd
     end
 
     def c_command

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ bundle exec gdb -x run.gdb --args ruby test/narray_test.rb
 
 You may put a breakpoint by calling `cumo_debug_breakpoint()` at C source codes.
 
+### Specify nvcc --generate-code options
+
+```
+bundle exec CUMO_NVCC_GENERATE_CODE=arch=compute_60,sm_60 rake compile
+```
+
+This is useful even on development because it makes possible to skip JIT compilation of PTX to cubin occurring on runtime.
+
 ### Run program always synchronizing CPU and GPU
 
 ```


### PR DESCRIPTION
I've found that it sometimes takes time on booting CUDA program.
It was caused by first-time JIT compilation of PTX into cubin.

By specifying --generate-code with real architecture, we can create cubin beforehand and avoid JIT compilation.

Specifying multiple --generate-code options takes much of time on compilation, but one --generate-code does not increase build time so much (and we originally specified `-arch=sm_35`, so the compilation time does not change).
