### PR TITLE
Fix process abort when freeing device memory fails

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -1,5 +1,7 @@
 #include "memory_pool_impl.hpp"
 
+#include <cstdio>
+
 #include <ruby.h>
 
 namespace cumo {
@@ -25,9 +27,15 @@ Memory::~Memory() {
         cudaError_t status = cudaFree(ptr_);
         // CUDA driver may shut down before freeing memory inside memory pool.
         // It is okay to simply ignore because CUDA driver automatically frees memory.
-        if (status != cudaErrorCudartUnloading) {
-            CheckStatus(status);
+        if (status == cudaSuccess || status == cudaErrorCudartUnloading) {
+            return;
         }
+        // A destructor is implicitly noexcept, so throwing here would call
+        // std::terminate and abort the process. Report the failure instead:
+        // cudaFree only fails once the context is already unusable, and the
+        // next runtime call reports the same status to the caller anyway.
+        std::fprintf(stderr, "cumo: failed to free %zu bytes of device memory: %s\n",
+                     size_, cudaGetErrorString(status));
     }
 }
 

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -592,6 +592,29 @@ public:
     }
 };
 
+// Resets the CUDA device, so it has to run after every other test.
+class TestMemoryDestructor {
+public:
+    void Run() {
+        TestFailingFreeDoesNotAbort();
+    }
+
+    // A destructor is implicitly noexcept, so a throwing CheckStatus here used
+    // to call std::terminate and abort the whole process.
+    void TestFailingFreeDoesNotAbort() {
+        auto mem = std::make_shared<Memory>(kRoundSize);
+        // Destroying the primary context invalidates the pointer, so the
+        // cudaFree in ~Memory fails with cudaErrorInvalidValue.
+        CheckStatus(cudaDeviceReset());
+
+        std::cerr << "(the cumo warning below is expected)" << std::endl;
+        mem.reset();
+        // Reaching this line is the assertion: the destructor reported the
+        // failure instead of terminating the process.
+        cudaGetLastError();  // clear the error left by the failed cudaFree
+    }
+};
+
 }  // namespace internal
 }  // namespace cumo
 
@@ -599,5 +622,6 @@ int main() {
     cumo::internal::TestChunk{}.Run();
     cumo::internal::TestSingleDeviceMemoryPool{}.Run();
     cumo::internal::TestMemoryPool{}.Run();
+    cumo::internal::TestMemoryDestructor{}.Run();
     return 0;
 }


### PR DESCRIPTION
## Summary

Report a failing `cudaFree` on stderr instead of throwing out of `~Memory`, which aborted the process.

## Problem

`~Memory` passes the result of `cudaFree` to `CheckStatus`, which throws a `CUDARuntimeError`. Since C++11 a destructor is implicitly `noexcept`, so that throw does not unwind — it calls `std::terminate` and kills the Ruby process.

The error was clearly meant to reach Ruby: `rb_memory_pool_free_all_blocks` wraps `FreeAllBlocks` in `catch (const CUDARuntimeError&)`. That handler is unreachable, because the only way `FreeAllBlocks` can produce the error is through this destructor.

`cudaFree` fails when the CUDA context is already unusable, most commonly after an asynchronous kernel left a sticky error. Destroying a `Memory` after that — on a GC sweep, or through `Cumo::CUDA::MemoryPool.free_all_blocks` — turns a reportable CUDA error into `SIGABRT`. Reproduced against `memory_pool_impl.cpp` by faulting a kernel and then letting a `Memory` go out of scope:

```
allocated 1024 bytes
sticky error: an illegal memory access was encountered
destroying Memory (cudaFree will fail)...
terminate called after throwing an instance of 'cumo::internal::CUDARuntimeError'
  what():  an illegal memory access was encountered
```

Nothing is lost by not raising. A sticky error is returned again by the next runtime call, so cumo still reports it to the caller through the normal path; the process just no longer dies before it can.

The regression test provokes the same failure without a sticky error, by resetting the device so the cached pointer becomes invalid. It runs last because `cudaDeviceReset` invalidates every allocation in the process.
