### PR TITLE
Fix store into a strided view reading a released staging buffer

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -161,10 +161,15 @@ static void
                 } else {
                     <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,s1,device_z,i);
                 }
-                cumo_cuda_runtime_check_status(cudaStreamAddCallback(0,<%=c_iter%>_callback,host_z,0));
-            } else {
-                xfree(host_z);
+                // The kernel reads device_z, so wait for it before giving the
+                // buffer back. The memory pool hands a freed chunk straight out
+                // again, and a host write into that managed memory does not wait
+                // for the stream, so the kernel would read the new contents.
+                status = cudaStreamSynchronize(0);
             }
+            // Freeing here rather than from a stream callback: the copy is over
+            // by now, and a callback may not call the CUDA API anyway.
+            xfree(host_z);
             cumo_cuda_runtime_free((void*)device_z);
             cumo_cuda_runtime_check_status(status);
         }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1100,6 +1100,24 @@ class NArrayTest < Test::Unit::TestCase
     assert { a.to_a == [[0, 1, 2], [0, 1, 2]] }
   end
 
+  test "store into a strided view is not clobbered by a later allocation" do
+    # Storing a Ruby Array into a strided destination stages it in a device
+    # buffer and launches a kernel to scatter it. The buffer was released right
+    # after the launch, so the memory pool could hand it out again while the
+    # kernel was still reading it; from_binary then memcpy'd over it from the
+    # host, which does not wait for the stream.
+    n = 1_000_000
+    src = Array.new(n, 7.0)
+    poison = [-1.0].pack("d") * n
+
+    5.times do
+      a = Cumo::DFloat.zeros(n, 2)
+      a[true, 0] = src
+      Cumo::DFloat.from_binary(poison)
+      assert { a[true, 0].eq(7.0).count_true == n }
+    end
+  end
+
   test "indexing by an array does not leak host memory" do
     # The index list was staged in pinned host memory released from a CUDA
     # stream callback, but a callback may not call the CUDA API: cudaFreeHost


### PR DESCRIPTION
## Summary

Wait for the scatter kernel before returning its staging buffer to the memory pool.

## Problem

Storing a Ruby Array into a strided or indexed destination stages the values in a device buffer and launches a kernel to scatter them. The buffer was released immediately after the launch, while the kernel was still reading it. The memory pool hands a freed chunk straight back out, and a host write into that managed memory does not wait for the stream, so the kernel ends up reading whatever the new owner put there:

```ruby
n = 1_000_000
a = Cumo::DFloat.zeros(n, 2)
a[true, 0] = Array.new(n, 7.0)                    # stages into a pooled buffer
Cumo::DFloat.from_binary([-1.0].pack("d") * n)    # memcpy over that buffer
a[true, 0]                                        # contains -1.0 in places
```

23 of 30 iterations came out corrupted, up to 855312 of the 1000000 elements, always with the value `from_binary` wrote. The corruption is silent — the store reports success and the array simply holds the wrong numbers.

`from_binary` is only the most convenient way to demonstrate it: any host write into freshly allocated memory can land on the buffer, because the pool's invariant that a released chunk is no longer referenced by pending GPU work was broken.

The host side staging buffer is now released on the spot as well, rather than from a stream callback, since the copy is over by the time the stream has drained.

## Note

This makes a store into a strided destination synchronous. The buffer cannot be reused before the kernel is done in any case, so the previous asynchrony was not real, only unchecked.
