### PR TITLE
Fix pinned host memory leak when indexing by an array

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -107,12 +107,6 @@ cumo_na_range_check(ssize_t pos, ssize_t size, int dim)
     return idx;
 }
 
-static void CUDART_CB
-cumo_na_parse_array_callback(cudaStream_t stream, cudaError_t status, void *data)
-{
-    cudaFreeHost(data);
-}
-
 // copy ruby array to idx
 static void
 cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
@@ -125,18 +119,21 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
     //for (k=0; k<n; k++) {
     //    q->idx[k] = na_range_check(NUM2SSIZET(RARRAY_AREF(ary,k)), size, orig_dim);
     //}
-    // make a contiguous pinned memory on host => copy to device => release pinned memory after copy finished on callback
+    // make a contiguous memory on host => copy to device => release it.
+    //
+    // The host buffer is pageable on purpose. cudaMemcpyAsync only returns once
+    // a pageable source has been copied into the driver's staging buffer, so the
+    // buffer can be released right away while the DMA to the device carries on.
+    // Pinned memory would have to outlive the copy, and there is no way to
+    // release it once the copy is done: a stream callback may not call the CUDA
+    // API, so cudaFreeHost() there fails with cudaErrorNotPermitted and leaks.
     q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-    cudaHostAlloc((void**)&idx, sizeof(size_t)*n, cudaHostAllocDefault);
+    idx = ALLOC_N(size_t, n);
     for (k=0; k<n; k++) {
         idx[k] = cumo_na_range_check(NUM2SSIZET(RARRAY_AREF(ary,k)), size, orig_dim);
     }
     status = cudaMemcpyAsync(q->idx,idx,sizeof(size_t)*n,cudaMemcpyHostToDevice,0);
-    if (status == 0) {
-        cumo_cuda_runtime_check_status(cudaStreamAddCallback(0,cumo_na_parse_array_callback,idx,0));
-    } else {
-        cudaFreeHost(idx);
-    }
+    xfree(idx);
     cumo_cuda_runtime_check_status(status);
 
     q->n    = n;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1099,4 +1099,29 @@ class NArrayTest < Test::Unit::TestCase
     # sanity: the full-length store is still correct
     assert { a.to_a == [[0, 1, 2], [0, 1, 2]] }
   end
+
+  test "indexing by an array does not leak host memory" do
+    # The index list was staged in pinned host memory released from a CUDA
+    # stream callback, but a callback may not call the CUDA API: cudaFreeHost
+    # returned cudaErrorNotPermitted and the buffer was never freed, leaking
+    # 8 bytes of page-locked memory per element on every indexing.
+    omit "needs /proc/self/status" unless File.readable?("/proc/self/status")
+    rss = -> { File.read("/proc/self/status")[/VmRSS:\s+(\d+)/, 1].to_i }
+
+    a = Cumo::DFloat.new(1000).seq
+    idx = (0...500).to_a
+    assert { a[idx].to_a == (0...500).map(&:to_f) }
+    GC.start
+
+    before_rss = rss.call
+    before_pool = Cumo::CUDA::MemoryPool.total_bytes
+    20_000.times { a[idx] }
+    GC.start
+    # Device memory the pool holds on to also counts towards RSS, and how much
+    # it keeps depends on what ran before, so discount it: the pinned host
+    # buffers were never in the pool.
+    grew = (rss.call - before_rss) - (Cumo::CUDA::MemoryPool.total_bytes - before_pool) / 1024
+    # the leak alone was 20_000 * 500 * 8 bytes = 78 MB
+    assert { grew < 40_000 }
+  end
 end


### PR DESCRIPTION
## Summary

Stage the index list in a pageable buffer released right after `cudaMemcpyAsync`, instead of pinned memory a stream callback could never free.

## Problem

`cumo_na_parse_array` allocated the index list with `cudaHostAlloc` and registered a stream callback to release it with `cudaFreeHost` once the copy to the device had finished. **A stream callback may not call the CUDA API**, so `cudaFreeHost` returns `cudaErrorNotPermitted` there. Its result was not checked, so the buffer was never freed: every `a[[...]]` leaked 8 bytes of page-locked host memory per index element, for the life of the process.

A callback which frees a `cudaHostAlloc` buffer reports:

```
cudaFreeHost inside the callback -> 800 (operation not permitted)
after callback: cudaPointerGetAttributes -> 0 (no error), type=1 (still host pinned)
```

and 20000 iterations of `a[idx]` with 500 indices grew RSS by 117 MB, next to the 78 MB the leak alone accounts for. After this change the same loop grows by 8-9 MB, which is the memory pool reaching a steady state.

CUDA only returns from a pageable host to device copy once the source has been copied into the driver's staging buffer, so a pageable buffer may be reused as soon as `cudaMemcpyAsync` returns and needs no callback at all. This also drops a `cudaHostAlloc` and a `cudaFreeHost` per indexing, both of which are heavyweight calls.

The test discounts the pool's own growth from the RSS delta, because how much device memory the pool retains depends on what ran before it; the pinned buffers were never in the pool. It measures 139 MB without this change and at most 6 MB with it, against a 40 MB threshold.
