### PR TITLE
Stop freeing the Ruby heap from a CUDA stream callback

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -7,7 +7,9 @@ void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(char *p1, ssize_t s1, dty
 static void CUDART_CB
 <%=c_iter%>_callback(cudaStream_t stream, cudaError_t status, void *data)
 {
-    xfree(data);
+    // Runs on a CUDA driver thread which does not hold the GVL, so this must
+    // not touch the Ruby heap. The buffer comes from malloc, not ALLOC_N.
+    free(data);
 }
 //<% end %>
 
@@ -123,7 +125,16 @@ static void
         //
         // FYI: We may have to care of cuda stream callback serializes stream execution when we support stream.
         // https://devtalk.nvidia.com/default/topic/822942/why-does-cudastreamaddcallback-serialize-kernel-execution-and-break-concurrency-/
-        dtype* host_z = ALLOC_N(dtype, n);
+
+        // Deliberately not ALLOC_N: the callback below releases this buffer
+        // from a CUDA driver thread, which cannot touch the Ruby heap. Ask for
+        // one element when n is 0 so the pointer stays non-NULL, as ALLOC_N's
+        // would have been.
+        dtype* host_z = (dtype*)malloc(sizeof(dtype) * (n == 0 ? 1 : n));
+        if (host_z == NULL) {
+            rb_raise(rb_eNoMemError, "failed to allocate %"SZF"u bytes to stage the copy",
+                     sizeof(dtype) * n);
+        }
         for (i=i1=0; i1<n1 && i<n; i1++) {
             x = ptr[i1];
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
@@ -149,7 +160,7 @@ static void
             if (status == 0) {
                 cumo_cuda_runtime_check_status(cudaStreamAddCallback(0,<%=c_iter%>_callback,host_z,0));
             } else {
-                xfree(host_z);
+                free(host_z);
             }
             cumo_cuda_runtime_check_status(status);
         } else {
@@ -163,7 +174,7 @@ static void
                 }
                 cumo_cuda_runtime_check_status(cudaStreamAddCallback(0,<%=c_iter%>_callback,host_z,0));
             } else {
-                xfree(host_z);
+                free(host_z);
             }
             cumo_cuda_runtime_free((void*)device_z);
             cumo_cuda_runtime_check_status(status);


### PR DESCRIPTION
## Summary

Stage the host side copy in a `malloc` buffer released with `free`, so the CUDA stream callback no longer calls into the Ruby allocator.

## Problem

`store_array` copies a Ruby Array into a heap buffer, starts an asynchronous copy to the device, and releases the buffer from a `cudaStreamAddCallback` callback once the copy has finished. The buffer came from `ALLOC_N` and the callback released it with `xfree`, but a stream callback runs on a CUDA driver thread, so this calls a Ruby API without the GVL.

Probing the callback confirms it, for a plain `Cumo::DFloat[1.0, 2.0, 3.0]`:

```
MAIN:  tid=349257                                              # the thread running Ruby
PROBE  iter_dfloat_store_array_callback: gvl=0 ruby_thread=0 tid=349281
```

`ruby_thread_has_gvl_p()` is 0 and `ruby_native_thread_p()` is 0, on a native thread which is not the one running Ruby. Both the contiguous fast path and the strided path register the same callback, so every store of a Ruby Array goes through it — this is not limited to Ractor or any unusual usage.

Nothing about the buffer needs the Ruby allocator: it holds plain numbers and never becomes visible to the GC. `malloc` and `free` are safe to call from any thread. The `n == 0` case asks for one element so the pointer stays non-NULL, which is what `ALLOC_N` guaranteed.

## Note

`narray/index.c:110-114` has the same shape of bug in the other direction: its stream callback calls `cudaFreeHost`, and CUDA forbids calling the CUDA API from a stream callback. Left out of this change as it is a different mechanism in a different file.
