### PR TITLE
Fix missing range check on NArray indices

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -147,11 +147,11 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
 static void
 cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
 {
-    VALUE idx;
+    VALUE idx, buf;
     cumo_narray_t *na;
     cumo_narray_data_t *nidx;
-    size_t n;
-    ssize_t *nidxp;
+    size_t k, n;
+    ssize_t *nidxp, *host_idx;
 
     CumoGetNArray(a,na);
     if (CUMO_NA_NDIM(na) != 1) {
@@ -170,12 +170,27 @@ cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_ar
 
     CumoGetNArrayData(idx,nidx);
     nidxp   = (ssize_t*)nidx->ptr; // Cumo::NArray data resides on GPU
-    //q->idx  = ALLOC_N(size_t, n);
-    //for (k=0; k<n; k++) {
-    //    q->idx[k] = na_range_check(nidxp[k], size, orig_dim);
-    //}
+
+    // Check the indices on the host, as cumo_na_parse_array() does: a kernel
+    // could neither raise IndexError nor rewrite a negative index into the
+    // element it denotes. Copy them rather than read the managed memory in
+    // place -- "synchronize, then touch it from the host" is what breaks under
+    // Ractor (sonots/cumo#180), where only the GVL made it atomic. The buffer
+    // is a String so the raise below cannot leak it.
+    buf = rb_str_tmp_new((long)(sizeof(ssize_t)*n));
+    host_idx = (ssize_t*)RSTRING_PTR(buf);
+    cumo_cuda_runtime_check_status(
+        cudaMemcpy(host_idx,nidxp,sizeof(ssize_t)*n,cudaMemcpyDeviceToHost));
+    for (k=0; k<n; k++) {
+        // A checked index is non-negative, so it is already a valid size_t.
+        host_idx[k] = cumo_na_range_check(host_idx[k], size, orig_dim);
+    }
+
     q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-    cumo_cuda_runtime_check_status(cudaMemcpyAsync(q->idx,nidxp,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
+    cumo_cuda_runtime_check_status(
+        cudaMemcpyAsync(q->idx,host_idx,sizeof(size_t)*n,cudaMemcpyHostToDevice,0));
+    RB_GC_GUARD(buf);
+    RB_GC_GUARD(idx);
 
     q->n    = n;
     q->beg  = 0;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1118,6 +1118,74 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  # cumo_na_parse_narray_index() copied an NArray index straight to the device
+  # with no bounds check, so an out-of-range index read out of bounds and a
+  # negative one -- which is an ordinary way to index -- became a huge size_t
+  # and segfaulted. Every case below is written twice, once for [] and once for
+  # at(): they share cumo_na_parse_narray_index(), so one fix closes both, and
+  # without both a later at_mode branch could reopen one of them unnoticed.
+  #
+  # Passing here is not the same as being in bounds: the memory pool rounds
+  # allocations up, so a small out-of-range read used to land inside the same
+  # chunk and quietly return a value.
+  test "an out-of-range NArray index raises" do
+    a = Cumo::DFloat.new(4).seq
+    v = Cumo::DFloat.new(8).seq[0..3]
+
+    [a, v].each do |x|
+      [Cumo::Int32, Cumo::Int64].each do |itype|
+        assert_raise(IndexError) { x[itype[4]] }
+        assert_raise(IndexError) { x[itype[9999]] }
+        assert_raise(IndexError) { x[itype[0, 4]] }
+        assert_raise(IndexError) { x.at(itype[4]) }
+        assert_raise(IndexError) { x.at(itype[9999]) }
+      end
+      assert_raise(IndexError) { x[Cumo::Int64[1 << 40]] }
+      assert_raise(IndexError) { x.at(Cumo::Int64[1 << 40]) }
+    end
+  end
+
+  test "a negative NArray index counts from the end" do
+    a = Cumo::DFloat.new(4).seq
+    v = Cumo::DFloat.new(8).seq[0..3]
+
+    [a, v].each do |x|
+      assert { x[Cumo::Int32[-1]] == [3] }
+      assert { x[Cumo::Int32[-4]] == [0] }
+      assert { x[Cumo::Int32[-1, -2]] == [3, 2] }
+      assert { x.at(Cumo::Int32[-1]) == [3] }
+      # same index as a Ruby Array, which was always checked
+      assert { x[Cumo::Int32[-1]] == x[[-1]] }
+      assert { x.at(Cumo::Int32[-1]) == x.at([-1]) }
+      # one past the end going backwards
+      assert_raise(IndexError) { x[Cumo::Int32[-5]] }
+      assert_raise(IndexError) { x.at(Cumo::Int32[-5]) }
+    end
+  end
+
+  test "an NArray index is checked in every dimension" do
+    a = Cumo::DFloat.new(3, 4).seq
+
+    assert { a[Cumo::Int32[0, 2], Cumo::Int32[1, 3]] == [[1, 3], [9, 11]] }
+    assert { a[Cumo::Int32[-1], Cumo::Int32[-1]] == [[11]] }
+    assert_raise(IndexError) { a[Cumo::Int32[3], Cumo::Int32[0]] }
+    assert_raise(IndexError) { a[Cumo::Int32[0], Cumo::Int32[4]] }
+    assert_raise(IndexError) { a[Cumo::Int32[0], Cumo::Int32[-5]] }
+    assert { a.at(Cumo::Int32[0, 2], Cumo::Int32[1, 3]) == [1, 11] }
+    assert_raise(IndexError) { a.at(Cumo::Int32[0, 3], Cumo::Int32[0, 0]) }
+  end
+
+  test "indexing by a Bit array is unaffected by the range check" do
+    # A Bit index goes through where(), whose result is in range by
+    # construction, so the check must not reject it.
+    a = Cumo::DFloat.new(6).seq
+
+    assert { a[a > 2.0] == [3, 4, 5] }
+    assert { a[a.eq(0.0)] == [0] }
+    assert { a[a > 99.0].size == 0 }
+    assert { a[Cumo::Bit[1, 0, 1, 0, 1, 0]] == [0, 2, 4] }
+  end
+
   test "indexing by an array does not leak host memory" do
     # The index list was staged in pinned host memory released from a CUDA
     # stream callback, but a callback may not call the CUDA API: cudaFreeHost


### PR DESCRIPTION
`cumo_na_parse_narray_index()` copies the caller's indices straight to the device with no bounds check. The `na_range_check()` call numo makes there is still in the file, commented out above the `cudaMemcpyAsync` that replaced it:

```c
//q->idx  = ALLOC_N(size_t, n);
//for (k=0; k<n; k++) {
//    q->idx[k] = na_range_check(nidxp[k], size, orig_dim);
//}
q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
cumo_cuda_runtime_check_status(cudaMemcpyAsync(q->idx,nidxp,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
```

Nothing downstream compensates. `index_kernel.cu:10` multiplies the index by a stride, and for an index-backed view `:17` subscripts another device buffer with it (`idx[i] = idx1[idx[i]]`); neither kernel checks anything.

## What it does

Measured on master `e68e392`, RTX 5070 Ti, with `a = Cumo::DFloat.new(4).seq`:

| expression | result | | expression | result |
|---|---|---|---|---|
| `a[Cumo::Int32[-1]]` | **SEGV** | | `a[[-1]]` | `[3.0]` |
| `a[Cumo::Int64[1<<40]]` | **SEGV** | | `a[[9999]]` | `IndexError` |
| `a[Cumo::Int32[9999]]` | passes | | `a[[4]]` | `IndexError` |

`at()` behaves identically, in both columns.

**The negative index is the one that matters most.** Counting from the end is an ordinary way to index, and `na_range_check` is what turns `-1` into the element it denotes. So writing the same index as an NArray does not merely skip a check — `-1` reaches the device as a `size_t` and the read lands eight bytes below the allocation.

A larger array segfaults on the index exactly one past the end:

```ruby
n = 1_000_000
b = Cumo::DFloat.new(n).fill(1.0)
b[Cumo::Int32[n]]   # => SEGV, with CUMO_MEMORY_POOL on and off alike
```

Small arrays hide it: indices 4 through 12 into a 4-element array all returned `0.0`, because the memory pool rounds allocations up and the read stays inside the same chunk. A case that does not crash is not a case that is in bounds.

numo-narray 0.11.0 gets both right (`[3.0]` and `IndexError`), so this entered with the CUDA port rather than coming from numo.

## The fix

The neighbouring `cumo_na_parse_array()` — the Ruby Array path — shows this was a slip rather than a decision. It carries the same commented-out block, but still checks on the host before copying up. This change does the same for the NArray path: copy the indices back, check them, copy the checked ones up.

The check cannot move into a kernel: it has to raise `IndexError`, and it has to rewrite a negative index.

Reading the indices from the host without copying would also work — every cumo allocation is `cudaMallocManaged` — and `index.c:1089` already does exactly that. It is deliberately not used here. "Synchronize, then touch managed memory from the host" is the pattern behind the Ractor corruption in #180, where the sequence was atomic only because the GVL serialized it; the existing site carries a `CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE` for the same reason. An explicit copy does not depend on where the data currently lives, and that independence is what the round trip buys.

`at()` shares this parser, so it had the same hole and the same change closes it. Note that #161 only rejects `:new` in `at()`; it does nothing for out-of-range indices.

## Scope

Three sweeps were run to check whether the same omission exists elsewhere. It does not.

1. **Fossils.** cumo leaves numo's host loops commented out above the device code that replaced them, so those comments mark the places where porting changed behaviour. `index.c:118/173/565/608/668`, `data.c:524/540/773/788/802`, `narray.c:1067/1209`, `struct.c:150` — `:173` is the only one where a check was dropped. The rest are plain index copies or allocate-only sites with no check in numo either.
2. **Raise-message diff against numo-narray-alt's `index.c`.** The only genuinely missing raises belong to an already-queued upstream fix. `the number of argument must be same as dimension` is not missing — `check_index_count` (`index.c:1014`) checks it with different wording.
3. **The same diff widened to every `.c` file**, with a DOTALL match so multi-line `rb_raise(cls,\n "msg")` calls are not skipped. Six alt-only messages, all accounted for by upstream PRs already queued for backport or by module naming.

Neither sweep would catch a check deleted without leaving a comment, or one that clamped instead of raising, so this bounds the scope rather than proving absence.

`index.c:615` reads `strides_na1[q[i].orig_dim]` unguarded, but is unreachable: #161 rejects `:new` and `:minus` in `at_mode`, and `at()` requires one index per dimension, so `orig_dim < ndim` always holds.

## Cost

A Bit index (`a[a > 0]`) goes through `where()`, whose result is in range by construction, and it now pays the round trip anyway. Skipping the check on that path is possible — the Bit array's size is already verified against the dimension at `index.c:161` — but it is left for later on purpose: this defect exists precisely because two index paths were treated differently, so reintroducing a split needs its own justification recorded next to it.

## Tests

`test/narray_test.rb` gains four cases: out-of-range rejection, negative-index normalization (including parity with the Ruby Array path), per-dimension checking on a 2-d array, and confirmation that Bit indexing still works.

Every case is written twice, once for `[]` and once for `at()`. They share `cumo_na_parse_narray_index()`, so one fix closes both — which is exactly why testing only one would let a future `at_mode` branch reopen the other unnoticed.

Full suite: 859 tests, 10832 assertions, 0 failures, 0 errors.
