### PR TITLE
Backport: prevent out-of-bounds access to stridx when orig_dim exceeds ndim

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -501,17 +501,25 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
     ssize_t total=1;
 
     for (i=j=0; i<ndim; i++) {
-        cumo_stridx_t sdx1 = na1->stridx[q[i].orig_dim];
+        int orig_dim = q[i].orig_dim;
+        cumo_stridx_t sdx1;
         ssize_t size;
 
-        // numeric index -- trim dimension
-        if (!keep_dim && q[i].n==1 && q[i].step==0) {
-            if (CUMO_SDX_IS_INDEX(sdx1)) {
-                na2->offset += CUMO_SDX_GET_INDEX(sdx1)[q[i].beg];
-            } else {
-                na2->offset += CUMO_SDX_GET_STRIDE(sdx1)*q[i].beg;
+        sdx1.stride = 0;
+        sdx1.index = NULL;
+
+        if (orig_dim < na1->base.ndim) {
+            sdx1 = na1->stridx[orig_dim];
+
+            // numeric index -- trim dimension
+            if (!keep_dim && q[i].n==1 && q[i].step==0) {
+                if (CUMO_SDX_IS_INDEX(sdx1)) {
+                    na2->offset += CUMO_SDX_GET_INDEX(sdx1)[q[i].beg];
+                } else {
+                    na2->offset += CUMO_SDX_GET_STRIDE(sdx1)*q[i].beg;
+                }
+                continue;
             }
-            continue;
         }
 
         na2->base.shape[j] = size = q[i].n;
@@ -521,7 +529,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             na2->base.reduce = rb_funcall(m,'|',1,na2->base.reduce);
         }
 
-        if (q[i].orig_dim >= na1->base.ndim) {
+        if (orig_dim >= na1->base.ndim) {
             // new dimension
             CUMO_SDX_SET_STRIDE(na2->stridx[j], elmsz);
         }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -915,4 +915,27 @@ class NArrayTest < Test::Unit::TestCase
       assert { a[true] == [3] }
     end
   end
+
+  test "adding a new axis to a narray-view" do
+    # cumo_na_index_aref_naview read na1->stridx[q[i].orig_dim] before checking
+    # orig_dim against na1->base.ndim. A trailing :new keeps orig_dim == ndim,
+    # so the read went one element past the end of the view's stridx array.
+    a = Cumo::DFloat.new(4).seq
+    v = a[1..2]
+    assert { v.shape == [2] }
+
+    assert { v[true, :new].shape == [2, 1] }
+    assert { v[true, :new] == [[1], [2]] }
+    assert { v[:new, true].shape == [1, 2] }
+    assert { v[:new, true] == [[1, 2]] }
+
+    b = Cumo::DFloat.new(3, 4).seq
+    u = b[true, 1..2]
+    assert { u.shape == [3, 2] }
+
+    assert { u[true, true, :new].shape == [3, 2, 1] }
+    assert { u[true, true, :new] == [[[1], [2]], [[5], [6]], [[9], [10]]] }
+    assert { u[true, :new, true].shape == [3, 1, 2] }
+    assert { u[true, :new, true] == [[[1, 2]], [[5, 6]], [[9, 10]]] }
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`cd2f136a3d`](https://github.com/yoshoku/numo-narray-alt/commit/cd2f136a3d73ef4ba33229c0c416c4d21ad0631d) ("fix: prevent out-of-bounds access to na1->stridx when q[i].orig_dim exceeds na1->base.ndim") from `yoshoku/numo-narray-alt`.

## Problem

`cumo_na_index_aref_naview` (`ext/cumo/narray/index.c`) read `na1->stridx[q[i].orig_dim]` at the top of the loop body, before the `q[i].orig_dim >= na1->base.ndim` check that handles the "new dimension" case further down.

`cumo_na_index_parse_args` does not advance the original-dimension counter `k` for a `:new` index, so a trailing `:new` produces `orig_dim == na1->base.ndim`. Since a view's `stridx` is allocated with exactly `base.ndim` elements (`ALLOC_N(cumo_stridx_t, nd)` in `cumo_na_make_view`), that read goes one element past the end of the heap buffer.

Reached from Ruby by adding a trailing new axis to a narray-view:

```ruby
a = Cumo::DFloat.new(4).seq
v = a[1..2]        # Cumo::DFloat(view)#shape=[2]
v[true, :new]      # read of v.stridx[1], one past the end
```

The value read is never used (the `orig_dim >= ndim` branch overwrites it with `CUMO_SDX_SET_STRIDE`), so the result stays correct; the defect is the out-of-bounds read itself, which is undefined behaviour and can fault if `stridx` sits at the end of a page.

## Fix

Read `stridx` only when `orig_dim` is in range, and zero-initialize `sdx1` so the new-dimension branch never observes an indeterminate value. Matches upstream.

## Verification

Confirmed the out-of-bounds read empirically: with a temporary probe on the pre-fix code, the three-case snippet below reported exactly 2 hits — `v[true, :new]` and `u[true, true, :new]` (trailing `:new`), and not `u[true, :new, true]` (non-trailing `:new`, where `orig_dim < ndim`). After the fix the probe reports none.

Added a regression test covering both a 1-d and a 2-d view, with `:new` in trailing and non-trailing positions.

Full suite passes on an RTX 5070 Ti Laptop GPU (Ruby 4.0.6, CUDA 13):

| file | result |
| --- | --- |
| `test/bit_test.rb` | 11 tests, 136 assertions, 0 failures, 0 errors |
| `test/cudnn_test.rb` | 74 tests, 152 assertions, 0 failures, 0 errors |
| `test/cumo_test.rb` | 3 tests, 3 assertions, 0 failures, 0 errors |
| `test/narray_test.rb` | 676 tests, 10256 assertions, 0 failures, 0 errors |
| `test/ractor_test.rb` | 36 tests, 60 assertions, 0 failures, 0 errors |

## Note

Cumo also has `cumo_na_index_at_naview`, which reads `na1->stridx[q[i].orig_dim]` without a range check as well. It is left untouched here to keep the backport faithful to upstream: upstream removed that function entirely when `NArray#at` was reimplemented (`3fcde3e450`), and in cumo the function is currently unreachable — `cumo_na_at_main` is the only caller path that sets `at_mode = 1` and it has no caller, since cumo never registers an `at` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
