### PR TITLE
Fix segfaults from unchecked String arguments in Driver

### DIFF
--- a/ext/cumo/cuda/driver.c
+++ b/ext/cumo/cuda/driver.c
@@ -102,15 +102,19 @@ rb_cuLinkAddData(VALUE self, VALUE state, VALUE type, VALUE data, VALUE name)
 {
     CUlinkState _state = (CUlinkState)NUM2SIZET(state);
     CUjitInputType _type = (CUjitInputType)NUM2INT(type);
-    void* _data = (void *)RSTRING_PTR(data);
+    // The image may be a cubin, so it is taken by length and allowed to hold
+    // NUL bytes; the name is a plain C string cuLinkAddData reports errors with.
+    void* _data = (void *)StringValuePtr(data);
     size_t _size = RSTRING_LEN(data);
-    const char* _name = RSTRING_PTR(data);
+    const char* _name = StringValueCStr(name);
     CUresult status;
 
     struct cuLinkAddDataParam param = {_state, _type, _data, _size, _name, 0, (CUjit_option*)0, (void**)0};
     status = (CUresult)rb_thread_call_without_gvl(cuLinkAddData_without_gvl_cb, &param, NULL, NULL);
     //status = cuLinkAddData(_state, _type, _data, _size, _name, 0, (CUjit_option*)0, (void**)0);
 
+    RB_GC_GUARD(data);
+    RB_GC_GUARD(name);
     check_status(status);
     return Qnil;
 }
@@ -139,13 +143,14 @@ rb_cuLinkAddFile(VALUE self, VALUE state, VALUE type, VALUE path)
 {
     CUlinkState _state = (CUlinkState)NUM2SIZET(state);
     CUjitInputType _type = (CUjitInputType)NUM2INT(type);
-    const char* _path = RSTRING_PTR(path);
+    const char* _path = StringValueCStr(path);
     CUresult status;
 
     struct cuLinkAddFileParam param = {_state, _type, _path, 0, (CUjit_option*)0, (void **)0};
     status = (CUresult)rb_thread_call_without_gvl(cuLinkAddFile_without_gvl_cb, &param, NULL, NULL);
     //status = cuLinkAddFile(_state, _type, _path, 0, (CUjit_option*)0, (void **)0);
 
+    RB_GC_GUARD(path);
     check_status(status);
     return Qnil;
 }
@@ -259,13 +264,14 @@ rb_cuModuleGetFunction(VALUE self, VALUE hmod, VALUE name)
 {
     CUfunction _hfunc;
     CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
-    const char* _name = RSTRING_PTR(name);
+    const char* _name = StringValueCStr(name);
     CUresult status;
 
     struct cuModuleGetFunctionParam param = {&_hfunc, _hmod, _name};
     status = (CUresult)rb_thread_call_without_gvl(cuModuleGetFunction_without_gvl_cb, &param, NULL, NULL);
     //status = cuModuleGetFunction(&_hfunc, _hmod, _name);
 
+    RB_GC_GUARD(name);
     check_status(status);
     return SIZET2NUM((size_t)_hfunc);
 }
@@ -292,7 +298,7 @@ rb_cuModuleGetGlobal(VALUE self, VALUE hmod, VALUE name)
     CUdeviceptr _dptr;
     size_t _bytes;
     CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
-    const char* _name = RSTRING_PTR(name);
+    const char* _name = StringValueCStr(name);
     CUresult status;
     VALUE ret;
 
@@ -300,6 +306,7 @@ rb_cuModuleGetGlobal(VALUE self, VALUE hmod, VALUE name)
     status = (CUresult)rb_thread_call_without_gvl(cuModuleGetGlobal_without_gvl_cb, &param, NULL, NULL);
     //status = cuModuleGetGlobal(&_dptr, &_bytes, _hmod, _name);
 
+    RB_GC_GUARD(name);
     check_status(status);
 
     // _dptr addresses device memory, which the host cannot read directly.
@@ -326,13 +333,14 @@ static VALUE
 rb_cuModuleLoad(VALUE self, VALUE fname)
 {
     CUmodule _module;
-    const char* _fname = RSTRING_PTR(fname);
+    const char* _fname = StringValueCStr(fname);
     CUresult status;
 
     struct cuModuleLoadParam param = {&_module, _fname};
     status = (CUresult)rb_thread_call_without_gvl(cuModuleLoad_without_gvl_cb, &param, NULL, NULL);
     //status = cuModuleLoad(&_module, _fname);
 
+    RB_GC_GUARD(fname);
     check_status(status);
     return SIZET2NUM((size_t)_module);
 }
@@ -355,13 +363,15 @@ static VALUE
 rb_cuModuleLoadData(VALUE self, VALUE image)
 {
     CUmodule _module;
-    const void* _image = (void*)RSTRING_PTR(image);
+    // A cubin is binary, so the image is not required to be NUL-free.
+    const void* _image = (void*)StringValuePtr(image);
     CUresult status;
 
     struct cuModuleLoadDataParam param = {&_module, _image};
     status = (CUresult)rb_thread_call_without_gvl(cuModuleLoadData_without_gvl_cb, &param, NULL, NULL);
     //status = cuModuleLoadData(&_module, _image);
 
+    RB_GC_GUARD(image);
     check_status(status);
     return SIZET2NUM((size_t)_module);
 }

--- a/test/cuda/driver_test.rb
+++ b/test/cuda/driver_test.rb
@@ -21,5 +21,45 @@ module Cumo::CUDA
         assert { var.unpack("l<4") == [11, 22, 33, 44] }
       end
     end
+
+    # cuLinkAddData used to pass the PTX blob as the `name` argument and ignore
+    # the one it was given, so this also covers that the name reaches the driver
+    # without upsetting it.
+    def test_link_state_round_trip
+      ptx = Compiler.new.compile_using_nvrtc(SOURCE)
+      cubin = nil
+      LinkState.new do |link|
+        link.add_ptr_data(ptx, "cumo_test.ptx")
+        cubin = link.complete
+      end
+      Module.new do |mod|
+        mod.load(cubin)
+        assert { mod.get_global_var("cumo_test_global").unpack("l<4") == [11, 22, 33, 44] }
+      end
+    end
+
+    # Every one of these read RSTRING_PTR off whatever it was handed, so a
+    # non-String argument reached the driver as a garbage pointer and segfaulted.
+    NON_STRINGS = [[1, 2, 3], 123456, nil, { a: 1 }].freeze
+
+    def test_string_arguments_are_type_checked
+      NON_STRINGS.each do |bad|
+        assert_raise(TypeError) { Driver.cuModuleLoad(bad) }
+        assert_raise(TypeError) { Driver.cuModuleLoadData(bad) }
+        assert_raise(TypeError) { Driver.cuModuleGetFunction(0, bad) }
+        assert_raise(TypeError) { Driver.cuModuleGetGlobal(0, bad) }
+      end
+    end
+
+    def test_link_state_arguments_are_type_checked
+      NON_STRINGS.each do |bad|
+        LinkState.new do |link|
+          state = link.instance_variable_get(:@ptr)
+          assert_raise(TypeError) { Driver.cuLinkAddFile(state, Driver::CU_JIT_INPUT_PTX, bad) }
+          assert_raise(TypeError) { Driver.cuLinkAddData(state, Driver::CU_JIT_INPUT_PTX, bad, "n.ptx") }
+          assert_raise(TypeError) { Driver.cuLinkAddData(state, Driver::CU_JIT_INPUT_PTX, "", bad) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Every entry point in `driver.c` that takes a string read `RSTRING_PTR` off the argument without checking it is a String:

```c
const char* _fname = RSTRING_PTR(fname);
```

`RSTRING_PTR` on another object reinterprets that object's header, so the driver receives a pointer assembled out of unrelated fields. All six of these are public singleton methods on `Cumo::CUDA::Driver`, and all six segfault:

| method | `[1,2,3]` | `123456` | `nil` | `{a: 1}` |
|---|---|---|---|---|
| `cuModuleLoad` | SEGV | SEGV | SEGV | ok |
| `cuModuleLoadData` | SEGV | SEGV | SEGV | ok |
| `cuModuleGetFunction` | ok | SEGV | SEGV | ok |
| `cuModuleGetGlobal` | ok | SEGV | SEGV | ok |
| `cuLinkAddFile` | SEGV | SEGV | SEGV | ok |
| `cuLinkAddData` | SEGV | SEGV | SEGV | ok |

```
[BUG] Segmentation fault at 0x0000000000000005
c:0003 p:---- s:0014 e:000013 l:y b:0001 CFUNC  :cuModuleLoad
/usr/lib/libcuda.so.1(cuModuleLoad+0x1a) [0x7f1b323696ea]
```

The `ok` cells are not safe, only lucky — the bogus pointer happened to land somewhere readable and the driver returned an ordinary error.

## The fix

- `StringValueCStr` where the driver wants a NUL-terminated C string: `fname`, `path`, and the two `name` arguments.
- `StringValuePtr` where the call takes an explicit length and the bytes may be binary. This distinction matters: a cubin passed to `cuModuleLoadData` or `cuLinkAddData` legitimately contains NUL bytes, so it must not be rejected for holding them.

All 24 combinations above now raise `TypeError`.

## `cuLinkAddData` ignored its name argument

Noticed while fixing the lines above:

```c
rb_cuLinkAddData(VALUE self, VALUE state, VALUE type, VALUE data, VALUE name)
{
    void* _data = (void *)RSTRING_PTR(data);
    size_t _size = RSTRING_LEN(data);
    const char* _name = RSTRING_PTR(data);   // <- data, not name
```

`name` was never read, and the entire PTX blob stood in for it. `LinkState#add_ptr_data(data, name)` has always taken a name and had it silently discarded. The name is what `cuLinkAddData` labels the input with in JIT diagnostics, so this now passes the name it was asked for.

I could not make the difference observable from Ruby: the JIT error log needs `CU_JIT_ERROR_LOG_BUFFER`, and options are still the `TODO(sonots): Support options` in this file. So this rests on reading the call rather than on a reproduction — it is a plainly unused parameter either way.

## RB_GC_GUARD

The converted pointers stay live across `rb_thread_call_without_gvl`, so the values are guarded past their last use. Conservative stack marking already covers them in practice; this is to keep it that way rather than a fix for an observed failure.

## Tests

`test/cuda/driver_test.rb` gains the type checks and a `LinkState` round trip (compile PTX with NVRTC → `cuLinkAddData` → `cuLinkComplete` → `cuModuleLoadData` → `cuModuleGetGlobal`), which had no coverage at all.

| test | without the fix |
|---|---|
| `test_string_arguments_are_type_checked` | **SIGSEGV** |
| `test_link_state_arguments_are_type_checked` | **SIGSEGV** |
| `test_link_state_round_trip` | passes — guards the change |

`rake test` 855 tests / 10781 assertions / 0 failures, `rake ctest` clean.

Follows #178, which fixed the same class of omission in `nvrtc.c`.
