### PR TITLE
Backport: use an inline function to prevent double use of macro argument

### DIFF
--- a/ext/cumo/include/cumo/types/float_macro.h
+++ b/ext/cumo/include/cumo/types/float_macro.h
@@ -12,7 +12,7 @@ extern double pow(double, double);
 #define m_zero 0.0
 #define m_one  1.0
 
-#define m_num_to_data(x) (NIL_P(x) ? nan("") : NUM2DBL(x))
+#define m_num_to_data(x) cumo_na_ruby_num_to_flt(x)
 #define m_data_to_num(x) rb_float_new(x)
 
 #define m_from_double(x) (x)
@@ -116,6 +116,11 @@ extern double pow(double, double);
 #define m_erfc(x)    erfc(x)
 #define m_ldexp(x,y) ldexp(x,y)
 #define m_frexp(x,exp) frexp(x,exp)
+
+static inline dtype cumo_na_ruby_num_to_flt(VALUE x)
+{
+    return NIL_P(x) ? nan("") : NUM2DBL(x);
+}
 
 static inline dtype pow_int(dtype x, int p)
 {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -957,4 +957,19 @@ class NArrayTest < Test::Unit::TestCase
       assert_raise(IndexError) { x.at(:new, [0], [0]) }
     end
   end
+
+  test "map yields once per element" do
+    # m_num_to_data used to evaluate its argument twice, so m_map's
+    # rb_yield() ran twice for every element.
+    [Cumo::DFloat, Cumo::SFloat].each do |dtype|
+      a = dtype[1, 2, 3]
+      count = 0
+      result = a.map { |x| count += 1; x * 2 }
+      assert { count == 3 }
+      assert { result == [2, 4, 6] }
+    end
+
+    # nil from the block still becomes NaN
+    assert { Cumo::DFloat[1, 2].map { nil }.to_a.all? { |x| x.nan? } }
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`e793995b3f`](https://github.com/yoshoku/numo-narray-alt/commit/e793995b3f27bd5f54ae6a383b546aadcb159e58) ("fix: use an inline function to prevent double use of macro argument") from `yoshoku/numo-narray-alt`.

## Problem

`m_num_to_data()` in `ext/cumo/include/cumo/types/float_macro.h` was defined as a macro that expands its argument twice:

```c
#define m_num_to_data(x) (NIL_P(x) ? nan("") : NUM2DBL(x))
```

Any caller passing an expression with side effects therefore ran that expression twice. `NArray#map` is the visible case, because `m_map` (`ext/cumo/narray/gen/tmpl/lib.c:22`) feeds `rb_yield()` straight into it:

```c
#define m_map(x) m_num_to_data(rb_yield(m_data_to_num(x)))
```

So the block ran twice for every element:

```ruby
count = 0
Cumo::DFloat[1, 2, 3].map { |x| count += 1; x * 2 }
count  # => 6 before the fix, 3 after
```

The returned values were correct, so the only observable effect was the duplicated block invocation — which matters for blocks that are not pure, and which no test would notice.

Only `float_macro.h` needs the change; the int, uint, complex and robject definitions of `m_num_to_data` already use their argument exactly once. Upstream with this commit applied yields exactly once per element for `map`, `map_with_index` and `each` across all types, which matches the behaviour after this backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
