### PR TITLE
Fix out-of-bounds read of a shorter sub-narray in store

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -32,8 +32,16 @@ static void
 
     if (lp->args[1].ptr) {
         if (v1 == Qtrue) {
-            iter_<%=type_name%>_store_<%=type_name%>(lp);
+            // The loop counter is the destination length, but the sub-narray
+            // may be shorter. Copy only what the source actually holds, or the
+            // kernel would read past its end; the rest is zero-filled below.
             i = lp->args[1].shape[0];
+            if (i > n) {
+                i = n;
+            }
+            CUMO_NDL_CNT(lp) = i;
+            iter_<%=type_name%>_store_<%=type_name%>(lp);
+            CUMO_NDL_CNT(lp) = n;
             if (idx1) {
                 idx1 += i;
             } else {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1082,4 +1082,21 @@ class NArrayTest < Test::Unit::TestCase
     d.store([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
     assert { d.to_a == [[1, 2, 3], [6, 7, 8]] }
   end
+
+  test "store with a sub-narray shorter than the destination" do
+    # The inner copy used the destination length as its element count, so it
+    # read past the end of a shorter sub-narray. The stale values only became
+    # visible once the memory behind the source had been reused, which needed
+    # a previous full-length store plus a GC.
+    a = Cumo::DFloat.zeros(2, 3)
+    a.store([Cumo::DFloat.new(3).seq, Cumo::DFloat.new(3).seq])
+    GC.start
+
+    b = Cumo::DFloat.zeros(2, 3)
+    b.store([Cumo::DFloat.new(2).seq, Cumo::DFloat.new(2).seq])
+    assert { b.to_a == [[0, 1, 0], [0, 1, 0]] }
+
+    # sanity: the full-length store is still correct
+    assert { a.to_a == [[0, 1, 2], [0, 1, 2]] }
+  end
 end


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds read in `NArray#store` when a sub-narray is shorter than the destination. Like #168 this is cumo-specific: it comes from the copy being a kernel launch that takes an element count, where numo runs a bounded loop. #168 was the write side of the same template; this is the read side.

To be precise about the defect class: the source object stays alive for the whole store, so this is an out-of-bounds read past its allocation rather than a use-after-free.

## Problem

In the `Qtrue` branch the copy is delegated to `iter_<type>_store_<type>`, which takes its element count from `CUMO_INIT_COUNTER(lp, i)` — the destination length. When the sub-narray is shorter, the kernel still copies that many elements and reads past the source.

The stale values are only observable once the memory behind the source has been reused, which needs a previous full-length store plus a GC:

```ruby
a = Cumo::DFloat.zeros(2,3); a.store([Cumo::DFloat.new(3).seq] * 2)
GC.start
b = Cumo::DFloat.zeros(2,3); b.store([Cumo::DFloat.new(2).seq] * 2)
b.to_a  # => [[0, 1, 2], [0, 1, 0]], expected [[0, 1, 0], [0, 1, 0]]
```

`b` holds zeros right up to the store, and the `2.0` that appears is the third element of `a`'s source, whose buffer `b`'s source was allocated over. Running the same store twice makes the second one correct, since by then nothing is left to read.

Tracing confirmed the zero fill itself was fine — `i=2, n=3`, launched for both rows. The corruption came earlier, from the inner copy overwriting the third element before the fill ran.

## Fix

Clamp the loop counter to the source length around the inner call and restore it afterwards, so the trailing zero fill still covers `n-i`.

Checked against `numo-narray-alt` 0.11.0: all seven store shapes (oversized / shorter / exact sub-narrays, nested plain Arrays, mixed inputs, 1-d destinations) match, and the case above now produces what numo produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
