### PR TITLE
Fix advanced indexing

### DIFF
--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -41,7 +41,9 @@ static inline bool
 cumo_cuda_runtime_is_device_memory(void* ptr)
 {
     struct cudaPointerAttributes attrs;
-    cudaError_t status = cudaPointerGetAttributes(&attrs, ptr);
+    cudaError_t status;
+    if (!ptr) { return false; }
+    status = cudaPointerGetAttributes(&attrs, ptr);
     cudaGetLastError(); // reset last error to success
     return (status != cudaErrorInvalidValue);
 }

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -427,10 +427,26 @@ _cumo_na_get_narray_t(VALUE obj, unsigned char cumo_na_type)
 
 #define CUMO_DEBUG_PRINT(v) puts(StringValueCStr(rb_funcall(v,rb_intern("inspect"),0)))
 
-#define CUMO_NA_CumoIsNArray(obj) \
-  (rb_obj_is_kind_of(obj,cNArray)==Qtrue)
-#define CUMO_NA_IsArray(obj) \
-  (TYPE(obj)==T_ARRAY || rb_obj_is_kind_of(obj,cNArray)==Qtrue)
+#define CUMO_NA_CumoIsNArray(obj) (rb_obj_is_kind_of(obj,cNArray)==Qtrue)
+#define CUMO_NA_IsArray(obj) (TYPE(obj)==T_ARRAY || rb_obj_is_kind_of(obj,cNArray)==Qtrue)
+
+static inline bool
+cumo_na_has_idx_p(VALUE obj)
+{
+    cumo_narray_t *na;
+    cumo_narray_view_t *nv;
+    int i = 0;
+    CumoGetNArray(obj, na);
+    if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+        CumoGetNArrayView(obj, nv);
+        for (; i < nv->base.ndim; ++i) {
+            if (nv->stridx[i].index) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
 
 #define CUMO_NUM2REAL(v)  NUM2DBL( rb_funcall((v),cumo_na_id_real,0) )
 #define CUMO_NUM2IMAG(v)  NUM2DBL( rb_funcall((v),cumo_na_id_imag,0) )

--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -33,7 +33,7 @@ __global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, int out_blo
     cumo_na_indexer_t& in_indexer = arg.in_indexer;
     cumo_na_indexer_t& out_indexer = arg.out_indexer;
 
-    using TypeReduce = decltype(impl.Identity());
+    using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
@@ -48,14 +48,17 @@ __global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, int out_blo
 
     for (int64_t i_out = out_base + out_offset; i_out < out_indexer.total_size; i_out += out_stride) {
         cumo_na_indexer_set_dim(&out_indexer, i_out);
-        TypeReduce accum = impl.Identity();
-
         int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
+
+        // Note that spec of (min|max)_index of cumo is different with arg(min|max) of cupy.
+        // Cumo returns index of input elements, CuPy returns index of reduction axis.
+        cumo_na_indexer_set_dim(&in_indexer, i_in);
+        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
+        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
+
         for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
             cumo_na_indexer_set_dim(&in_indexer, i_in);
-            TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-            // Note that spec of (min|max)_index of cumo is different with arg(min|max) of cupy.
-            // Cumo returns index of input elements, CuPy returns index of reduction axis.
+            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
             impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
             //printf("threadId.x:%d blockIdx.x:%d blockDim.x:%d gridDim.x:%d accum:%d i_in:%ld i_reduce:%ld i_out:%ld in:%p(%d)\n", threadIdx.x, blockIdx.x, blockDim.x, gridDim.x, accum, i_in, i_reduce, i_out, in_ptr, *in_ptr);
         }
@@ -102,7 +105,7 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
 
     int64_t block_size = cumo_detail::max_block_size;
     int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
-    int64_t shared_mem_size = sizeof(decltype(impl.Identity())) * block_size;
+    int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
     cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
 }

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -512,7 +512,8 @@ cumo_na_flatten_dim(VALUE self, int sd)
             na2->stridx[sd] = na1->stridx[nd-1];
         } else {
             // set index
-            idx2 = ALLOC_N(size_t, shape[sd]);
+            // idx2 = ALLOC_N(size_t, shape[sd]);
+            idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[sd]);
             CUMO_SDX_SET_INDEX(na2->stridx[sd],idx2);
             // init for md-loop
             fd = nd-sd;
@@ -521,6 +522,8 @@ cumo_na_flatten_dim(VALUE self, int sd)
             pos = ALLOC_N(size_t, fd+1);
             pos[0] = 0;
             // md-loop
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_flatten_dim", "any");
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
             for (i=j=0;;) {
                 for (; i<fd; i++) {
                     sdx = na1->stridx[i+sd];

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -1,4 +1,6 @@
 #include <ruby.h>
+#include "cumo.h"
+#include "cumo/cuda/runtime.h"
 #include "cumo/narray.h"
 #include "cumo/template.h"
 
@@ -56,7 +58,8 @@ iter_copy_bytes(cumo_na_loop_t *const lp)
 {
     size_t e;
     e = lp->args[0].elmsz;
-    // TODO(sonots): CUDA kernelize
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("iter_copy_bytes", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     LOOP_UNARY_PTR(lp,m_memcpy);
 }
 
@@ -99,6 +102,8 @@ iter_swap_byte(cumo_na_loop_t *const lp)
     e = lp->args[0].elmsz;
     b1 = ALLOCA_N(char, e);
     b2 = ALLOCA_N(char, e);
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("iter_swap_bytes", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     LOOP_UNARY_PTR(lp,m_swap_byte);
 }
 
@@ -725,6 +730,9 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
         for (i=k=0; i<nd; i++) {
             if (i != ax[0] && i != ax[1]) {
                 if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
+                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_diagonal", "any");
+                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
                     idx0 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
                     idx1 = ALLOC_N(size_t, na->shape[i]);
                     for (j=0; j<na->shape[i]; j++) {
@@ -738,6 +746,9 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
             }
         }
         if (CUMO_SDX_IS_INDEX(na1->stridx[ax[0]])) {
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_diagonal", "any");
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
             idx0 = CUMO_SDX_GET_INDEX(na1->stridx[ax[0]]);
             diag_idx = ALLOC_N(size_t, diag_size);
             if (CUMO_SDX_IS_INDEX(na1->stridx[ax[1]])) {
@@ -755,6 +766,9 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
         } else {
             stride0 = CUMO_SDX_GET_STRIDE(na1->stridx[ax[0]]);
             if (CUMO_SDX_IS_INDEX(na1->stridx[ax[1]])) {
+                CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_diagonal", "any");
+                cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[ax[1]]);
                 diag_idx = ALLOC_N(size_t, diag_size);
                 for (j=0; j<diag_size; j++) {

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -494,10 +494,12 @@ cumo_na_flatten_dim(VALUE self, int sd)
         for (i=0; i<sd; i++) {
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                idx2 = ALLOC_N(size_t, shape[i]);
-                for (j=0; j<shape[i]; j++) {
-                    idx2[j] = idx1[j];
-                }
+                // idx2 = ALLOC_N(size_t, shape[i]);
+                // for (j=0; j<shape[i]; j++) {
+                //     idx2[j] = idx1[j];
+                // }
+                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[i]);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*shape[i],cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
             } else {
                 na2->stridx[i] = na1->stridx[i];

--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -77,7 +77,12 @@ static VALUE
   <% else %>
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
   <% end %>
-    v =  cumo_na_ndloop(&ndf, 2, self, reduce);
+    if (cumo_na_has_idx_p(self)) {
+        VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
+        v =  cumo_na_ndloop(&ndf, 2, copy, reduce);
+    } else {
+        v =  cumo_na_ndloop(&ndf, 2, self, reduce);
+    }
   <% if result_class == "cT" %>
     return <%=type_name%>_extract(v);
   <% else %>

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -113,7 +113,12 @@ static VALUE
             <% end %>
         }
 
-        return cumo_na_ndloop(&ndf, 2, self, reduce);
+        if (cumo_na_has_idx_p(self)) {
+            VALUE copy = cumo_na_copy(self); // reduction does not support idx, make conttiguous
+            return cumo_na_ndloop(&ndf, 2, copy, reduce);
+        } else {
+            return cumo_na_ndloop(&ndf, 2, self, reduce);
+        }
     }
     <% end %>
 }

--- a/ext/cumo/narray/gen/tmpl/accum_index_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_index_kernel.cu
@@ -17,7 +17,7 @@ struct cumo_<%=type_name%>_min_index_int<%=i%>_impl {
         dtype min;
         idx_t argmin;
     };
-    __device__ MinAndArgMin Identity() { return {DATA_MAX, 0}; }
+    __device__ MinAndArgMin Identity(idx_t index) { return {DATA_MAX, index}; }
     __device__ MinAndArgMin MapIn(dtype in, idx_t index) { return {in, index}; }
     __device__ void Reduce(MinAndArgMin next, MinAndArgMin& accum) {
         if (accum.min > next.min) {
@@ -32,7 +32,7 @@ struct cumo_<%=type_name%>_max_index_int<%=i%>_impl {
         dtype max;
         idx_t argmax;
     };
-    __device__ MaxAndArgMax Identity() { return {DATA_MIN, 0}; }
+    __device__ MaxAndArgMax Identity(idx_t index) { return {DATA_MIN, index}; }
     __device__ MaxAndArgMax MapIn(dtype in, idx_t index) { return {in, index}; }
     __device__ void Reduce(MaxAndArgMax next, MaxAndArgMax& accum) {
         if (accum.max < next.max) {

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -6,14 +6,14 @@
 #endif
 
 struct cumo_<%=type_name%>_sum_impl {
-    __device__ <%=dtype%> Identity() { return m_zero; }
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_zero; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum = m_add(next, accum); }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_prod_impl {
-    __device__ <%=dtype%> Identity() { return m_one; }
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_one; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum = m_mul(next, accum); }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -6,28 +6,28 @@
 #endif
 
 struct cumo_<%=type_name%>_sum_impl {
-    __device__ <%=dtype%> Identity() { return m_zero; }
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_zero; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum += next; }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_prod_impl {
-    __device__ <%=dtype%> Identity() { return m_one; }
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_one; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum *= next; }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_min_impl {
-    __device__ dtype Identity() { return DATA_MAX; }
+    __device__ dtype Identity(int64_t /*index*/) { return DATA_MAX; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { accum = next < accum ? next : accum; }
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_max_impl {
-    __device__ dtype Identity() { return DATA_MIN; }
+    __device__ dtype Identity(int64_t /*index*/) { return DATA_MIN; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { accum = next < accum ? accum : next; }
     __device__ dtype MapOut(dtype accum) { return accum; }

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -425,7 +425,7 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
 
         // array index
         if (q[i].idx != NULL) {
-            SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_nadata", "any");
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_nadata", "any");
             cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
             index = q[i].idx;
@@ -484,7 +484,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             int k;
             size_t *index = q[i].idx;
 
-            SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
             cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
             CUMO_SDX_SET_INDEX(na2->stridx[j], index);
@@ -499,7 +499,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             ssize_t stride1 = CUMO_SDX_GET_STRIDE(sdx1);
             size_t *index = q[i].idx;
 
-            SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
             cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
             CUMO_SDX_SET_INDEX(na2->stridx[j],index);
@@ -533,7 +533,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             size_t *index = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*size);
             CUMO_SDX_SET_INDEX(na2->stridx[j],index);
 
-            SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
+            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
             cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
             for (k=0; k<size; k++) {

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -529,8 +529,13 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             int k;
             size_t beg  = q[i].beg;
             ssize_t step = q[i].step;
-            size_t *index = ALLOC_N(size_t, size);
+            // size_t *index = ALLOC_N(size_t, size);
+            size_t *index = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*size);
             CUMO_SDX_SET_INDEX(na2->stridx[j],index);
+
+            SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_index_aref_naview", "any");
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
             for (k=0; k<size; k++) {
                 index[k] = CUMO_SDX_GET_INDEX(sdx1)[beg+step*k];
             }

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -664,12 +664,7 @@ cumo_na_aref_md_ensure(VALUE data_value)
     cumo_na_aref_md_data_t *data = (cumo_na_aref_md_data_t*)(data_value);
     int i;
     for (i=0; i<data->ndim; i++) {
-        if (cumo_cuda_runtime_is_device_memory(data->q[i].idx)) {
-            cumo_cuda_runtime_free((char*)(data->q[i].idx));
-        } else {
-            // TODO(sonots): Remove xfree path
-            xfree(data->q[i].idx);
-        }
+        cumo_cuda_runtime_free((char*)(data->q[i].idx));
     }
     if (data->q) xfree(data->q);
     return Qnil;

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -53,7 +53,7 @@ print_index_arg(cumo_na_index_arg_t *q, int n)
         printf("  q[%d].n=%"SZF"d\n",i,q[i].n);
         printf("  q[%d].beg=%"SZF"d\n",i,q[i].beg);
         printf("  q[%d].step=%"SZF"d\n",i,q[i].step);
-        printf("  q[%d].idx=0x%"SZF"x (cumo:%d)\n",i,(size_t)q[i].idx, cumo_cuda_runtime_is_device_memory(q[i].idx));
+        printf("  q[%d].idx=0x%"SZF"x (cuda:%d)\n",i,(size_t)q[i].idx, cumo_cuda_runtime_is_device_memory(q[i].idx));
         // printf("  q[%d].idx=0x%"SZF"x\n",i,(size_t)q[i].idx);
         printf("  q[%d].reduce=0x%x\n",i,q[i].reduce);
         printf("  q[%d].orig_dim=%d\n",i,q[i].orig_dim);

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -880,7 +880,6 @@ VALUE
 cumo_na_make_view(VALUE self)
 {
     int i, nd;
-    size_t  j;
     size_t *idx1, *idx2;
     ssize_t stride;
     cumo_narray_t *na;
@@ -914,10 +913,12 @@ cumo_na_make_view(VALUE self)
         for (i=0; i<nd; i++) {
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                idx2 = ALLOC_N(size_t,na1->base.shape[i]);
-                for (j=0; j<na1->base.shape[i]; j++) {
-                    idx2[j] = idx1[j];
-                }
+                // idx2 = ALLOC_N(size_t,na1->base.shape[i]);
+                // for (j=0; j<na1->base.shape[i]; j++) {
+                //     idx2[j] = idx1[j];
+                // }
+                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*na1->base.shape[i]);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*na1->base.shape[i],cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
             } else {
                 na2->stridx[i] = na1->stridx[i];

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -944,8 +944,8 @@ static VALUE
 cumo_na_expand_dims(VALUE self, VALUE vdim)
 {
     int  i, j, nd, dim;
-    size_t *shape, *cumo_na_shape;
-    cumo_stridx_t *stridx, *cumo_na_stridx;
+    size_t *shape, *na2_shape;
+    cumo_stridx_t *stridx, *na2_stridx;
     cumo_narray_t *na;
     cumo_narray_view_t *na2;
     VALUE view;
@@ -967,25 +967,25 @@ cumo_na_expand_dims(VALUE self, VALUE vdim)
 
     shape = ALLOC_N(size_t,nd+1);
     stridx = ALLOC_N(cumo_stridx_t,nd+1);
-    cumo_na_shape = na2->base.shape;
-    cumo_na_stridx = na2->stridx;
+    na2_shape = na2->base.shape;
+    na2_stridx = na2->stridx;
 
     for (i=j=0; i<=nd; i++) {
         if (i==dim) {
             shape[i] = 1;
             CUMO_SDX_SET_STRIDE(stridx[i],0);
         } else {
-            shape[i] = cumo_na_shape[j];
-            stridx[i] = cumo_na_stridx[j];
+            shape[i] = na2_shape[j];
+            stridx[i] = na2_stridx[j];
             j++;
         }
     }
 
     na2->stridx = stridx;
-    xfree(cumo_na_stridx);
+    xfree(na2_stridx);
     na2->base.shape = shape;
-    if (cumo_na_shape != &(na2->base.size)) {
-        xfree(cumo_na_shape);
+    if (na2_shape != &(na2->base.size)) {
+        xfree(na2_shape);
     }
     na2->base.ndim++;
     return view;

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -168,12 +168,8 @@ cumo_na_view_free(void* ptr)
     if (na->stridx != NULL) {
         for (i=0; i<na->base.ndim; i++) {
             if (CUMO_SDX_IS_INDEX(na->stridx[i])) {
-                void *p = CUMO_SDX_GET_INDEX(na->stridx[i]);
-                if (cumo_cuda_runtime_is_device_memory(p)) {
-                    cumo_cuda_runtime_free(p);
-                } else {
-                    xfree(p);
-                }
+                void *idx = CUMO_SDX_GET_INDEX(na->stridx[i]);
+                cumo_cuda_runtime_free(idx);
             }
         }
         xfree(na->stridx);

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -164,7 +164,8 @@ print_ndloop(cumo_na_md_loop_t *lp) {
                 printf(" &user.args[%d].iter[%d] = 0x%"SZF"x\n", j,i, (size_t)&lp->user.args[j].iter[i]);
                 printf("  user.args[%d].iter[%d].pos = %"SZF"u\n", j,i, lp->user.args[j].iter[i].pos);
                 printf("  user.args[%d].iter[%d].step = %"SZF"u\n", j,i, lp->user.args[j].iter[i].step);
-                printf("  user.args[%d].iter[%d].idx = 0x%"SZF"x\n", j,i, (size_t)lp->user.args[j].iter[i].idx);
+                printf("  user.args[%d].iter[%d].idx = 0x%"SZF"x (cuda:%d)\n", j,i, (size_t)lp->user.args[j].iter[i].idx, cumo_cuda_runtime_is_device_memory(lp->user.args[j].iter[i].idx));
+                // printf("  user.args[%d].iter[%d].idx = 0x%"SZF"x\n", j,i, (size_t)lp->user.args[j].iter[i].idx);
             }
         }
         //
@@ -174,7 +175,8 @@ print_ndloop(cumo_na_md_loop_t *lp) {
             printf(" &xargs[%d].iter[%d] = 0x%"SZF"x\n", j,i, (size_t)&LITER(lp,i,j));
             printf("  xargs[%d].iter[%d].pos = %"SZF"u\n", j,i, LITER(lp,i,j).pos);
             printf("  xargs[%d].iter[%d].step = %"SZF"u\n", j,i, LITER(lp,i,j).step);
-            printf("  xargs[%d].iter[%d].idx = 0x%"SZF"x\n", j,i, (size_t)LITER(lp,i,j).idx);
+            printf("  xargs[%d].iter[%d].idx = 0x%"SZF"x (cuda:%d)\n", j,i, (size_t)LITER(lp,i,j).idx, cumo_cuda_runtime_is_device_memory(LITER(lp,i,j).idx));
+            // printf("  xargs[%d].iter[%d].idx = 0x%"SZF"x\n", j,i, (size_t)LITER(lp,i,j).idx);
         }
         printf("  xargs[%d].bufcp = 0x%"SZF"x\n", j, (size_t)lp->xargs[j].bufcp);
         if (lp->xargs[j].bufcp) {

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1491,6 +1491,8 @@ loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
             // j-th argument
             for (j=0; j<lp->narg; j++) {
                 if (LITER(lp,i,j).idx) {
+                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("loop_narrayx", "any");
+                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).idx[c[i]];
                 } else {
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).step*c[i];

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -76,7 +76,7 @@ void cumo_na_copy_array_structure(VALUE self, VALUE view);
 static VALUE
 cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
 {
-    size_t i, n;
+    size_t n;
     int j, k, ndim;
     size_t *shape;
     size_t *idx1, *idx2;
@@ -147,10 +147,12 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
             if (CUMO_SDX_IS_INDEX(na1->stridx[j])) {
                 n = na1->base.shape[j];
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[j]);
-                idx2 = ALLOC_N(size_t, na1->base.shape[j]);
-                for (i=0; i<n; i++) {
-                    idx2[i] = idx1[i];
-                }
+                // idx2 = ALLOC_N(size_t, na1->base.shape[j]);
+                // for (i=0; i<n; i++) {
+                //     idx2[i] = idx1[i];
+                // }
+                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[j],idx2);
             } else {
                 na2->stridx[j] = na1->stridx[j];

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -478,6 +478,9 @@ class NArrayTest < Test::Unit::TestCase
       unless [Cumo::DComplex, Cumo::SComplex].include?(dtype)
         assert_nothing_raised { dtype.ones(2,3,9,4,2).max_index(2) }
       end
+      if [Cumo::DFloat, Cumo::SFloat].include?(dtype)
+        assert { dtype[[-Float::INFINITY, 0, 1, -Float::INFINITY]].max_index(0) == [0,1,2,3] }
+      end
     end
 
     test "#{dtype},advanced indexing" do

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -278,6 +278,21 @@ class NArrayTest < Test::Unit::TestCase
         v[0] = 13
         assert { v == [13,7,11] }
         assert { a == [[1,2,3],[13,7,11]] }
+
+        a = init.call(dtype, src)
+        a[[1,2,3]] = 13
+        assert { a[[1,2,3]] == [13,13,13] }
+        assert { a == [[1,13,13],[13,7,11]] }
+
+        a = init.call(dtype, src)
+        a[1,[0,2]] = [13,13]
+        assert { a[1,[0,2]] == [13,13] }
+        assert { a == [[1,2,3],[13,7,13]] }
+
+        a = init.call(dtype, src)
+        a[1,true] = 13
+        assert { a[1,true] == [13,13,13] }
+        assert { a == [[1,2,3],[13,13,13]] }
       end
 
     end
@@ -463,6 +478,12 @@ class NArrayTest < Test::Unit::TestCase
       unless [Cumo::DComplex, Cumo::SComplex].include?(dtype)
         assert_nothing_raised { dtype.ones(2,3,9,4,2).max_index(2) }
       end
+    end
+
+    test "#{dtype},advanced indexing" do
+      a = dtype[[1,2,3],[4,5,6]]
+      assert { a[[0,1],[0,1]].dup == [[1,2],[4,5]] }
+      assert { a[[0,1],[0,1]].sum == 12 }
     end
   end
 end


### PR DESCRIPTION
Fix https://github.com/sonots/cumo/issues/88

Now, idx is always unified memory.

1. To use in GPU, just access it
2. To use in CPU, call cudaSynchronize() for now

We should eventually remove 2. by CUDA kernels, but it is not done yet.