### PR TITLE
Backport: fix na_flatten_dim for multi-dimensional empty arrays

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -464,7 +464,7 @@ VALUE
 cumo_na_flatten_dim(VALUE self, int sd)
 {
     int i, nd, fd;
-    size_t j;
+    size_t j, ofs;
     size_t *c, *pos, *idx1, *idx2;
     size_t stride;
     size_t  *shape, size;
@@ -476,7 +476,7 @@ cumo_na_flatten_dim(VALUE self, int sd)
     CumoGetNArray(self,na);
     nd = na->ndim;
 
-     if (nd==0 || na->size==0) {
+    if (nd==0) {
         return cumo_na_make_view(self);
     }
     if (sd<0 || sd>=nd) {
@@ -537,14 +537,14 @@ cumo_na_flatten_dim(VALUE self, int sd)
             na2->stridx[sd] = na1->stridx[nd-1];
         } else {
             // set index
-            // idx2 = ALLOC_N(size_t, shape[sd]);
-            idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[sd]);
+            // idx2 = ALLOC_N(size_t, (shape[sd]==0) ? 1 : shape[sd]);
+            idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*((shape[sd]==0) ? 1 : shape[sd]));
             CUMO_SDX_SET_INDEX(na2->stridx[sd],idx2);
             // init for md-loop
             fd = nd-sd;
-            c = ALLOC_N(size_t, fd);
+            c = ALLOCA_N(size_t, fd);
             for (i=0; i<fd; i++) c[i]=0;
-            pos = ALLOC_N(size_t, fd+1);
+            pos = ALLOCA_N(size_t, fd+1);
             pos[0] = 0;
             // md-loop
             CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_flatten_dim", "any");
@@ -553,10 +553,15 @@ cumo_na_flatten_dim(VALUE self, int sd)
                 for (; i<fd; i++) {
                     sdx = na1->stridx[i+sd];
                     if (CUMO_SDX_IS_INDEX(sdx)) {
-                        pos[i+1] = pos[i] + CUMO_SDX_GET_INDEX(sdx)[c[i]];
+                        if (CUMO_SDX_GET_INDEX(sdx)) {
+                            ofs = CUMO_SDX_GET_INDEX(sdx)[c[i]];
+                        } else {
+                            ofs = 0;
+                        }
                     } else {
-                        pos[i+1] = pos[i] + CUMO_SDX_GET_STRIDE(sdx)*c[i];
+                        ofs = CUMO_SDX_GET_STRIDE(sdx)*c[i];
                     }
+                    pos[i+1] = pos[i] + ofs;
                 }
                 idx2[j++] = pos[i];
                 for (;;) {
@@ -568,8 +573,7 @@ cumo_na_flatten_dim(VALUE self, int sd)
                 }
             }
         loop_end:
-            xfree(pos);
-            xfree(c);
+            ;
         }
         break;
     }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1049,4 +1049,20 @@ class NArrayTest < Test::Unit::TestCase
       assert { a[a.sort_index].to_a == a.to_a.sort }
     end
   end
+
+  test "flatten on empty arrays" do
+    # na_flatten_dim returned the array unchanged whenever size == 0, so a
+    # multi-dimensional empty array kept its dimensions instead of becoming 1-D.
+    [[0, 3], [2, 0], [0, 0], [0, 2, 3], [2, 0, 3]].each do |shape|
+      f = Cumo::DFloat.new(*shape).flatten
+      assert { f.ndim == 1 }
+      assert { f.shape == [0] }
+    end
+
+    # non-empty arrays and views keep working
+    a = Cumo::DFloat.new(2, 3).seq
+    assert { a.flatten.to_a == [0, 1, 2, 3, 4, 5] }
+    assert { a.transpose.flatten.to_a == [0, 3, 1, 4, 2, 5] }
+    assert { Cumo::DFloat.cast(5).flatten.shape == [] }
+  end
 end


### PR DESCRIPTION
## Summary

Backports [`69c12dad12`](https://github.com/ruby-numo/numo-narray/commit/69c12dad12040486ac305d68d1f5fb32f07aba78) ("fix na_flatten_dim(): correctly flatten >= 2-dimensional empty array") from `ruby-numo/numo-narray`.

## Problem

`cumo_na_flatten_dim` bailed out early whenever the array was empty:

```c
if (nd==0 || na->size==0) {
    return cumo_na_make_view(self);
}
```

So flattening a multi-dimensional empty array returned it with its dimensions intact:

```ruby
Cumo::DFloat.new(0, 3).flatten.shape   # => [0, 3], expected [0]
Cumo::DFloat.new(2, 0, 3).flatten.ndim # => 3, expected 1
```

Removing the `size==0` condition exposes two allocations that the early return had been hiding, both of which upstream also guards: the index array was sized from `shape[sd]`, which is 0 for an empty array, and the md-loop dereferenced an index array that can be NULL. The scratch buffers move from `ALLOC_N` to `ALLOCA_N`, which also removes the manual `xfree` at `loop_end`.

The zero-sized allocation is worth more attention in cumo than upstream: cumo allocates the index array with `cumo_cuda_runtime_malloc` rather than `ALLOC_N`, and that pool mishandles zero-sized requests — `GetRoundedSize(0)` is 0 and `GetBinIndex(0)` truncates to -1, so the request can alias an existing chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
