### PR TITLE
Backport: make qsort loop condition explicit to prevent incorrect optimization

### DIFF
--- a/ext/cumo/narray/gen/tmpl/qsort.c
+++ b/ext/cumo/narray/gen/tmpl/qsort.c
@@ -163,9 +163,8 @@ static void
             pm = med3(pl, pm, pn, cmp);
         }
     swap(a, pm);
-    pa = pb = (char *) a + es;
-    pc = pd = (char *) a + (n - 1) * es;
-    for (;;)
+    for (pa = pb = (char *) a + es, pc = pd = (char *) a + (n - 1) * es;
+         pb <= pc; pb += es, pc -= es)
         {
             while (pb <= pc && (r = cmp(pb, a)) <= 0)
                 {
@@ -188,8 +187,6 @@ static void
             if (pb > pc)
                 break;
             swap(pb, pc);
-            pb += es;
-            pc -= es;
         }
     pn = (char *) a + n * es;
     r = Min(pa - (char *) a, pb - pa);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1022,4 +1022,31 @@ class NArrayTest < Test::Unit::TestCase
     assert { a.shape == [2, 3, 4] }
     assert { a.to_a.flatten == src }
   end
+
+  test "sort and sort_index over many values" do
+    # The partition loop used `for (;;)` with the pointer updates at the end
+    # of the body, which some compilers could optimize incorrectly.
+    rng = Random.new(42)
+
+    arr = Array.new(100) { rng.rand(-1.0...1.0) }
+    [Cumo::DFloat, Cumo::SFloat].each do |dtype|
+      a = dtype.cast(arr)
+      assert { a.sort.to_a == a.to_a.sort }
+      assert { a[a.sort_index].to_a == a.to_a.sort }
+    end
+
+    arr = Array.new(100) { rng.rand(-100...100) }
+    [Cumo::Int64, Cumo::Int32, Cumo::Int16, Cumo::Int8].each do |dtype|
+      a = dtype.cast(arr)
+      assert { a.sort.to_a == a.to_a.sort }
+      assert { a[a.sort_index].to_a == a.to_a.sort }
+    end
+
+    arr = Array.new(100) { rng.rand(0...100) }
+    [Cumo::UInt64, Cumo::UInt32, Cumo::UInt16, Cumo::UInt8].each do |dtype|
+      a = dtype.cast(arr)
+      assert { a.sort.to_a == a.to_a.sort }
+      assert { a[a.sort_index].to_a == a.to_a.sort }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`c12364b24f`](https://github.com/yoshoku/numo-narray-alt/commit/c12364b24fab20bab1b0353cf17b7f32e5fb9a74) ("fix: make loop condition explicit to prevent incorrect optimization") from `yoshoku/numo-narray-alt`.

## Problem

The partition loop in `ext/cumo/narray/gen/tmpl/qsort.c` was written with an implicit termination condition:

```c
pa = pb = (char *) a + es;
pc = pd = (char *) a + (n - 1) * es;
for (;;)
    {
        ...
        if (pb > pc)
            break;
        swap(pb, pc);
        pb += es;
        pc -= es;
    }
```

The bounds `pb <= pc` and the pointer updates live in the middle and at the end of the body rather than in the `for` header, which is what the upstream commit addresses as a guard against a compiler optimizing the loop incorrectly. Moving the initialization, condition and updates into the header leaves the behaviour unchanged.

## Scope note

cumo generates this one template for both the value and the index qsort variants (`gen/spec.rb:391-401` emits `<type>_qsort*` and `<type>_index_qsort*`), so the change covers all 24 generated instances across the 10 sortable types. Upstream touches only its `*_index_qsort_*` functions, since its non-index copies are generated from a separate source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
