### PR TITLE
Backport: convert max to double in rand method of Cumo::RObject

### DIFF
--- a/ext/cumo/include/cumo/types/robject.h
+++ b/ext/cumo/include/cumo/types/robject.h
@@ -23,5 +23,5 @@ inline static int robj_nearly_eq(VALUE vx, VALUE vy)
 /* generates a random number on [0,1)-real-interval */
 inline static dtype m_rand(dtype max)
 {
-    return DBL2NUM(genrand_res53_mix() * max);
+    return DBL2NUM(genrand_res53_mix() * NUM2DBL(max));
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -972,4 +972,20 @@ class NArrayTest < Test::Unit::TestCase
     # nil from the block still becomes NaN
     assert { Cumo::DFloat[1, 2].map { nil }.to_a.all? { |x| x.nan? } }
   end
+
+  test "Cumo::RObject#rand stays within range" do
+    # m_rand multiplied by the raw VALUE instead of NUM2DBL(max),
+    # so the generated values fell outside the requested interval.
+    Cumo::NArray.srand(0)
+    a = Cumo::RObject.new(1000).rand.to_a
+    assert { a.min >= 0 && a.max < 1 }
+
+    Cumo::NArray.srand(0)
+    b = Cumo::RObject.new(1000).rand(10).to_a
+    assert { b.min >= 0 && b.max < 10 }
+
+    Cumo::NArray.srand(0)
+    c = Cumo::RObject.new(1000).rand(-2, 3).to_a
+    assert { c.min >= -2 && c.max < 3 }
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`ea944928b5`](https://github.com/yoshoku/numo-narray-alt/commit/ea944928b5948204d0f79d925dc97e67aa02de9a) ("fix: convert max to double in rand method of Numo::RObject") from `yoshoku/numo-narray-alt`.

## Problem

`m_rand()` in `ext/cumo/include/cumo/types/robject.h` multiplied the random value by its argument directly:

```c
inline static dtype m_rand(dtype max)
{
    return DBL2NUM(genrand_res53_mix() * max);
}
```

For `Cumo::RObject`, `dtype` is `VALUE`, so this multiplies by the tagged Ruby object rather than by its numeric value. The generated numbers therefore fell outside the requested interval:

```ruby
Cumo::NArray.srand(0)
Cumo::RObject.new(5).rand
# => [0.185, 1.119, 2.384, 0.603, 0.348]   # 1.119 and 2.384 are outside [0,1)

Cumo::NArray.srand(0)
Cumo::RObject.new(5).rand(10)
# => [1.297, 7.834, 16.691, 4.222, 2.437]  # 16.691 is outside [0,10)
```

Other dtypes are unaffected, since `dtype` is a real numeric type for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
