### PR TITLE
Fix segfault in Module#get_global_var reading device memory as a host pointer

### DIFF
--- a/ext/cumo/cuda/driver.c
+++ b/ext/cumo/cuda/driver.c
@@ -294,13 +294,18 @@ rb_cuModuleGetGlobal(VALUE self, VALUE hmod, VALUE name)
     CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
     const char* _name = RSTRING_PTR(name);
     CUresult status;
+    VALUE ret;
 
     struct cuModuleGetGlobalParam param = {&_dptr, &_bytes, _hmod, _name};
     status = (CUresult)rb_thread_call_without_gvl(cuModuleGetGlobal_without_gvl_cb, &param, NULL, NULL);
     //status = cuModuleGetGlobal(&_dptr, &_bytes, _hmod, _name);
 
     check_status(status);
-    return rb_str_new((char *)_dptr, _bytes);
+
+    // _dptr addresses device memory, which the host cannot read directly.
+    ret = rb_str_new(NULL, (long)_bytes);
+    check_status(cuMemcpyDtoH(RSTRING_PTR(ret), _dptr, _bytes));
+    return ret;
 }
 
 struct cuModuleLoadParam {

--- a/test/cuda/driver_test.rb
+++ b/test/cuda/driver_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Cumo::CUDA
+  class DriverTest < Test::Unit::TestCase
+    SOURCE = <<~CUDA
+      extern "C" {
+        __device__ int cumo_test_global[4] = {11, 22, 33, 44};
+      }
+      __global__ void cumo_test_kernel() {}
+    CUDA
+
+    def test_cuModuleGetGlobal
+      ptx = Compiler.new.compile_using_nvrtc(SOURCE)
+      Module.new do |mod|
+        mod.load(ptx)
+        # the global lives in device memory, so reading it needs a copy back
+        var = mod.get_global_var("cumo_test_global")
+        assert { var.bytesize == 16 }
+        assert { var.unpack("l<4") == [11, 22, 33, 44] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Copy a module global back from the device with `cuMemcpyDtoH` instead of handing its device address to `rb_str_new`.

## Problem

`cuModuleGetGlobal` reports the address of a module global as a `CUdeviceptr`, which is a device virtual address. `rb_str_new((char *)_dptr, _bytes)` copies `_bytes` from it as if it were a host pointer, so `Cumo::CUDA::Module#get_global_var` segfaults on its documented use — no unusual input needed:

```ruby
src = 'extern "C" { __device__ int g[4] = {11, 22, 33, 44}; }'
ptx = Cumo::CUDA::Compiler.new.compile_using_nvrtc(src)
Cumo::CUDA::Module.new { |m| m.load(ptx); m.get_global_var("g") }
#=> module.rb:32: [BUG] Segmentation fault at 0x000001000e000000
```

The crash is deterministic: five runs faulted at the same address, which `/proc/self/maps` places inside a `---p` (`PROT_NONE`) range the driver reserves for the unified address space, so even a one byte read faults.

```
00010005fec000-00010020000000 ---p        <- 0x1000e000000 lives here
00010005a00000-00010005fec000 rw-s  /dev/nvidiactl
00010005800000-00010005a00000 rw-s  /dev/zero (deleted)
```

Readable driver mappings sit right next to it, so a global placed there would be copied into the String without faulting at all.

`cudaMallocManaged` is what makes cumo's own device pointers readable from the host, and a module global is not one of those.
