### PR TITLE
Fix SEGV when calling {mean, var, stddev, rms} on a single-element array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -105,10 +105,10 @@ void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, 
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_end, (rtype*)p2);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
     }

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -79,10 +79,10 @@ void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, ch
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_end, (dtype*)p2, n);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (dtype*)p2, n);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (dtype*)p2, n);
     }

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -92,10 +92,10 @@ void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_end, (rtype*)p2);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
     } else {
+    thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
     }

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -118,10 +118,10 @@ void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_end, (rtype*)p2, n);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2, n);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2, n);
     }

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -70,10 +70,10 @@ void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_end, (<%=dtype%>*)p2);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
     }

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -96,10 +96,10 @@ void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_end, (<%=dtype%>*)p2, n);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
     }

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -57,10 +57,10 @@ void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, ch
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_end, (<%=dtype%>*)p2, n);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
     }

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -83,10 +83,10 @@ void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, 
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> data_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-    if (s1_idx == 1) {
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_end, (<%=dtype%>*)p2);
+    if (s1_idx == 1 || n == 1) {
+        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
     } else {
+        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
     }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -756,6 +756,9 @@ class NArrayTest < Test::Unit::TestCase
 
     assert { Cumo::SFloat[1].stddev.to_f.nan? }
     assert { Cumo::DFloat[1].stddev.to_f.nan? }
+    assert { Cumo::SComplex[1].stddev.to_f.nan? }
+    assert { Cumo::DComplex[1].stddev.to_f.nan? }
+
     assert { Cumo::SFloat[1].rms == 1.0 }
     assert { Cumo::DFloat[1].rms == 1.0 }
   end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -743,7 +743,7 @@ class NArrayTest < Test::Unit::TestCase
                  Cumo::DFloat.cast(Cumo::RObject[1, nil, 3]).format_to_a)
   end
 
-  test "one element array" do
+  test "single element array" do
     assert { Cumo::SFloat[1].mean == 1.0 }
     assert { Cumo::DFloat[1].mean == 1.0 }
     assert { Cumo::SComplex[1].mean == 1.0 }
@@ -761,5 +761,7 @@ class NArrayTest < Test::Unit::TestCase
 
     assert { Cumo::SFloat[1].rms == 1.0 }
     assert { Cumo::DFloat[1].rms == 1.0 }
+    assert { Cumo::SComplex[1].rms == 1.0 }
+    assert { Cumo::DComplex[1].rms == 1.0 }
   end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -746,6 +746,9 @@ class NArrayTest < Test::Unit::TestCase
   test "one element array" do
     assert { Cumo::SFloat[1].mean == 1.0 }
     assert { Cumo::DFloat[1].mean == 1.0 }
+    assert { Cumo::SComplex[1].mean == 1.0 }
+    assert { Cumo::DComplex[1].mean == 1.0 }
+
     assert { Cumo::SFloat[1].var.to_f.nan? }
     assert { Cumo::DFloat[1].var.to_f.nan? }
     assert { Cumo::SFloat[1].stddev.to_f.nan? }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -746,5 +746,7 @@ class NArrayTest < Test::Unit::TestCase
   test "one element array" do
     assert { Cumo::SFloat[1].mean == 1.0 }
     assert { Cumo::DFloat[1].mean == 1.0 }
+    assert { Cumo::SFloat[1].var.to_f.nan? }
+    assert { Cumo::DFloat[1].var.to_f.nan? }
   end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -742,4 +742,9 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(Cumo::DFloat[1, Float::NAN, 3].format_to_a,
                  Cumo::DFloat.cast(Cumo::RObject[1, nil, 3]).format_to_a)
   end
+
+  test "one element array" do
+    assert { Cumo::SFloat[1].mean == 1.0 }
+    assert { Cumo::DFloat[1].mean == 1.0 }
+  end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -750,5 +750,7 @@ class NArrayTest < Test::Unit::TestCase
     assert { Cumo::DFloat[1].var.to_f.nan? }
     assert { Cumo::SFloat[1].stddev.to_f.nan? }
     assert { Cumo::DFloat[1].stddev.to_f.nan? }
+    assert { Cumo::SFloat[1].rms == 1.0 }
+    assert { Cumo::DFloat[1].rms == 1.0 }
   end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -751,6 +751,9 @@ class NArrayTest < Test::Unit::TestCase
 
     assert { Cumo::SFloat[1].var.to_f.nan? }
     assert { Cumo::DFloat[1].var.to_f.nan? }
+    assert { Cumo::SComplex[1].var.to_f.nan? }
+    assert { Cumo::DComplex[1].var.to_f.nan? }
+
     assert { Cumo::SFloat[1].stddev.to_f.nan? }
     assert { Cumo::DFloat[1].stddev.to_f.nan? }
     assert { Cumo::SFloat[1].rms == 1.0 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -748,5 +748,7 @@ class NArrayTest < Test::Unit::TestCase
     assert { Cumo::DFloat[1].mean == 1.0 }
     assert { Cumo::SFloat[1].var.to_f.nan? }
     assert { Cumo::DFloat[1].var.to_f.nan? }
+    assert { Cumo::SFloat[1].stddev.to_f.nan? }
+    assert { Cumo::DFloat[1].stddev.to_f.nan? }
   end
 end


### PR DESCRIPTION
Fix https://github.com/sonots/cumo/issues/143