### PR TITLE
Fix out-of-bounds stridx access in at() when :new is given

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -910,8 +910,20 @@ cumo_na_aref_md(int argc, VALUE *argv, VALUE self, int keep_dim, int result_nd, 
     CumoGetNArray(self,na1);
 
     args = rb_ary_new4(argc,argv);
-    if (at_mode && na1->ndim == 0) {
-        rb_raise(cumo_na_eDimensionError,"argument length does not match dimension size");
+    if (at_mode) {
+        int i;
+        if (na1->ndim == 0) {
+            rb_raise(cumo_na_eDimensionError,"argument length does not match dimension size");
+        }
+        // at() takes one index per existing dimension and returns a 1-d view, so
+        // :new has no meaning here. It also leaves q[i].orig_dim == na1->ndim,
+        // which would read one element past the end of stridx/strides in
+        // cumo_na_index_at_naview()/cumo_na_index_at_nadata().
+        for (i=0; i<argc; i++) {
+            if (argv[i] == cumo_sym_new || argv[i] == cumo_sym_minus) {
+                rb_raise(rb_eIndexError,":new is not allowed for at()");
+            }
+        }
     }
 
     if (argc == 1 && result_nd == 1) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -938,4 +938,23 @@ class NArrayTest < Test::Unit::TestCase
     assert { u[true, :new, true].shape == [3, 1, 2] }
     assert { u[true, :new, true] == [[[1, 2]], [[5, 6]], [[9, 10]]] }
   end
+
+  test "at() rejects :new" do
+    # :new leaves q[i].orig_dim == ndim, which made cumo_na_index_at_naview read
+    # one element past the end of the view's stridx array. That union member was
+    # then used as a device index pointer, so a[..].at([0],[0],:new) died with
+    # "an illegal memory access was encountered". at() must reject :new instead.
+    a = Cumo::DFloat.new(3, 3).seq
+    v = a[true, 0..1]
+
+    # sanity: at() itself still works on both data and view arrays
+    assert { a.at([0, 1], [0, 1]) == [0, 4] }
+    assert { v.at([0, 1], [0, 1]) == [0, 4] }
+
+    [a, v].each do |x|
+      assert_raise(IndexError) { x.at([0], [0], :new) }
+      assert_raise(IndexError) { x.at([0], :new, [0]) }
+      assert_raise(IndexError) { x.at(:new, [0], [0]) }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds `stridx`/`strides` access in `NArray#at()` when a `:new` index is given. This is the `at()` counterpart of #160 — same root cause, but here the out-of-bounds value is actually *used*, so it is reachable as a GPU illegal memory access rather than a harmless read.

This one is cumo-specific: upstream `numo-narray-alt` rewrote `NArray#at` (`3fcde3e450`) and no longer has `na_index_at_naview`/`na_index_at_nadata`, so there is no upstream commit to backport.

## Problem

`cumo_na_index_parse_args()` does not advance the original-dimension counter for a `:new` index, so `q[i].orig_dim` can equal `na1->base.ndim`. Both `cumo_na_index_at_naview()` and `cumo_na_index_at_nadata()` index with `orig_dim` at the top of their loop, before any range check:

```c
cumo_stridx_t sdx1 = na1->stridx[q[i].orig_dim];   // at_naview
stride1 = strides_na1[q[i].orig_dim];              // at_nadata
```

- **View path** — a view's `stridx` holds exactly `base.ndim` elements. The out-of-bounds `cumo_stridx_t` is a union; when the garbage low bit is 0 it is taken as an index array and dereferenced by a kernel:

  ```ruby
  a = Cumo::DFloat.new(3, 3).seq
  a[true, 0..1].at([0], [0], :new)
  # => Cumo::CUDA::RuntimeError: an illegal memory access was encountered (error=700)
  ```

  Reproduced 3/3 before the fix. Note this also leaves a sticky CUDA error on the context.

- **Data path** — `strides_na1` is `ALLOCA_N(ssize_t, na1->base.ndim)`, so the read runs one element past the stack buffer. The garbage stride is multiplied by `beg == 0`, so it happens to be neutralised and `a.at([0], [0], :new)` silently returns `[0.0]`; it is still undefined behaviour.

The size-consistency check that raises `"index array sizes mismatch"` runs *after* the offending read, which is why the mismatching case appeared to fail cleanly while the matching case crashed.

## Fix

`at()` takes one index per existing dimension and returns a 1-d view, so `:new` has no meaning for it. Upstream rejects it too — the rewritten `na_at` requires `NA_NDIM(na) == argc` and raises `ArgumentError` otherwise. Reject `:new` (and its `:-` alias) in `at_mode` instead of walking off the end of the array.

The rejection is placed at the `cumo_na_aref_md()` entry next to the existing `at_mode` validation, so it covers both the view and data paths and both trailing and non-trailing `:new` consistently.

## Compatibility

No existing behaviour is lost: before this change `at()` with `:new` either crashed the CUDA context (view) or returned a stack-garbage-derived value (data). No test used `at()` with `:new`.

## Verification

```ruby
a = Cumo::DFloat.new(3, 3).seq
v = a[true, 0..1]
a.at([0, 1], [0, 1])          # => [0, 4]   (unchanged)
v.at([0, 1], [0, 1])          # => [0, 4]   (unchanged)
v.at([0], [0], :new)          # => IndexError: :new is not allowed for at()
```

All six combinations (`:new` in leading / middle / trailing position × data / view) now raise `IndexError`; none crashes.

Full suite on an RTX 5070 Ti Laptop GPU (Ruby 4.0.6, CUDA 13):

| file | result |
| --- | --- |
| `test/bit_test.rb` | 11 tests, 136 assertions, 0 failures, 0 errors |
| `test/cudnn_test.rb` | 74 tests, 152 assertions, 0 failures, 0 errors |
| `test/cumo_test.rb` | 3 tests, 3 assertions, 0 failures, 0 errors |
| `test/narray_test.rb` | 677 tests, 10264 assertions, 0 failures, 0 errors |
| `test/ractor_test.rb` | 36 tests, 60 assertions, 0 failures, 0 errors |

## Unrelated pre-existing issue noticed

`test/ractor_test.rb` is flaky independently of this change — `test_parallel` intermittently returns an all-zero array from one Ractor. Measured on `master` without this patch: **4 failures in 15 runs**. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
