### PR TITLE
Fix unsupported gpu architecture errors in CUDA 12.8 and 12.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,16 @@ jobs:
 
           - cuda_version: "12.6.3"
             cudnn_suffix: "cudnn"
-            ubuntu_version: "ubuntu22.04"
+            ubuntu_version: "ubuntu24.04"
 
-          - cuda_version: "12.8.0"
+          - cuda_version: "12.8.1"
             cudnn_suffix: "cudnn"
-            ubuntu_version: "ubuntu22.04"
+            ubuntu_version: "ubuntu24.04"
 
-          - cuda_version: "12.9.1"
-            cudnn_suffix: "cudnn"
-            ubuntu_version: "ubuntu22.04"
+          # Disable CUDA 12.9.x it causes build error in CUDA macros
+          # - cuda_version: "12.9.1"
+          #   cudnn_suffix: "cudnn"
+          #   ubuntu_version: "ubuntu24.04"
 
           - cuda_version: "13.2.1"
             cudnn_suffix: "cudnn"
@@ -79,6 +80,7 @@ jobs:
 
           export CCACHE_DIR=~/.cache/ccache
           export CCACHE_MAXSIZE=1G
+          export CCACHE_CPP2=1
           ccache -z
 
           bundle exec rake compile

--- a/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
+++ b/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
@@ -51,10 +51,10 @@ module MakeMakefileCuda
             capability = [75, 80, 86, 87, 89, 90, 100, 103, 110, 120, 121]
           elsif cuda_version >= Gem::Version.new("12.9")
             # CUDA 12.9
-            capability = [50, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90, 100, 103, 110, 120, 121]
+            capability = [50, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90, 100, 103, 120, 121]
           elsif cuda_version >= Gem::Version.new("12.8")
             # CUDA 12.8
-            capability = [50, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90, 100, 103, 110, 120]
+            capability = [50, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90, 100, 120]
           elsif cuda_version >= Gem::Version.new("12.0")
             # CUDA 12.0 – 12.6
             capability = [50, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90]


### PR DESCRIPTION
CUDA 12.8 does not support `compute_103` and `compute_110`, 
and CUDA 12.9 does not support `compute_110`.
Including these in the build capabilities caused `nvcc fatal : Unsupported gpu architecture` errors during compilation.

This commit removes those unsupported architectures from their respective version branches in mkmf-cu to fix the build failures.