### PR TITLE
Fix run-ctest failing to start the test binary

### DIFF
--- a/ext/cumo/depend.erb
+++ b/ext/cumo/depend.erb
@@ -52,7 +52,7 @@ src : <%= list_type_cu.join(" ") %> <%= list_type_c.join(" ") %>
 build-ctest : <%= __dir__ %>/cuda/memory_pool_impl_test.exe
 
 run-ctest : <%= __dir__ %>/cuda/memory_pool_impl_test.exe
-	./$<
+	$<
 
 <%= __dir__ %>/cuda/memory_pool_impl_test.exe: <%= __dir__ %>/cuda/memory_pool_impl_test.cpp <%= __dir__ %>/cuda/memory_pool_impl.cpp <%= __dir__ %>/cuda/memory_pool_impl.hpp
 	nvcc -std=c++17 <%= ENV['DEBUG'] ? '-g -O0 --compiler-options -Wall' : '' %> -L. -L$(libdir) -I. $(INCFLAGS) -o $@ $< <%= __dir__ %>/cuda/memory_pool_impl.cpp


### PR DESCRIPTION
## Summary

Invoke the test binary directly in the `run-ctest` recipe instead of prefixing it with `./`.

## Problem

`$<` expands to an absolute path built from `<%= __dir__ %>`, so `./$<` makes make execute `.//home/.../memory_pool_impl_test.exe`. `rake ctest` therefore always fails with exit 127, right after building the binary it was about to run:

```
make: .//home/.../ext/cumo/cuda/memory_pool_impl_test.exe: No such file or directory
make: *** [Makefile:629: run-ctest] Error 127
```

The C++ side tests of the memory pool have not been runnable through `rake ctest` until now.
