### PR TITLE
Backport: prevent negative array index in na_get_strides_nadata when ndim is zero

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -427,9 +427,11 @@ static void
 cumo_na_get_strides_nadata(const cumo_narray_data_t *na, ssize_t *strides, ssize_t elmsz)
 {
     int i = na->base.ndim - 1;
-    strides[i] = elmsz;
-    for (; i>0; i--) {
-        strides[i-1] = strides[i] * na->base.shape[i];
+    if (i >= 0) {
+        strides[i] = elmsz;
+        for (; i>0; i--) {
+            strides[i-1] = strides[i] * na->base.shape[i];
+        }
     }
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -903,4 +903,16 @@ class NArrayTest < Test::Unit::TestCase
     assert { q == [-3, 2, 3] }
     assert { r == [2, 1, 2] }
   end
+
+  test "indexing a 0-dimensional array" do
+    # Indexing a 0-d (scalar) array reaches na_get_strides_nadata with ndim == 0.
+    # Before the fix this wrote strides[-1] out of bounds; the result must stay correct.
+    [Cumo::DFloat, Cumo::Int32].each do |dtype|
+      a = dtype.cast(3)
+      assert { a.ndim == 0 }
+      assert { a[nil] == [3] }
+      assert { a[nil].shape == [1] }
+      assert { a[true] == [3] }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`5820a54c8c`](https://github.com/yoshoku/numo-narray-alt/commit/5820a54c8cd6dfcd3bfc1c86051ec85138db27f9) ("fix: prevent negative array index when na->base.ndim is zero") from `yoshoku/numo-narray-alt`.

## Problem

`cumo_na_get_strides_nadata` (`ext/cumo/narray/index.c`) starts from `i = na->base.ndim - 1` and writes `strides[i] = elmsz` unconditionally. For a 0-dimensional array (`ndim == 0`), `i` is `-1`, so `strides[-1] = elmsz` is an out-of-bounds write into the caller's `ALLOCA_N(ssize_t, na1->base.ndim)` (zero-element) buffer. This path is reached by indexing a 0-d (scalar) array from Ruby, for example `Cumo::DFloat.cast(3)[nil]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
