### PR TITLE
Arithmetic sequence support.

### DIFF
--- a/ext/cumo/extconf.rb
+++ b/ext/cumo/extconf.rb
@@ -159,6 +159,7 @@ unless have_type("u_int64_t", stdint)
   have_type("uint64_t", stdint)
 end
 have_func("exp10")
+have_func("rb_arithmetic_sequence_extract")
 
 have_var("rb_cComplex")
 have_func("rb_thread_call_without_gvl")

--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -69,7 +69,7 @@ bool cumo_na_test_reduce(VALUE reduce, int dim);
 
 void cumo_na_step_array_index(VALUE self, size_t ary_size, size_t *plen, ssize_t *pbeg, ssize_t *pstep);
 void cumo_na_step_sequence(VALUE self, size_t *plen, double *pbeg, double *pstep);
-void cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep );
+void cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep);
 
 // used in aref, aset
 int cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);

--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -69,6 +69,7 @@ bool cumo_na_test_reduce(VALUE reduce, int dim);
 
 void cumo_na_step_array_index(VALUE self, size_t ary_size, size_t *plen, ssize_t *pbeg, ssize_t *pstep);
 void cumo_na_step_sequence(VALUE self, size_t *plen, double *pbeg, double *pstep);
+void cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep );
 
 // used in aref, aset
 int cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -200,6 +200,9 @@ extern VALUE cumo_na_cStep;
 #ifndef HAVE_RB_CCOMPLEX
 extern VALUE rb_cComplex;
 #endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+VALUE rb_cArithSeq;
+#endif
 
 extern VALUE cumo_sym_reduce;
 extern VALUE cumo_sym_option;
@@ -265,6 +268,23 @@ typedef struct {
     unsigned int element_stride;
 } cumo_narray_type_info_t;
 
+// from ruby/enumerator.c
+struct enumerator {
+    VALUE obj;
+    ID    meth;
+    VALUE args;
+    // use only above in this source
+    VALUE fib;
+    VALUE dst;
+    VALUE lookahead;
+    VALUE feedvalue;
+    VALUE stop_exc;
+    VALUE size;
+    // incompatible below depending on ruby version
+    //VALUE procs;                      // ruby 2.4
+    //rb_enumerator_size_func *size_fn; // ruby 2.1-2.4
+    //VALUE (*size_fn)(ANYARGS);        // ruby 2.0
+};
 
 static inline cumo_narray_t *
 cumo_na_get_narray_t(VALUE obj)

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -201,7 +201,7 @@ extern VALUE cumo_na_cStep;
 extern VALUE rb_cComplex;
 #endif
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-VALUE rb_cArithSeq;
+extern VALUE rb_cArithSeq;
 #endif
 
 extern VALUE cumo_sym_reduce;

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -196,7 +196,6 @@ extern VALUE cumo_cUInt32;
 extern VALUE cumo_cUInt16;
 extern VALUE cumo_cUInt8;
 extern VALUE cumo_cRObject;
-extern VALUE cumo_na_cStep;
 #ifndef HAVE_RB_CCOMPLEX
 extern VALUE rb_cComplex;
 #endif

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -268,7 +268,7 @@ typedef struct {
 } cumo_narray_type_info_t;
 
 // from ruby/enumerator.c
-struct enumerator {
+typedef struct {
     VALUE obj;
     ID    meth;
     VALUE args;
@@ -283,7 +283,7 @@ struct enumerator {
     //VALUE procs;                      // ruby 2.4
     //rb_enumerator_size_func *size_fn; // ruby 2.1-2.4
     //VALUE (*size_fn)(ANYARGS);        // ruby 2.0
-};
+} cumo_enumerator_t;
 
 static inline cumo_narray_t *
 cumo_na_get_narray_t(VALUE obj)

--- a/ext/cumo/narray/array.c
+++ b/ext/cumo/narray/array.c
@@ -117,10 +117,12 @@ static int cumo_na_mdai_object_type(int type, VALUE v)
     if (rb_obj_is_kind_of(v, rb_cRange)) {
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
-    } else if (rb_obj_is_kind_of(v, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    } else if (rb_obj_is_kind_of(v, rb_cArithSeq)) {
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
         MDAI_ATTR_TYPE(type,v,step);
+#endif
     } else {
         type = cumo_na_object_type(type,v);
     }
@@ -205,7 +207,11 @@ cumo_na_mdai_investigate(cumo_na_mdai_t *mdai, int ndim)
             }
         }
         else
-        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, rb_cArithSeq)) {
+#else
+        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, rb_cEnumerator)) {
+#endif
             cumo_na_step_sequence(v,&length,&dbeg,&dstep);
             len += length-1;
             mdai->type = cumo_na_mdai_object_type(mdai->type, v);

--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -65,7 +65,11 @@ static void
         if (idx1) {
             for (i=i1=0; i1<n1 && i<n; i++,i1++) {
                 x = ptr[i1];
-                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
+                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
+#endif
                     cumo_na_step_sequence(x,&len,&beg,&step);
                     for (c=0; c<len && i<n; c++,i++) {
                         y = beg + step * c;
@@ -81,7 +85,11 @@ static void
         } else {
             for (i=i1=0; i1<n1 && i<n; i++,i1++) {
                 x = ptr[i1];
-                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
+                if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
+#endif
                     cumo_na_step_sequence(x,&len,&beg,&step);
                     for (c=0; c<len && i<n; c++,i++) {
                         y = beg + step * c;
@@ -110,7 +118,11 @@ static void
         dtype* host_z = ALLOC_N(dtype, n);
         for (i=i1=0; i1<n1 && i<n; i1++) {
             x = ptr[i1];
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
+#endif
                 cumo_na_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;

--- a/ext/cumo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array.c
@@ -52,7 +52,11 @@ static void
     if (idx1) {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
+#endif
                 cumo_na_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;
@@ -69,7 +73,11 @@ static void
     } else {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
+#endif
                 cumo_na_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -249,7 +249,7 @@ cumo_na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, cumo_
 }
 
 void
-cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep )
+cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep)
 {
     int len;
     VALUE step;

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -253,12 +253,12 @@ cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep)
 {
     int len;
     VALUE step;
-    struct enumerator *e;
+    cumo_enumerator_t *e;
 
     if (!RB_TYPE_P(enum_obj, T_DATA)) {
         rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
     }
-    e = (struct enumerator *)DATA_PTR(enum_obj);
+    e = (cumo_enumerator_t *)DATA_PTR(enum_obj);
 
     if (!rb_obj_is_kind_of(e->obj, rb_cRange)) {
         rb_raise(rb_eTypeError,"not Range object");
@@ -286,13 +286,13 @@ static void
 cumo_na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
 {
     VALUE step;
-    struct enumerator *e;
+    cumo_enumerator_t *e;
 
     if (!RB_TYPE_P(enum_obj, T_DATA)) {
         rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
     }
     cumo_na_parse_enumerator_step(enum_obj, &step);
-    e = (struct enumerator *)DATA_PTR(enum_obj);
+    e = (cumo_enumerator_t *)DATA_PTR(enum_obj);
     cumo_na_parse_range(e->obj, NUM2SSIZET(step), orig_dim, size, q); // e->obj : Range Object
 }
 

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -12,23 +12,6 @@
 #define cIndex cumo_cInt32
 #endif
 
-// from ruby/enumerator.c
-struct enumerator {
-    VALUE obj;
-    ID    meth;
-    VALUE args;
-    // use only above in this source
-    VALUE fib;
-    VALUE dst;
-    VALUE lookahead;
-    VALUE feedvalue;
-    VALUE stop_exc;
-    VALUE size;
-    // incompatible below depending on ruby version
-    //VALUE procs;                      // ruby 2.4
-    //rb_enumerator_size_func *size_fn; // ruby 2.1-2.4
-    //VALUE (*size_fn)(ANYARGS);        // ruby 2.0
-};
 
 // note: the memory refed by this pointer is not freed and causes memroy leak.
 //
@@ -204,6 +187,42 @@ cumo_na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, cumo_
     ssize_t beg, end, beg_orig, end_orig;
     const char *dot = "..", *edot = "...";
 
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_arithmetic_sequence_components_t x;
+    rb_arithmetic_sequence_extract(range, &x);
+    step = NUM2SSIZET(x.step);
+
+    beg = beg_orig = NUM2SSIZET(x.begin);
+    if (beg < 0) {
+        beg += size;
+    }
+    if (T_NIL == TYPE(x.end)) { // endless range
+        end = size -1;
+        if (RTEST(x.exclude_end)) {
+            dot = edot;
+        }
+    } else {
+        end = end_orig = NUM2SSIZET(x.end);
+        if (end < 0) {
+            end += size;
+        }
+        if (RTEST(x.exclude_end)) {
+            end--;
+            dot = edot;
+        }
+    }
+    if (beg < 0 || beg >= size || end < 0 || end >= size) {
+        if (T_NIL == TYPE(x.end)) { // endless range
+            rb_raise(rb_eRangeError,
+                     "%"SZF"d%s is out of range for size=%"SZF"d",
+                     beg_orig, dot, size);
+        } else {
+            rb_raise(rb_eRangeError,
+                     "%"SZF"d%s%"SZF"d is out of range for size=%"SZF"d",
+                     beg_orig, dot, end_orig, size);
+        }
+    }
+#else
     beg = beg_orig = NUM2SSIZET(rb_funcall(range,cumo_id_beg,0));
     if (beg < 0) {
         beg += size;
@@ -222,17 +241,18 @@ cumo_na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, cumo_
                  "%"SZF"d%s%"SZF"d is out of range for size=%"SZF"d",
                  beg_orig, dot, end_orig, size);
     }
+#endif
     n = (end-beg)/step+1;
     if (n<0) n=0;
     cumo_na_index_set_step(q,orig_dim,n,beg,step);
 
 }
 
-static void
-cumo_na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
+void
+cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep )
 {
     int len;
-    ssize_t step;
+    VALUE step;
     struct enumerator *e;
 
     if (!RB_TYPE_P(enum_obj, T_DATA)) {
@@ -240,26 +260,40 @@ cumo_na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, cumo_na_ind
     }
     e = (struct enumerator *)DATA_PTR(enum_obj);
 
-    if (rb_obj_is_kind_of(e->obj, rb_cRange)) {
-        if (e->meth == cumo_id_each) {
-            cumo_na_parse_range(e->obj, 1, orig_dim, size, q);
-        }
-        else if (e->meth == cumo_id_step) {
-            if (TYPE(e->args) != T_ARRAY) {
-                rb_raise(rb_eArgError,"no argument for step");
-            }
-            len = RARRAY_LEN(e->args);
-            if (len != 1) {
-                rb_raise(rb_eArgError,"invalid number of step argument (1 for %d)",len);
-            }
-            step = NUM2SSIZET(RARRAY_AREF(e->args,0));
-            cumo_na_parse_range(e->obj, step, orig_dim, size, q);
-        } else {
-            rb_raise(rb_eTypeError,"unknown Range method: %s",rb_id2name(e->meth));
-        }
-    } else {
+    if (!rb_obj_is_kind_of(e->obj, rb_cRange)) {
         rb_raise(rb_eTypeError,"not Range object");
     }
+
+    if (e->meth == cumo_id_each) {
+        step = INT2NUM(1);
+    }
+    else if (e->meth == cumo_id_step) {
+        if (TYPE(e->args) != T_ARRAY) {
+            rb_raise(rb_eArgError,"no argument for step");
+        }
+        len = RARRAY_LEN(e->args);
+        if (len != 1) {
+            rb_raise(rb_eArgError,"invalid number of step argument (1 for %d)",len);
+        }
+        step = RARRAY_AREF(e->args,0);
+    } else {
+        rb_raise(rb_eTypeError,"unknown Range method: %s",rb_id2name(e->meth));
+    }
+    if (pstep) *pstep = step;
+}
+
+static void
+cumo_na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
+{
+    VALUE step;
+    struct enumerator *e;
+
+    if (!RB_TYPE_P(enum_obj, T_DATA)) {
+        rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
+    }
+    cumo_na_parse_enumerator_step(enum_obj, &step);
+    e = (struct enumerator *)DATA_PTR(enum_obj);
+    cumo_na_parse_range(e->obj, NUM2SSIZET(step), orig_dim, size, q); // e->obj : Range Object
 }
 
 // Analyze *a* which is *i*-th index object and store the information to q
@@ -316,13 +350,13 @@ cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_ar
         if (rb_obj_is_kind_of(a, rb_cRange)) {
             cumo_na_parse_range(a, 1, i, size, q);
         }
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+        else if (rb_obj_is_kind_of(a, rb_cArithSeq)) {
+            cumo_na_parse_range(a, 1, i, size, q);
+        }
+#endif
         else if (rb_obj_is_kind_of(a, rb_cEnumerator)) {
             cumo_na_parse_enumerator(a, i, size, q);
-        }
-        else if (rb_obj_is_kind_of(a, cumo_na_cStep)) {
-            ssize_t beg, step, n;
-            cumo_na_step_array_index(a, size, (size_t*)(&n), &beg, &step);
-            cumo_na_index_set_step(q,i,n,beg,step);
         }
         // NArray index
         else if (CUMO_NA_CumoIsNArray(a)) {

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -40,9 +40,11 @@ VALUE cumo_sym_option;
 VALUE cumo_sym_loop_opt;
 VALUE cumo_sym_init;
 
-VALUE cumo_na_cStep;
 #ifndef HAVE_RB_CCOMPLEX
 VALUE rb_cComplex;
+#endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+VALUE rb_cArithSeq;
 #endif
 
 int cumo_na_inspect_rows_=20;
@@ -1512,7 +1514,11 @@ cumo_na_get_reduce_flag_from_axes(VALUE cumo_na_obj, VALUE axes)
             step = 0;
             //printf("beg=%d step=%d len=%d\n",beg,step,len);
         } else if (rb_obj_is_kind_of(v,rb_cRange) ||
-                   rb_obj_is_kind_of(v,cumo_na_cStep)) {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+                   rb_obj_is_kind_of(v,rb_cArithSeq)) {
+#else
+                   rb_obj_is_kind_of(v,rb_cEnumerator)) {
+#endif
             cumo_na_step_array_index( v, ndim, &len, &beg, &step );
         } else {
             rb_raise(cumo_na_eDimensionError, "invalid dimension argument %s",
@@ -1848,6 +1854,9 @@ Init_cumo_narray()
 #ifndef HAVE_RB_CCOMPLEX
     rb_require("complex");
     rb_cComplex = rb_const_get(rb_cObject, rb_intern("Complex"));
+#endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
 #endif
 
     rb_define_const(cNArray, "VERSION", rb_str_new2(CUMO_VERSION));

--- a/ext/cumo/narray/step.c
+++ b/ext/cumo/narray/step.c
@@ -54,13 +54,13 @@ cumo_na_step_array_index(VALUE obj, size_t ary_size,
     vbeg = x.begin;
     vend = x.end;
 #else
-    struct enumerator *e;
+    cumo_enumerator_t *e;
 
     if (rb_obj_is_kind_of(obj, rb_cRange)) {
         vstep = rb_ivar_get(obj, cumo_id_step);
     } else { // Enumerator
         cumo_na_parse_enumerator_step(obj, &vstep);
-        e = (struct enumerator *)DATA_PTR(obj);
+        e = (cumo_enumerator_t *)DATA_PTR(obj);
         obj =  e->obj; // Range
     }
 
@@ -202,13 +202,13 @@ cumo_na_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
     dbeg = NUM2DBL(x.begin);
     vend = x.end;
 #else
-    struct enumerator *e;
+    cumo_enumerator_t *e;
 
     if (rb_obj_is_kind_of(obj, rb_cRange)) {
         vstep = rb_ivar_get(obj, cumo_id_step);
     } else { // Enumerator
         cumo_na_parse_enumerator_step(obj, &vstep);
-        e = (struct enumerator *)DATA_PTR(obj);
+        e = (cumo_enumerator_t *)DATA_PTR(obj);
         obj =  e->obj; // Range
     }
 

--- a/ext/cumo/narray/step.c
+++ b/ext/cumo/narray/step.c
@@ -24,164 +24,10 @@
 #define DBL_EPSILON 2.2204460492503131e-16
 #endif
 
-static ID cumo_id_beg, cumo_id_end, cumo_id_len, cumo_id_step, cumo_id_excl;
+static ID cumo_id_beg, cumo_id_end, cumo_id_len, cumo_id_step;
 
-//#define EXCL(r) RTEST(rb_ivar_get((r), cumo_id_excl))
+
 #define EXCL(r) RTEST(rb_funcall((r), rb_intern("exclude_end?"), 0))
-
-#define SET_EXCL(r,v) rb_ivar_set((r), cumo_id_excl, (v) ? Qtrue : Qfalse)
-
-static void
-step_init(
-  VALUE self,
-  VALUE beg,
-  VALUE end,
-  VALUE step,
-  VALUE len,
-  VALUE excl
-)
-{
-    if (RTEST(len)) {
-        if (!(FIXNUM_P(len) || TYPE(len)==T_BIGNUM)) {
-            rb_raise(rb_eArgError, "length must be Integer");
-        }
-        if (RTEST(rb_funcall(len,rb_intern("<"),1,INT2FIX(0)))) {
-            rb_raise(rb_eRangeError,"length must be non negative");
-        }
-    }
-    rb_ivar_set(self, cumo_id_beg, beg);
-    rb_ivar_set(self, cumo_id_end, end);
-    rb_ivar_set(self, cumo_id_len, len);
-    rb_ivar_set(self, cumo_id_step, step);
-    SET_EXCL(self, excl);
-}
-
-static VALUE
-cumo_na_step_new2(
-  VALUE range,
-  VALUE step,
-  VALUE len
-)
-{
-    VALUE beg, end, excl;
-    VALUE self = rb_obj_alloc(cumo_na_cStep);
-
-    //beg = rb_ivar_get(range, cumo_id_beg);
-    beg = rb_funcall(range, cumo_id_beg, 0);
-    //end = rb_ivar_get(range, cumo_id_end);
-    end = rb_funcall(range, cumo_id_end, 0);
-    excl = rb_funcall(range, rb_intern("exclude_end?"), 0);
-
-    step_init(self, beg, end, step, len, excl);
-    return self;
-}
-
-
-/*
- *  call-seq:
- *     Step.new(start, end, step=nil, length=nil)    => step
- *     Step.new(range, step=nil, length=nil)         => step
- *
- *  Constructs a step using three parameters among <i>start</i>,
- *  <i>end</i>, <i>step</i> and <i>length</i>.  <i>start</i>,
- *  <i>end</i> parameters can be replaced with <i>range</i>.  If the
- *  <i>step</i> is omitted (or supplied with nil), then calculated
- *  from <i>length</i> or definded as 1.
- */
-
-static VALUE
-step_initialize( int argc, VALUE *argv, VALUE self )
-{
-    VALUE a, b=Qnil, c=Qnil, d=Qnil, e=Qnil;
-
-    rb_scan_args(argc, argv, "13", &a, &b, &c, &d);
-    /* Selfs are immutable, so that they should be initialized only once. */
-    if (rb_ivar_defined(self, cumo_id_beg)) {
-        rb_name_error(rb_intern("initialize"), "`initialize' called twice");
-    }
-    if (rb_obj_is_kind_of(a,rb_cRange)) {
-        if (argc>3) {
-            rb_raise(rb_eArgError, "extra argument");
-        }
-        d = c;
-        c = b;
-        e = rb_funcall(a, rb_intern("exclude_end?"), 0);
-        //b = rb_ivar_get(a, cumo_id_end);
-        b = rb_funcall(a, cumo_id_end, 0);
-        //a = rb_ivar_get(a, cumo_id_beg);
-        a = rb_funcall(a, cumo_id_beg, 0);
-    }
-    step_init(self, a, b, c, d, e);
-    return Qnil;
-}
-
-/*
- *  call-seq:
- *     step.begin  => obj
- *     step.first  => obj
- *
- *  Returns the start of <i>step</i>.
- */
-
-static VALUE
-step_first( VALUE self )
-{
-    return rb_ivar_get(self, cumo_id_beg);
-}
-
-/*
- *  call-seq:
- *     step.end    => obj
- *     step.last   => obj
- *
- *  Returns the object that defines the end of <i>step</i>.
- */
-
-static VALUE
-step_last( VALUE self )
-{
-    return rb_ivar_get(self, cumo_id_end);
-}
-
-/*
- *  call-seq:
- *     step.length  => obj
- *     step.size    => obj
- *
- *  Returns the length of <i>step</i>.
- */
-
-static VALUE
-step_length( VALUE self )
-{
-    return rb_ivar_get(self, cumo_id_len);
-}
-
-/*
- *  call-seq:
- *     step.step    => obj
- *
- *  Returns the step of <i>step</i>.
- */
-
-static VALUE
-step_step( VALUE self )
-{
-    return rb_ivar_get(self, cumo_id_step);
-}
-
-/*
- *  call-seq:
- *     step.exclude_end?    => true or false
- *
- *  Returns <code>true</code> if <i>step</i> excludes its end value.
- */
-static VALUE
-step_exclude_end_p(VALUE self)
-{
-    return RTEST(rb_ivar_get(self, cumo_id_excl)) ? Qtrue : Qfalse;
-}
-
 
 /*
  *  call-seq:
@@ -192,7 +38,7 @@ step_exclude_end_p(VALUE self)
  */
 
 void
-cumo_na_step_array_index(VALUE self, size_t ary_size,
+cumo_na_step_array_index(VALUE obj, size_t ary_size,
                       size_t *plen, ssize_t *pbeg, ssize_t *pstep)
 {
     size_t len;
@@ -200,14 +46,28 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
     VALUE vbeg, vend, vstep, vlen;
     ssize_t end=ary_size;
 
-    //vbeg = rb_ivar_get(self, cumo_id_beg);
-    //vend = rb_ivar_get(self, cumo_id_end);
-    vlen = rb_ivar_get(self, cumo_id_len);
-    vstep = rb_ivar_get(self, cumo_id_step);
-    vbeg = rb_funcall(self, cumo_id_beg, 0);
-    vend = rb_funcall(self, cumo_id_end, 0);
-    //vlen = rb_funcall(self, cumo_id_len, 0);
-    //vstep = rb_funcall(self, cumo_id_step, 0);
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_arithmetic_sequence_components_t x;
+    rb_arithmetic_sequence_extract(obj, &x);
+
+    vstep = x.step;
+    vbeg = x.begin;
+    vend = x.end;
+#else
+    struct enumerator *e;
+
+    if (rb_obj_is_kind_of(obj, rb_cRange)) {
+        vstep = rb_ivar_get(obj, cumo_id_step);
+    } else { // Enumerator
+        cumo_na_parse_enumerator_step(obj, &vstep);
+        e = (struct enumerator *)DATA_PTR(obj);
+        obj =  e->obj; // Range
+    }
+
+    vbeg = rb_funcall(obj, cumo_id_beg, 0);
+    vend = rb_funcall(obj, cumo_id_end, 0);
+#endif
+    vlen = rb_ivar_get(obj, cumo_id_len);
 
     if (RTEST(vbeg)) {
         beg = NUM2SSIZET(vbeg);
@@ -237,7 +97,7 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
                     }
                 } else {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             if (step>0) end--;
                             if (step<0) end++;
                         }
@@ -251,7 +111,7 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
                 step = 1;
                 if (RTEST(vbeg)) {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             if (beg<end) end--;
                             if (beg>end) end++;
                         }
@@ -262,7 +122,7 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
                     }
                 } else {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             end--;
                         }
                         beg = end - (len-1);
@@ -286,7 +146,7 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
             if (!RTEST(vend)) {
                 end = ary_size-1;
             }
-            else if (EXCL(self)) {
+            else if (EXCL(obj)) {
                 end--;
             }
             if (beg<=end) {
@@ -301,7 +161,7 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
             if (!RTEST(vend)) {
                 end = 0;
             }
-            else if (EXCL(self)) {
+            else if (EXCL(obj)) {
                 end++;
             }
             if (beg>=end) {
@@ -327,25 +187,35 @@ cumo_na_step_array_index(VALUE self, size_t ary_size,
     if (pstep) *pstep = step;
 }
 
-
 void
-cumo_na_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
+cumo_na_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
 {
-    VALUE vbeg, vend, vstep, vlen;
+    VALUE vend, vstep, vlen;
     double dbeg, dend, dstep=1, dsize, err;
     size_t size, n;
 
-    //vbeg = rb_ivar_get(self, cumo_id_beg);
-    vbeg = rb_funcall(self, cumo_id_beg, 0);
-    dbeg = NUM2DBL(vbeg);
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_arithmetic_sequence_components_t x;
+    rb_arithmetic_sequence_extract(obj, &x);
 
-    //vend = rb_ivar_get(self, cumo_id_end);
-    vend = rb_funcall(self, cumo_id_end, 0);
+    vstep = x.step;
+    dbeg = NUM2DBL(x.begin);
+    vend = x.end;
+#else
+    struct enumerator *e;
 
-    vlen = rb_ivar_get(self, cumo_id_len);
-    vstep = rb_ivar_get(self, cumo_id_step);
-    //vlen  = rb_funcall(self, cumo_id_len ,0);
-    //vstep = rb_funcall(self, cumo_id_step,0);
+    if (rb_obj_is_kind_of(obj, rb_cRange)) {
+        vstep = rb_ivar_get(obj, cumo_id_step);
+    } else { // Enumerator
+        cumo_na_parse_enumerator_step(obj, &vstep);
+        e = (struct enumerator *)DATA_PTR(obj);
+        obj =  e->obj; // Range
+    }
+
+    dbeg = NUM2DBL(rb_funcall(obj, cumo_id_beg, 0));
+    vend = rb_funcall(obj, cumo_id_end, 0);
+#endif
+    vlen = rb_ivar_get(obj, cumo_id_len);
 
     if (RTEST(vlen)) {
         size = NUM2SIZET(vlen);
@@ -353,7 +223,7 @@ cumo_na_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
         if (!RTEST(vstep)) {
             if (RTEST(vend)) {
                 dend = NUM2DBL(vend);
-                if (EXCL(self)) {
+                if (EXCL(obj)) {
                     n = size;
                 } else {
                     n = size-1;
@@ -378,7 +248,7 @@ cumo_na_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
             err = (fabs(dbeg)+fabs(dend)+fabs(dend-dbeg))/fabs(dstep)*DBL_EPSILON;
             if (err>0.5) err=0.5;
             dsize = (dend-dbeg)/dstep;
-            if (EXCL(self))
+            if (EXCL(obj))
                 dsize -= err;
             else
                 dsize += err;
@@ -398,77 +268,13 @@ cumo_na_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
     if (pstep) *pstep = dstep;
 }
 
-/*
-static VALUE
-step_each( VALUE self )
-{
-    VALUE  a;
-    double beg, step;
-    size_t i, size;
-
-    a = cumo_na_step_parameters( self, Qnil );
-    beg  = NUM2DBL(RARRAY_PTR(a)[0]);
-    step = NUM2DBL(RARRAY_PTR(a)[1]);
-    size = NUM2SIZET(RARRAY_PTR(a)[2]);
-
-    for (i=0; i<size; i++) {
-        rb_yield(rb_float_new(beg+i*step));
-    }
-    return self;
-}
-*/
-
-static VALUE
-range_with_step( VALUE range, VALUE step )
-{
-    return cumo_na_step_new2( range, step, Qnil );
-}
-
-static VALUE
-range_with_length( VALUE range, VALUE len )
-{
-    return cumo_na_step_new2( range, Qnil, len );
-}
-
-
-static VALUE
-cumo_na_s_step( int argc, VALUE *argv, VALUE mod )
-{
-    VALUE self = rb_obj_alloc(cumo_na_cStep);
-    step_initialize(argc, argv, self);
-    return self;
-}
-
-
 void
 Init_cumo_na_step()
 {
-    cumo_na_cStep = rb_define_class_under(cNArray, "Step", rb_cObject);
-    rb_include_module(cumo_na_cStep, rb_mEnumerable);
-    rb_define_method(cumo_na_cStep, "initialize", step_initialize, -1);
-
-    //rb_define_method(cumo_na_cStep, "each", step_each, 0);
-
-    rb_define_method(cumo_na_cStep, "first", step_first, 0);
-    rb_define_method(cumo_na_cStep, "last", step_last, 0);
-    rb_define_method(cumo_na_cStep, "begin", step_first, 0);
-    rb_define_method(cumo_na_cStep, "end", step_last, 0);
-    rb_define_method(cumo_na_cStep, "step", step_step, 0);
-    rb_define_method(cumo_na_cStep, "length", step_length, 0);
-    rb_define_method(cumo_na_cStep, "size", step_length, 0);
-    rb_define_method(cumo_na_cStep, "exclude_end?", step_exclude_end_p, 0);
-    //rb_define_method(cumo_na_cStep, "to_s", step_to_s, 0);
-    //rb_define_method(cumo_na_cStep, "inspect", step_inspect, 0);
-    //rb_define_method(cumo_na_cStep, "parameters", cumo_na_step_parameters, 1);
-
-    rb_define_method(rb_cRange, "%", range_with_step, 1);
-    rb_define_method(rb_cRange, "*", range_with_length, 1);
-
-    rb_define_singleton_method(cNArray, "step", cumo_na_s_step, -1);
+    rb_define_alias(rb_cRange, "%", "step");
 
     cumo_id_beg  = rb_intern("begin");
     cumo_id_end  = rb_intern("end");
     cumo_id_len  = rb_intern("length");
     cumo_id_step = rb_intern("step");
-    cumo_id_excl = rb_intern("excl");
 }

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -1036,7 +1036,7 @@ module Cumo
         raise NArray::ShapeError, "must be >= 2-dimensional array"
       end
       m,n = shape[-2..-1]
-      NArray.triu_indices(m,n,k=0)
+      NArray.triu_indices(m,n,k)
     end
 
     # Return the indices for the uppler-triangle on and above the k-th diagonal.

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -69,7 +69,43 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[5] == 11 }
         assert { a[5].size == 1 }
         assert { a[-1] == 11 }
+        assert { a[(0..-1).each] == [1,2,3,5,7,11] }
+        assert { a[(0...-1).each] == [1,2,3,5,7] }
+
+        if Enumerator.const_defined?(:ArithmeticSequence)
+          assert { a[0.step(-1)] == [1,2,3,5,7,11] }
+          assert { a[0.step(4)] == [1,2,3,5,7] }
+          assert { a[-5.step(-1)] == [2,3,5,7,11] }
+          assert { a[0.step(-1,2)] == [1,3,7] }
+          assert { a[0.step(4,2)] == [1,3,7] }
+          assert { a[-5.step(-1,2)] == [2,5,11] }
+
+          assert { a[0.step] == [1,2,3,5,7,11] }
+          assert { a[-5.step] == [2,3,5,7,11] }
+          assert { eval('a[(0..).step(2)]') == [1,3,7] }
+          assert { eval('a[(0...).step(2)]') == [1,3,7] }
+          assert { eval('a[(-5..).step(2)]') == [2,5,11] }
+          assert { eval('a[(-5...).step(2)]') == [2,5,11] }
+          assert { eval('a[(0..) % 2]') == [1,3,7] }
+          assert { eval('a[(0...) % 2]') == [1,3,7] }
+          assert { eval('a[(-5..) % 2]') == [2,5,11] }
+          assert { eval('a[(-5...) % 2]') == [2,5,11] }
+        end
+
+        assert { a[(0..-1).step(2)] == [1,3,7] }
+        assert { a[(0...-1).step(2)] == [1,3,7] }
+        assert { a[(0..4).step(2)] == [1,3,7] }
+        assert { a[(0...4).step(2)] == [1,3] }
+        assert { a[(-5..-1).step(2)] == [2,5,11] }
+        assert { a[(-5...-1).step(2)] == [2,5] }
+        assert { a[(0..-1) % 2] == [1,3,7] }
+        assert { a[(0...-1) % 2] == [1,3,7] }
+        assert { a[(0..4) % 2] == [1,3,7] }
+        assert { a[(0...4) % 2] == [1,3] }
+        assert { a[(-5..-1) % 2] == [2,5,11] }
+        assert { a[(-5...-1) % 2] == [2,5] }
         assert { a[[4,3,0,1,5,2]] == [7,5,1,2,11,3] }
+        assert { a.reverse == [11,7,5,3,2,1] }
         assert { a.sum == 29 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0/6 }
@@ -115,6 +151,44 @@ class NArrayTest < Test::Unit::TestCase
       assert { dtype[1..4] == [1,2,3,4] }
     end
 
+    test "#{dtype},[-4..-1]" do
+      assert { dtype[-4..-1] == [-4,-3,-2,-1] }
+    end
+
+    if Enumerator.const_defined?(:ArithmeticSequence)
+      test "#{dtype},[1.step(4)]" do
+        assert { dtype[1.step(4)] == [1,2,3,4] }
+      end
+
+      test "#{dtype},[-4.step(-1)]" do
+        assert { dtype[-4.step(-1)] == [-4,-3,-2,-1] }
+      end
+
+      test "#{dtype},[1.step(4, 2)]" do
+        assert { dtype[1.step(4, 2)] == [1,3] }
+      end
+
+      test "#{dtype},[-4.step(-1, 2)]" do
+        assert { dtype[-4.step(-1, 2)] == [-4,-2] }
+      end
+
+      test "#{dtype},[(-4..-1).step(2)]" do
+        assert { dtype[(-4..-1).step(2)] == [-4,-2] }
+      end
+    end
+
+    test "#{dtype},[(1..4) % 2]" do
+      assert { dtype[(1..4) % 2] == [1,3] }
+    end
+
+    test "#{dtype},[(-4..-1) % 2]" do
+      assert { dtype[(-4..-1) % 2] == [-4,-2] }
+    end
+
+    #test "#{dtype}.seq(5)" do
+    #  assert { dtype.seq(5) == [0,1,2,3,4] }
+    #end
+
     procs2 = [
       [proc{|tp,src| tp[*src] },""],
       [proc{|tp,src| tp[*src][true,true] },"[true,true]"],
@@ -157,6 +231,13 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.reshape(nil,2) == [[1,2],[3,5],[7,11]] }
         assert { a.transpose == [[1,5],[2,7],[3,11]] }
         assert { a.transpose(1,0) == [[1,5],[2,7],[3,11]] }
+        assert { a.triu == [[1,2,3],[0,7,11]] }
+        assert { a.tril == [[1,0,0],[5,7,0]] }
+        assert { a.reverse == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(0,1) == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(1,0) == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(0) == [[5,7,11],[1,2,3]] }
+        assert { a.reverse(1) == [[3,2,1],[11,7,5]] }
 
         assert { a.sum == 29 }
         assert { a.sum(0) == [6, 9, 14] }
@@ -313,6 +394,26 @@ class NArrayTest < Test::Unit::TestCase
       assert_raise(IndexError) { a[1, 1, 1, 1, :rest] }
       assert_raise(IndexError) { a[1, 1, 1, :rest, 1] }
       assert_raise(IndexError) { a[:rest, 1, :rest, 0] }
+
+      assert { a.transpose == [[[1,5],[3,7]],[[2,6],[4,8]]] }
+      assert { a.transpose(2,1,0) == [[[1,5],[3,7]],[[2,6],[4,8]]] }
+      assert { a.transpose(0,2,1) == [[[1,3],[2,4]],[[5,7],[6,8]]] }
+
+      assert { a.reverse           == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0,1,2)    == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(-3,-2,-1) == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0..2)     == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(-3..-1)   == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0...3)    == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0)        == [[[5,6],[7,8]],[[1,2],[3,4]]] }
+      assert { a.reverse(1)        == [[[3,4],[1,2]],[[7,8],[5,6]]] }
+      assert { a.reverse(2)        == [[[2,1],[4,3]],[[6,5],[8,7]]] }
+      assert { a.reverse(0,1)      == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0..1)     == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0...2)    == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0,2)      == [[[6,5],[8,7]],[[2,1],[4,3]]] }
+      assert { a.reverse((0..2) % 2) == [[[6,5],[8,7]],[[2,1],[4,3]]] }
+      assert { a.reverse((0..2).step(2)) == [[[6,5],[8,7]],[[2,1],[4,3]]] }
     end
 
     sub_test_case "#{dtype}, #mulsum" do


### PR DESCRIPTION
I supported the arithmetic sequence for Ruby 2.6 with this pull request.
Please confirm.

This is a pull request with the same content as https://github.com/ruby-numo/numo-narray/pull/121.

The changes are as follows.

* Support arithmetic sequence in Ruby 2.6.
* Support endless ranges in Ruby 2.6.
* Numo::NArray::Step class deleted. (used Range#step as an alias for Range#%.)
* Fix triu_indices method to enable k argument (https://github.com/ruby-numo/numo-narray/pull/112)