### PR TITLE
Fix freeing pooled memory with cudaFree after disabling the pool

### DIFF
--- a/ext/cumo/cuda/memory_pool.cpp
+++ b/ext/cumo/cuda/memory_pool.cpp
@@ -50,16 +50,22 @@ cumo_cuda_runtime_malloc(size_t size)
 void
 cumo_cuda_runtime_free(char *ptr)
 {
-    if (memory_pool_enabled) {
-        try {
-            // TODO(sonots): Get current CUDA stream and pass it
-            pool.Free(reinterpret_cast<intptr_t>(ptr));
-        } catch (const cumo::internal::CUDARuntimeError& e) {
-            cumo_cuda_runtime_check_status(e.status());
+    // Always offer the pointer to the pool first, whatever memory_pool_enabled
+    // says now: MemoryPool.enable/disable is public, so the state can differ
+    // from what it was at allocation time. Handing a pooled chunk to cudaFree
+    // releases memory the pool still hands out, and fails outright for a chunk
+    // which is not at the head of its buffer.
+    try {
+        // TODO(sonots): Get current CUDA stream and pass it
+        if (pool.Free(reinterpret_cast<intptr_t>(ptr))) {
+            return;
         }
-    } else {
-        cumo_cuda_runtime_check_status(cudaFree((void*)ptr));
+    } catch (const cumo::internal::CUDARuntimeError& e) {
+        cumo_cuda_runtime_check_status(e.status());
+        return;
     }
+    // No pool owns it, so it came straight from cudaMallocManaged.
+    cumo_cuda_runtime_check_status(cudaFree((void*)ptr));
 }
 
 /*

--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -186,17 +186,24 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
     return chunk->ptr();
 }
 
-void SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
+bool SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
     std::shared_ptr<Chunk> chunk = nullptr;
 
     {
         std::lock_guard<std::recursive_mutex> lock{mutex_};
 
-        chunk = in_use_[ptr];
-        // assert(chunk != nullptr);
-        if (!chunk) return;
+        // find rather than operator[], which would insert an empty entry for
+        // every pointer this pool does not own.
+        auto it = in_use_.find(ptr);
+        if (it == in_use_.end()) {
+            return false;
+        }
+        chunk = it->second;
+        in_use_.erase(it);
+        if (!chunk) {
+            return false;
+        }
         chunk->set_in_use(false);
-        in_use_.erase(ptr);
     }
 
     if (chunk->next() != nullptr && !chunk->next()->in_use()) {
@@ -211,6 +218,7 @@ void SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
         }
     }
     AppendToFreeList(chunk->size(), chunk, stream_ptr);
+    return true;
 }
 
 void SingleDeviceMemoryPool::CompactIndex(cudaStream_t stream_ptr, bool free) {

--- a/ext/cumo/cuda/memory_pool_impl.hpp
+++ b/ext/cumo/cuda/memory_pool_impl.hpp
@@ -172,7 +172,9 @@ public:
 
     intptr_t Malloc(size_t size, cudaStream_t stream_ptr = 0);
 
-    void Free(intptr_t ptr, cudaStream_t stream_ptr = 0);
+    // Returns false if this pool did not allocate the pointer, in which case
+    // nothing was freed.
+    bool Free(intptr_t ptr, cudaStream_t stream_ptr = 0);
 
     // Free all **non-split** chunks in all arenas
     void FreeAllBlocks();
@@ -325,9 +327,30 @@ public:
     // Args:
     //     ptr (intptr_t): Pointer of the memory buffer
     //     stream_ptr (cudaStream_t): Return the memory to the arena of given stream
-    void Free(intptr_t ptr, cudaStream_t stream_ptr = 0) {
-        auto& mp = pools_[device_id()];
-        mp.Free(ptr, stream_ptr);
+    // Returns:
+    //     bool: false if no pool allocated the pointer, in which case nothing
+    //           was freed and the caller has to free it by its own means.
+    bool Free(intptr_t ptr, cudaStream_t stream_ptr = 0) {
+        if (pools_.empty()) {  // nothing has ever been allocated from a pool
+            return false;
+        }
+        int current_device_id = device_id();
+        auto it = pools_.find(current_device_id);
+        if (it != pools_.end() && it->second.Free(ptr, stream_ptr)) {
+            return true;
+        }
+        // The current device may have been switched since the allocation.
+        // cudaMallocManaged hands out addresses which are unique across the
+        // host and every device, so the pointer identifies its pool on its own.
+        for (auto& entry : pools_) {
+            if (entry.first == current_device_id) {
+                continue;
+            }
+            if (entry.second.Free(ptr, stream_ptr)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // Free all **non-split** chunks in all arenas

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -142,6 +142,7 @@ public:
         TearDown(); SetUp(); TestMallocWithHugeSize();
         TearDown(); SetUp(); TestFree();
         TearDown(); SetUp(); TestFreeDoubly();
+        TearDown(); SetUp(); TestFreeReportsOwnership();
         TearDown(); SetUp(); TestMallocSplit();
         TearDown(); SetUp(); TestFreeMerge();
         TearDown(); SetUp(); TestFreeDifferentSize();
@@ -355,6 +356,33 @@ public:
         intptr_t p1 = pool_->Malloc(kRoundSize * 4);
         pool_->Free(p1);
         // pool_->Free(p1); // will abort
+    }
+
+    // Free reports whether the pool owns the pointer, so that a caller which
+    // allocated outside the pool can fall back to cudaFree without releasing
+    // memory the pool still hands out.
+    void TestFreeReportsOwnership() {
+        intptr_t p = pool_->Malloc(kRoundSize * 4);
+        assert(pool_->Free(p));
+        assert(!pool_->Free(p));  // already returned to the free list
+
+        assert(!pool_->Free(0));
+        assert(!pool_->Free(p + 1));
+
+        // a buffer allocated outside the pool, as happens while the pool is
+        // disabled, stays the caller's to free
+        void* raw = nullptr;
+        CheckStatus(cudaMallocManaged(&raw, kRoundSize, cudaMemAttachGlobal));
+        assert(!pool_->Free(reinterpret_cast<intptr_t>(raw)));
+        CheckStatus(cudaFree(raw));
+
+        // a chunk which is not at the head of its buffer is owned just as much,
+        // and is exactly the one cudaFree cannot free
+        intptr_t head = pool_->Malloc(kRoundSize * 2);
+        intptr_t tail = pool_->Malloc(kRoundSize * 2);
+        assert(head != tail);
+        assert(pool_->Free(tail));
+        assert(pool_->Free(head));
     }
 
     void TestMallocSplit() {


### PR DESCRIPTION
## Summary

Ask the memory pool on every free regardless of `memory_pool_enabled`, and fall back to `cudaFree` only for a pointer no pool owns.

## Problem

`cumo_cuda_runtime_malloc` picks its allocator from `memory_pool_enabled`, and `cumo_cuda_runtime_free` picks its deallocator from the same flag when the memory is released. `MemoryPool.enable` / `MemoryPool.disable` is public, so the two reads can disagree and the pointer ends up freed by the wrong allocator.

**Enabled at allocation, disabled at release.** `cudaFree` gets a chunk of a buffer the pool owns. For a chunk which is not at the head of its buffer `cudaFree` fails, and `cumo_cuda_runtime_check_status` raises it from inside the GC sweep:

```ruby
Cumo::CUDA::MemoryPool.enable
a = Cumo::DFloat.new(1024); a.allocate; a = nil; GC.start
head = Cumo::DFloat.new(512).seq   # head of the cached 8192 byte block
tail = Cumo::DFloat.new(512).seq   # chunk at head + 4096
Cumo::CUDA::MemoryPool.disable
tail = nil; GC.start
#=> in `GC.start': invalid argument (error=1) (Cumo::CUDA::RuntimeError)
```

For a chunk at the head of its buffer `cudaFree` succeeds instead, releasing memory the pool still hands out and leaving the buffer to be freed a second time by `~Memory`.

**Disabled at allocation, enabled at release.** The pool does not know the pointer and drops it, so it is never freed at all.

`Free` now reports whether the pool owns the pointer. It looks the pointer up with `find`, so a pointer belonging to nobody no longer leaves an empty entry behind in `in_use_`, and it walks the pools of the other devices as well: `cudaMallocManaged` addresses are unique across devices, and the current device may have been switched between the allocation and the free, which used to drop the pointer just as silently.

## Note

The regression test is on the C++ side only. Reproducing this from Ruby needs the GC to actually release a pooled pointer between an `enable` and a `disable`, and inside the test suite `GC.start` does not reclaim a just-allocated NArray — the same allocation is collected when the file runs on its own but survives several full GCs when the whole suite runs. The three scenarios above were verified by hand instead; the C++ test covers the ownership contract `cumo_cuda_runtime_free` now relies on, including the split chunk that is exactly what `cudaFree` cannot free.
