### PR TITLE
fix: handle compiler flags included in RbConfig::CONFIG properly

### DIFF
--- a/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
+++ b/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "English"
 require "mkmf"
 require "open3"
 require_relative "nvcc"
@@ -28,8 +29,10 @@ module MakeMakefileCuda
     # private
 
     def run_command!(*args)
-      puts colorize(:green, args.join(' '))
-      exit system(*args)
+      command = args.join(' ')
+      puts colorize(:green, command)
+      system(command)
+      exit($CHILD_STATUS.exitstatus)
     end
 
     # TODO(sonots): Make it possible to configure "nvcc" and additional arguments

--- a/3rd_party/mkmf-cu/lib/mkmf-cu/nvcc.rb
+++ b/3rd_party/mkmf-cu/lib/mkmf-cu/nvcc.rb
@@ -114,7 +114,7 @@ module MakeMakefileCuda
       if opt_h["--mkmf-cu-ext"][0] == "c"
         " --compiler-bindir " + ENV.fetch("NVCC_CCBIN", RbConfig::CONFIG["CC"])
       elsif opt_h["--mkmf-cu-ext"][0] == "cxx"
-        " --compiler-bindir " + ENV.fetch("NVCC_CCBIN", RbConfig::CONFIG["CXX"])
+        " --compiler-bindir " + ENV.fetch("NVCC_CCBIN", RbConfig::CONFIG["CXX"]).split.first
       end
     end
 


### PR DESCRIPTION
This commit fixes build failures caused by compiler flags (such as `-std=gnu++11`) being implicitly included in `RbConfig::CONFIG["CXX"]`.

- `lib/mkmf-cu/cli.rb`: Pass the command as a single string to `system()` so that it evaluates via the shell. Previously, passing an array where the first element contained spaces (e.g., "g++ -std=gnu++11") caused Ruby to search for a literal executable by that exact name, resulting in a TypeError or 127 command not found.
- `lib/mkmf-cu/nvcc.rb`: Extract only the compiler binary name (using `.split.first`) when passing it to nvcc's `--compiler-bindir`. nvcc raises a fatal parsing error if compiler flags are mixed into this directory/binary path option.