### PR TITLE
Fix build error with cuDNN features

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -18,7 +18,7 @@ extern VALUE cumo_cuda_eCUDNNError;
 
 #ifdef CUDNN_FOUND
 
-VALUE cumo_na_eShapeError;
+extern VALUE cumo_na_eShapeError;
 
 #define CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE 8 * 1024 * 1024
 


### PR DESCRIPTION
After set up cuDNN, it causes following link error.
This patch will fix the error.

```
$ rake compile
cd ext/cumo && ruby extconf.rb && make && make build-ctest
checking for numo/narray.h... yes
checking for dlfcn.h... yes
checking for -ldl... yes
checking for dlopen()... yes
checking for stdbool.h... yes
checking for stdint.h... yes
checking for bool in stdbool.h... yes
checking for u_int8_t in stdint.h... yes
checking for u_int16_t in stdint.h... yes
checking for int32_t in stdint.h... yes
checking for u_int32_t in stdint.h... yes
checking for int64_t in stdint.h... yes
checking for u_int64_t in stdint.h... yes
checking for exp10()... yes
checking for rb_arithmetic_sequence_extract()... yes
checking for RTYPEDDATA_GET_DATA()... yes
checking for rb_cComplex... yes
checking for rb_thread_call_without_gvl()... yes
creating include/cumo/extconf.h
creating depend
checking for -lcuda... yes
checking for -lcudart... yes
checking for -lnvrtc... yes
checking for -lcublas... yes
checking for -lcudnn... yes
checking for -lstdc++... yes
creating Makefile

...

linking shared-object cumo.so
gcc -shared -o cumo.so cumo.o narray/narray.o narray/array.o narray/step.o narray/index.o narray/index_kernel.o narray/ndloop.o narray/ndloop_kernel.o narray/data.o narray/data_kernel.o narray/types/bit.o narray/types/int8.o narray/types/int16.o narray/types/int32.o narray/types/int64.o narray/types/uint8.o narray/types/uint16.o narray/types/uint32.o narray/types/uint64.o narray/types/sfloat.o narray/types/dfloat.o narray/types/scomplex.o narray/types/dcomplex.o narray/types/robject.o narray/types/bit_kernel.o narray/types/int8_kernel.o narray/types/int16_kernel.o narray/types/int32_kernel.o narray/types/int64_kernel.o narray/types/uint8_kernel.o narray/types/uint16_kernel.o narray/types/uint32_kernel.o narray/types/uint64_kernel.o narray/types/sfloat_kernel.o narray/types/dfloat_kernel.o narray/types/scomplex_kernel.o narray/types/dcomplex_kernel.o narray/types/robject_kernel.o narray/math.o narray/SFMT.o narray/struct.o narray/rand.o cuda/cublas.o cuda/driver.o cuda/memory_pool.o cuda/memory_pool_impl.o cuda/runtime.o cuda/nvrtc.o cuda/cudnn.o cuda/cudnn_impl.o -L. -L/home/watson/.rbenv/versions/3.4.5/lib -Wl,-rpath,/home/watson/.rbenv/versions/3.4.5/lib -L/usr/lib -Wl,-rpath,/usr/lib -L/opt/cuda/lib64 -Wl,-rpath,/opt/cuda/lib64 -L/opt/cuda/lib -Wl,-rpath,/opt/cuda/lib -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--no-as-needed -Wl,--compress-debug-sections=zlib -Wl,-rpath,/home/watson/.rbenv/versions/3.4.5/lib -L/home/watson/.rbenv/versions/3.4.5/lib -lruby -lstdc++ -lcudnn -lcublas -lnvrtc -lcudart -lcuda -ldl -lm -lpthread -lc
/usr/bin/ld: narray/types/sfloat.o:/home/watson/prj/cumo/ext/cumo/include/cumo/cuda/cudnn.h:21: multiple definition of `cumo_na_eShapeError'; narray/narray.o:/home/watson/prj/cumo/ext/cumo/narray/narray.c:13: first defined here
/usr/bin/ld: narray/types/dfloat.o:/home/watson/prj/cumo/ext/cumo/include/cumo/cuda/cudnn.h:21: multiple definition of `cumo_na_eShapeError'; narray/narray.o:/home/watson/prj/cumo/ext/cumo/narray/narray.c:13: first defined here
/usr/bin/ld: cuda/cudnn.o:/home/watson/prj/cumo/ext/cumo/include/cumo/cuda/cudnn.h:21: multiple definition of `cumo_na_eShapeError'; narray/narray.o:/home/watson/prj/cumo/ext/cumo/narray/narray.c:13: first defined here
/usr/bin/ld: cuda/cudnn_impl.o:(.bss+0x0): multiple definition of `cumo_na_eShapeError'; narray/narray.o:/home/watson/prj/cumo/ext/cumo/narray/narray.c:13: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:479: cumo.so] Error 1
rake aborted!
Command failed with status (2): [cd ext/cumo && ruby extconf.rb && make && make build-ctest]
/home/watson/prj/cumo/Rakefile:11:in 'block in <top (required)>'
Tasks: TOP => compile
(See full trace by running task with --trace)

```