### PR TITLE
Fix out-of-bounds device write in store when a sub-narray is too long

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -179,10 +179,15 @@ static void
     }
     //<% else %>
     {
-        if (idx1) {
-            <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(p1,idx1+i,z,n-i);
-        } else {
-            <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(p1+s1*i,s1,z,n-i);
+        // i may exceed n when the sub-narray is longer than the destination;
+        // n-i would then wrap around as size_t. numo's scalar loop is a no-op
+        // in that case, so skip the launch instead.
+        if (i < n) {
+            if (idx1) {
+                <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(p1,idx1+i,z,n-i);
+            } else {
+                <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(p1+s1*i,s1,z,n-i);
+            }
         }
     }
     //<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1065,4 +1065,21 @@ class NArrayTest < Test::Unit::TestCase
     assert { a.transpose.flatten.to_a == [0, 3, 1, 4, 2, 5] }
     assert { Cumo::DFloat.cast(5).flatten.shape == [] }
   end
+
+  test "store with a sub-narray longer than the destination" do
+    # The zero-fill passed n-i as an unsigned kernel length. When a nested
+    # NArray was longer than the destination, i exceeded n and n-i wrapped
+    # around, so the kernel wrote far out of bounds (CUDA error 700).
+    # Values below match Numo::NArray.
+    [Cumo::DFloat, Cumo::Int32].each do |dtype|
+      a = dtype.zeros(2, 3)
+      a.store([dtype.new(5).seq, dtype.new(5).seq])
+      assert { a.to_a == [[0, 1, 2], [0, 1, 2]] }
+    end
+
+    # an oversized nested plain Array truncates the same way
+    d = Cumo::DFloat.zeros(2, 3)
+    d.store([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    assert { d.to_a == [[1, 2, 3], [6, 7, 8]] }
+  end
 end


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds device write in `NArray#store`. This one is cumo-specific — it was introduced when the zero-fill was turned into a CUDA kernel launch, and has no counterpart upstream.

## Problem

`ext/cumo/narray/gen/tmpl/store_array.c` ends by zero-filling whatever the source did not cover, passing `n-i` as the kernel length:

```c
if (idx1) {
    cumo_..._index_scalar_kernel_launch(p1, idx1+i, z, n-i);
} else {
    cumo_..._stride_scalar_kernel_launch(p1+s1*i, s1, z, n-i);
}
```

`i` comes from `lp->args[1].shape[0]`, the sub-narray's last dimension (`ndloop.c:1856`). Only the number of dimensions is checked there, never the size, so a nested NArray longer than the destination makes `i` exceed `n`. `n-i` is `size_t`, so it wraps to roughly 1.8e19 and the grid-stride kernel writes essentially without bound:

```ruby
Cumo::DFloat.zeros(2, 3).store([Cumo::DFloat.new(5).seq] * 2)
# => Cumo::CUDA::RuntimeError: an illegal memory access was encountered (error=700)
```

numo writes this as `for (; i<n; i++)`, which is simply a no-op when `i > n`, and cumo's own robject variant kept that bounded loop — only the kernelized typed path is affected.

## Fix

Skip the launch when `i >= n`, restoring the upstream behaviour: the destination keeps the truncated values instead of faulting.

Checked against `numo-narray-alt` 0.11.0 over seven store shapes (oversized / shorter / exact sub-narrays, nested plain Arrays, mixed inputs, 1-d destinations). All results now match numo exactly, including which cases raise `TypeError`.

## Note (out of scope)

While testing this I found a separate, pre-existing defect: after any `store` with a nested source, a `GC.start` followed by another `store` can leave stale values from the previous array in the destination.

```ruby
a = Cumo::DFloat.zeros(2,3); a.store([Cumo::DFloat.new(3).seq] * 2)
GC.start
b = Cumo::DFloat.zeros(2,3); b.store([Cumo::DFloat.new(2).seq] * 2)
b.to_a  # => [[0, 1, 2], [0, 1, 0]], expected [[0, 1, 0], [0, 1, 0]]
```

It reproduces on master without this change and does not involve an oversized source, so it is independent of this fix. numo returns the expected values, making it cumo-specific as well — most likely the `device_z` staging buffer being freed while the copy or kernel is still in flight (`cumo_cuda_runtime_free` is called with no synchronize, and the pool is not stream-ordered). Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
