### PR TITLE
Fix memory pool handing out a tiny chunk for a huge allocation

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -63,14 +63,14 @@ void Merge(std::shared_ptr<Chunk>& self, std::shared_ptr<Chunk> remaining) {
 
 void SingleDeviceMemoryPool::AppendToFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr) {
     assert(chunk != nullptr && !chunk->in_use());
-    int bin_index = GetBinIndex(size);
+    size_t bin_index = GetBinIndex(size);
 
     std::lock_guard<std::recursive_mutex> lock{mutex_};
 
     Arena& arena = GetArena(stream_ptr);
     ArenaIndexMap& arena_index_map = GetArenaIndexMap(stream_ptr);
-    int arena_index = std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
-    int length = static_cast<int>(arena_index_map.size());
+    size_t arena_index = std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
+    size_t length = arena_index_map.size();
     if (arena_index >= length || arena_index_map.at(arena_index) != bin_index) {
         arena_index_map.insert(arena_index_map.begin() + arena_index, bin_index);
         arena.insert(arena.begin() + arena_index, FreeList{});
@@ -81,7 +81,7 @@ void SingleDeviceMemoryPool::AppendToFreeList(size_t size, std::shared_ptr<Chunk
 
 bool SingleDeviceMemoryPool::RemoveFromFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr) {
     assert(chunk != nullptr && !chunk->in_use());
-    int bin_index = GetBinIndex(size);
+    size_t bin_index = GetBinIndex(size);
 
     std::lock_guard<std::recursive_mutex> lock{mutex_};
 
@@ -90,20 +90,32 @@ bool SingleDeviceMemoryPool::RemoveFromFreeList(size_t size, std::shared_ptr<Chu
     if (arena_index_map.size() == 0) {
         return false;
     }
-    int arena_index = std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
-    if (static_cast<size_t>(arena_index) == arena_index_map.size()) {
+    size_t arena_index = std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
+    if (arena_index == arena_index_map.size()) {
         // Bin does not exist for the given chunk size.
         return false;
     }
     if (arena_index_map.at(arena_index) != bin_index) {
         return false;
     }
-    assert(arena.size() > static_cast<size_t>(arena_index));
+    assert(arena.size() > arena_index);
     FreeList& free_list = arena[arena_index];
     return EraseFromFreeList(free_list, chunk);
 }
 
 intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
+    if (size == 0) {
+        // A zero-sized chunk would share its address with the chunk it was
+        // split from, and aliased addresses break the `in_use_` bookkeeping.
+        // cudaMalloc returns a null pointer for a zero-sized request as well.
+        return 0;
+    }
+    if (size > kMaxAllocationSize) {
+        // Rounding up would wrap around in size_t and the pool would then hand
+        // out a chunk far smaller than requested. Such a request can never be
+        // satisfied, so report it as out of memory instead.
+        throw OutOfMemoryError(size, GetTotalBytes());
+    }
     size = GetRoundedSize(size);
     std::shared_ptr<Chunk> chunk = nullptr;
 
@@ -112,9 +124,9 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
 
         // find best-fit, or a smallest larger allocation
         Arena& arena = GetArena(stream_ptr);
-        int arena_index = GetArenaIndex(size);
-        int arena_length = static_cast<int>(arena.size());
-        for (int i = arena_index; i < arena_length; ++i) {
+        size_t arena_index = GetArenaIndex(size);
+        size_t arena_length = arena.size();
+        for (size_t i = arena_index; i < arena_length; ++i) {
             FreeList& free_list = arena[i];
             if (free_list.empty()) {
                 continue;

--- a/ext/cumo/cuda/memory_pool_impl.hpp
+++ b/ext/cumo/cuda/memory_pool_impl.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -20,6 +21,10 @@ namespace internal {
 // cudaMalloc() is aligned to at least 512 bytes
 // cf. https://gist.github.com/sonots/41daaa6432b1c8b27ef782cd14064269
 constexpr int kRoundSize = 512; // bytes
+
+// The largest size which can be rounded up to a multiple of kRoundSize without
+// wrapping around in size_t. Larger requests can never be satisfied anyway.
+constexpr size_t kMaxAllocationSize = std::numeric_limits<size_t>::max() - (kRoundSize - 1);
 
 class CUDARuntimeError : public std::runtime_error {
 private:
@@ -143,7 +148,7 @@ public:
 
 using FreeList = std::vector<std::shared_ptr<Chunk>>;  // list of free chunk
 using Arena = std::vector<FreeList>;  // free_list w.r.t arena index
-using ArenaIndexMap = std::vector<int>;  // arena index <=> bin size index
+using ArenaIndexMap = std::vector<size_t>;  // arena index <=> bin size index
 
 // Memory pool implementation for single device.
 // - The allocator attempts to find the smallest cached block that will fit
@@ -188,17 +193,29 @@ public:
 // private:
 
     // Rounds up the memory size to fit memory alignment of cudaMalloc.
+    //
+    // `size` must not exceed kMaxAllocationSize. Otherwise the addition below
+    // wraps around in size_t, and the largest sizes would round down to 0.
     size_t GetRoundedSize(size_t size) {
+        assert(size <= kMaxAllocationSize);
         return ((size + kRoundSize - 1) / kRoundSize) * kRoundSize;
     }
 
     // Get bin index regarding the memory size
-    int GetBinIndex(size_t size) {
+    //
+    // The index is a size_t rather than an int because the bin index of a huge
+    // size does not fit in an int. A truncated (possibly negative) index makes
+    // the free list search below start at the wrong bin and hand out a chunk
+    // smaller than requested.
+    //
+    // `size` must be positive; a zero-sized allocation has no bin.
+    size_t GetBinIndex(size_t size) {
+        assert(size > 0);
         return (size - 1) / kRoundSize;
     }
 
-    int GetArenaIndex(size_t size, cudaStream_t stream_ptr = 0) {
-        int bin_index = GetBinIndex(size);
+    size_t GetArenaIndex(size_t size, cudaStream_t stream_ptr = 0) {
+        size_t bin_index = GetBinIndex(size);
         ArenaIndexMap& arena_index_map = GetArenaIndexMap(stream_ptr);
         return std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
     }

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -134,10 +134,12 @@ public:
     void Run() {
         TearDown(); SetUp(); TestGetRoundedSize();
         TearDown(); SetUp(); TestGetBinIndex();
+        TearDown(); SetUp(); TestGetArenaIndexWithHugeSize();
         TearDown(); SetUp(); TestAppendToFreeList();
         TearDown(); SetUp(); TestRemoveFromFreeList();
         TearDown(); SetUp(); TestMalloc();
         TearDown(); SetUp(); TestMallocWithZero();
+        TearDown(); SetUp(); TestMallocWithHugeSize();
         TearDown(); SetUp(); TestFree();
         TearDown(); SetUp(); TestFreeDoubly();
         TearDown(); SetUp(); TestMallocSplit();
@@ -156,12 +158,28 @@ public:
         assert(pool_->GetRoundedSize(kRoundSize - 1) == kRoundSize);
         assert(pool_->GetRoundedSize(kRoundSize) == kRoundSize);
         assert(pool_->GetRoundedSize(kRoundSize + 1) == kRoundSize * 2);
+        // the largest roundable size must not wrap around to 0
+        assert(pool_->GetRoundedSize(kMaxAllocationSize) == kMaxAllocationSize);
     }
 
     void TestGetBinIndex() {
         assert(pool_->GetBinIndex(kRoundSize - 1) == 0);
         assert(pool_->GetBinIndex(kRoundSize) == 0);
         assert(pool_->GetBinIndex(kRoundSize + 1) == 1);
+        // the bin index of a huge size does not fit in an int
+        assert(pool_->GetBinIndex(kMaxAllocationSize) == (kMaxAllocationSize - 1) / kRoundSize);
+    }
+
+    void TestGetArenaIndexWithHugeSize() {
+        auto mem = std::make_shared<Memory>(kRoundSize * 4);
+        auto chunk = std::make_shared<Chunk>(mem, 0, mem->size(), stream_ptr_);
+        pool_->AppendToFreeList(chunk->size(), chunk, stream_ptr_);
+
+        assert(pool_->GetArenaIndex(kRoundSize * 4, stream_ptr_) == 0);
+        // A bin index which does not fit in an int must not fold back to a
+        // smaller arena index, or the free list search would pick this chunk.
+        assert(pool_->GetArenaIndex(size_t(1) << 41, stream_ptr_) == 1);
+        assert(pool_->GetArenaIndex(kMaxAllocationSize, stream_ptr_) == 1);
     }
 
     void TestAppendToFreeList() {
@@ -292,7 +310,38 @@ public:
     }
 
     void TestMallocWithZero() {
-        pool_->Malloc(0); // actually, cuda returns 0
+        intptr_t p1 = pool_->Malloc(kRoundSize * 4);
+        pool_->Free(p1);
+
+        assert(pool_->Malloc(0) == 0); // actually, cuda returns 0
+        // A zero-sized request must not take a cached chunk, or two live
+        // allocations would share one address.
+        assert(pool_->GetUsedBytes() == 0);
+        assert(pool_->GetFreeBytes() == kRoundSize * 4);
+        assert(pool_->Malloc(kRoundSize * 4) == p1);
+    }
+
+    void TestMallocWithHugeSize() {
+        intptr_t p1 = pool_->Malloc(kRoundSize * 4);
+        pool_->Free(p1);
+
+        // Sizes which cannot be rounded up without wrapping around in size_t
+        // must be rejected instead of being rounded down to 0.
+        assert(RaisesOutOfMemory(kMaxAllocationSize + 1));
+        assert(RaisesOutOfMemory(std::numeric_limits<size_t>::max()));
+
+        assert(pool_->GetUsedBytes() == 0);
+        assert(pool_->GetFreeBytes() == kRoundSize * 4);
+        assert(pool_->Malloc(kRoundSize * 4) == p1);
+    }
+
+    bool RaisesOutOfMemory(size_t size) {
+        try {
+            pool_->Malloc(size);
+        } catch (const OutOfMemoryError&) {
+            return true;
+        }
+        return false;
     }
 
     void TestFree() {

--- a/test/cuda/memory_pool_test.rb
+++ b/test/cuda/memory_pool_test.rb
@@ -41,5 +41,15 @@ module Cumo::CUDA
     def test_total_bytes
       assert_nothing_raised { MemoryPool.total_bytes }
     end
+
+    def test_malloc_with_size_whose_rounding_overflows
+      MemoryPool.enable
+      # 8 * (2**61 - 1) is SIZE_MAX - 7. Rounding it up to a multiple of the
+      # 512 byte alignment wrapped around to 0, so the pool handed out a chunk
+      # of another allocation instead of reporting the failure.
+      assert_raise(OutOfMemoryError) { Cumo::DFloat.new(2**61 - 1).allocate }
+      # the pool must be left usable
+      assert { Cumo::DFloat.new(1024).seq.sum == 1024 * 1023 / 2 }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Reject an allocation size which cannot be rounded up to the 512 byte alignment without wrapping around in `size_t`, and keep bin and arena indices in `size_t` so a huge size can no longer fold back onto a smaller bin. A zero sized request is short circuited as well, because it has no bin at all and its chunk would always alias the chunk it was split from.

## Problem

`SingleDeviceMemoryPool::Malloc` rounds the requested size up to a multiple of the 512 byte alignment of `cudaMalloc`. The addition in `GetRoundedSize` wraps around in `size_t`, so every size in `[SIZE_MAX-510, SIZE_MAX]` rounds down to `0`.

`GetBinIndex` then computes `(0 - 1) / 512` and truncates the result into an `int`, which yields `-1`. `std::lower_bound` maps that to arena index `0`, so the free list search starts at the smallest bin and pops whatever chunk is cached there. `Split(chunk, 0)` hands back a remaining chunk at the very same address, so the allocation "succeeds" while sharing its address with a chunk that goes straight back to the free list. `in_use_.emplace` silently ignores the duplicate key, so the next allocation reusing that address is never tracked and its `Free` becomes a no-op.

`Cumo::DFloat.new(2**61 - 1)` asks for `8 * (2**61 - 1)`, which is `SIZE_MAX - 7`, and `allocate` returns without raising.

The truncation in `GetBinIndex` also fires on its own for any size whose bin index does not fit in an `int`, that is roughly 1 TiB and above, even though such a size rounds up correctly. There the pool pops a chunk far smaller than requested and `Split` sets the chunk size beyond the memory that backs it. Against a pool holding a single 8192 byte free chunk:

```ruby
Cumo::DFloat.new(2**38).allocate   # 2 TiB
Cumo::CUDA::MemoryPool.used_bytes  #=> 2199023255552
Cumo::CUDA::MemoryPool.free_bytes  #=> 18446741874686304256
```

## Note

The C++ side tests added here are built and run by `rake ctest`, which currently fails before reaching them: the `run-ctest` recipe in `ext/cumo/depend.erb` invokes `./$<` while `$<` is already an absolute path. Left out of this change as it is unrelated.
