### PR TITLE
Backport: fix Cumo::RObject#divmod to return the correct remainder

### DIFF
--- a/ext/cumo/include/cumo/types/robj_macro.h
+++ b/ext/cumo/include/cumo/types/robj_macro.h
@@ -19,7 +19,7 @@
 #define m_mod(x,y)     rb_funcall(x,'%',1,y)
 #define m_divmod(x,y,a,b)                               \
     {x = rb_funcall(x,cumo_id_divmod,1,y);                   \
-     a = RARRAY_PTR(x)[0]; b = RARRAY_PTR(x)[0];}
+     a = RARRAY_PTR(x)[0]; b = RARRAY_PTR(x)[1];}
 #define m_pow(x,y)     rb_funcall(x,cumo_id_pow,1,y)
 #define m_pow_int(x,y) rb_funcall(x,cumo_id_pow,1,y)
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -887,4 +887,20 @@ class NArrayTest < Test::Unit::TestCase
     assert { c.argmin == 2 }
     assert { c.argmin(nan: true) == 1 }
   end
+
+  test "divmod returns quotient and remainder" do
+    [Cumo::Int32, Cumo::Int64, Cumo::RObject].each do |dtype|
+      a = dtype[17, 20, 23]
+      b = dtype[5, 6, 7]
+      q, r = a.divmod(b)
+      assert { q == [3, 3, 3] }
+      assert { r == [2, 2, 2] }
+    end
+
+    # floored division semantics with negatives (Cumo::RObject was returning
+    # the quotient as the remainder before the fix)
+    q, r = Cumo::RObject[-7, 7, 17].divmod(Cumo::RObject[3, 3, 5])
+    assert { q == [-3, 2, 3] }
+    assert { r == [2, 1, 2] }
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`687b3bf558`](https://github.com/yoshoku/numo-narray-alt/commit/687b3bf5588c46212b71d75d8a17487b4de7122e) ("fix: use correct array index for mod result in divmod macro for Numo::RObject") from `yoshoku/numo-narray-alt`.

## Problem

The `m_divmod` macro in `ext/cumo/include/cumo/types/robj_macro.h` assigned `RARRAY_PTR(x)[0]` (the quotient) to both the quotient and the remainder outputs, so `Cumo::RObject#divmod` returned the quotient in place of the remainder. Since `Integer#divmod` returns `[quotient, remainder]`, the remainder must read index `[1]`. The `%` operator (`m_mod`) is defined separately and was not affected.

## Note (out of scope)

`Cumo::RObject#divmod` with a scalar divisor raises `TypeError: nil can't be coerced` — a separate, pre-existing bug (array divisors and `Cumo::Int32` scalar divisors work fine). It is independent of this change, which only touches the remainder index, and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
