### PR TITLE
Raise TypeError when store_binary receives a non-String

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1409,6 +1409,7 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
     cumo_narray_t *na;
 
     narg = rb_scan_args(argc,argv,"11",&vstr,&voffset);
+    Check_Type(vstr,T_STRING);
     str_len = RSTRING_LEN(vstr);
     if (narg==2) {
         offset = NUM2SIZET(voffset);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -817,6 +817,23 @@ class NArrayTest < Test::Unit::TestCase
         assert { restored_a != a }
         assert { data == original_data }
       end
+
+      test "string with offset" do
+        a = dtype.new(2)
+        a.rand(0, 10)
+        b = dtype.new(1)
+        b.store_binary(a.to_binary, dtype::ELEMENT_BYTE_SIZE)
+        assert { b == a[1..1] }
+      end
+
+      test "non-string argument" do
+        a = dtype.new(2)
+        # RSTRING_PTR() on a non-String reads whatever the object's layout
+        # happens to hold there, so these used to segfault or store garbage.
+        [nil, 123, 1.5, :sym, {}, [0x7fffffff, 0x1234].freeze, /abc/].each do |bad|
+          assert_raise(TypeError) { a.store_binary(bad) }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
`NArray#store_binary` passed its first argument straight to `RSTRING_LEN()` and `RSTRING_PTR()` without checking its type.
For a non-String those macros read whatever the object's layout happens to hold at the same offsets, so the outcome depended on the class — and none of the three outcomes was an error the caller could act on:

```ruby
Cumo::DFloat.new(2).store_binary(nil)    # => SEGV (fault at 0x14)
Cumo::DFloat.new(2).store_binary(/abc/)  # => no exception; the array now
                                         #    holds [6.9e-310, 0.0], a heap
                                         #    pointer word read as a double
Cumo::DFloat.new(2).store_binary({})     # => ArgumentError "string is too
                                         #    short to store" — not a guard,
                                         #    just the struct layout by luck
```

`nil`, Integer, Float, Symbol, Array and Regexp all reached the copy. The frozen-string path is the worse one of the two: it hands `RSTRING_PTR()` to `cumo_na_set_pointer()`, so the array keeps pointing into the foreign object after the call returns.

The sibling `from_binary` has had the corresponding check since it was written (`narray.c:1339`), so this was an asymmetry rather than a deliberate omission.

## Fix

Add `Check_Type(vstr, T_STRING)` right after `rb_scan_args()`. Every non-String argument now raises `TypeError` before any pointer is taken.

## Tests

Added to the existing `#{dtype}#store_binary` sub test case, so they run for all 12 element types:

- **non-string argument** — `nil`, `123`, `1.5`, `:sym`, `{}`, a frozen Array and a Regexp each raise `TypeError`. The frozen Array covers the copy-on-write branch specifically.
- **string with offset** — positive control for the two-argument form, which had no test before.

Verified on real hardware (RTX A4000, CUDA 13.0): all seven arguments segfault or corrupt data before the patch and raise `TypeError` after it, while the plain, offset and frozen String paths keep working. Full suite: 883 tests, 10928 assertions, 0 failures.

## Reference

Backport of [yoshoku/numo-narray-alt#14](https://github.com/yoshoku/numo-narray-alt/pull/14). The upstream fix is the same single line; the tests here are adapted to cumo's test-unit style and dtype loop.
