### PR TITLE
Raise ArgumentError for invalid reshape dimension values

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -361,7 +361,16 @@ cumo_na_check_reshape(int argc, VALUE *argv, VALUE self, size_t *shape)
     for (i=0; i<argc; ++i) {
         switch(TYPE(argv[i])) {
         case T_FIXNUM:
-            total *= shape[i] = NUM2INT(argv[i]);
+            {
+                ssize_t x = NUM2SSIZET(argv[i]);
+                if (x < 0) {
+                    rb_raise(rb_eArgError, "size must be non-negative");
+                }
+                if (x != 0 && total > SIZE_MAX / (size_t)x) {
+                    rb_raise(rb_eArgError, "total size is too large");
+                }
+                total *= shape[i] = (size_t)x;
+            }
             break;
         case T_NIL:
         case T_TRUE:
@@ -376,6 +385,9 @@ cumo_na_check_reshape(int argc, VALUE *argv, VALUE self, size_t *shape)
     }
 
     if (unfixed>=0) {
+        if (total == 0) {
+            rb_raise(rb_eArgError, "cannot determine unfixed dimension when total size is zero");
+        }
         if (CUMO_NA_SIZE(na) % total != 0) {
             rb_raise(rb_eArgError, "Total size size must be divisor");
         }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -842,6 +842,42 @@ class NArrayTest < Test::Unit::TestCase
     assert { Cumo::NArray.cast(object) == [1, 2, 3] }
   end
 
+  sub_test_case "reshape argument validation" do
+    test "a negative size raises" do
+      # A negative size used to be cast to size_t, so reshape(-2, -3) produced
+      # a shape of [2**64-2, 2**64-3] whose product wraps back to 6 and passes
+      # the "total size must be same" check.
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape(-2, -3) }
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape(2, -3) }
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape(-6) }
+      assert_raise(ArgumentError) { Cumo::DFloat.new(1).seq.reshape(-1, -1) }
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape!(-2, -3) }
+    end
+
+    test "a zero total with an unfixed dimension raises" do
+      # The unfixed dimension is solved by dividing by the total, so a zero
+      # total used to reach a division by zero and abort with SIGFPE.
+      assert_raise(ArgumentError) { Cumo::Int32[1, 2, 3].reshape(0, nil) }
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape(0, true) }
+    end
+
+    test "an overflowing total raises" do
+      # 2**30 * 2**30 * 16 is 2**64, which wraps to a total of zero.
+      assert_raise(ArgumentError) { Cumo::DFloat.new(6).seq.reshape(2**30, 2**30, 16, nil) }
+    end
+
+    test "a valid reshape is unaffected" do
+      a = Cumo::DFloat.new(6).seq
+      assert { a.reshape(2, 3).shape == [2, 3] }
+      assert { a.reshape(2, nil).shape == [2, 3] }
+      assert { a.reshape(nil, 3).shape == [2, 3] }
+      assert { a.reshape(6).to_a == [0, 1, 2, 3, 4, 5] }
+      assert_raise(ArgumentError) { a.reshape(4, nil) }
+      assert_raise(ArgumentError) { a.reshape(nil, nil) }
+      assert_raise(ArgumentError) { a.reshape(0, 6) }
+    end
+  end
+
   test "Cumo::DFloat.cast(Cumo::RObject[1, nil, 3])" do
     assert_equal(Cumo::DFloat[1, Float::NAN, 3].format_to_a,
                  Cumo::DFloat.cast(Cumo::RObject[1, nil, 3]).format_to_a)


### PR DESCRIPTION
`cumo_na_check_reshape()` read each fixnum argument with `NUM2INT()` and stored it straight into a `size_t` shape, with no check on the value and no check on the running product.
Three kinds of invalid input got through:

```ruby
a = Cumo::DFloat.new(6).seq

a.reshape(-2, -3)                 # => no exception; shape is
                                  #    [18446744073709551614, 18446744073709551613]
a.reshape(0, nil)                 # => SIGFPE (exit 136)
a.reshape(2**30, 2**30, 16, nil)  # => SIGFPE (exit 136)
```

- **Negative sizes.** `-2` becomes `2**64-2` as a `size_t`. The product of the wrapped values wraps back to `6`, so the `"Total size must be same"` check passes and the reshape succeeds. This is the one that survives the call: `a.reshape!(-2, -3)` leaves the array itself with that shape, `a.size` still reports `6`, and later operations keep computing from it (`a.sum` still returns `15`, `p a` prints `Cumo::DFloat#shape=[]`).
- **Zero total with an unfixed dimension.** The unfixed dimension is solved as `NA_SIZE(na) % total` / `NA_SIZE(na) / total`, so `total == 0` divides by zero and the process dies on SIGFPE — no Ruby-level exception to rescue.
- **Overflowing total.** `2**30 * 2**30 * 16` is exactly `2**64`, which wraps to `0` and lands in the same division by zero.

## Fix

In the `T_FIXNUM` branch, read with `NUM2SSIZET()`, reject negative values, and test `total > SIZE_MAX / x` before multiplying. Separately, refuse to solve an unfixed dimension when the total is zero.

## Incompatibility

A size above `INT_MAX` used to raise `RangeError` from `NUM2INT()`:

```ruby
Cumo::DFloat.new(6).seq.reshape(2**40)
# before: RangeError: integer 1099511627776 too big to convert to 'int'
# after:  ArgumentError: Total size must be same
```

`NUM2SSIZET()` accepts the value, so the size check rejects it instead. This matches upstream and is the same class of error for the same mistake.

## Tests

Added a `reshape argument validation` sub test case:

- **a negative size raises** — five forms including `reshape!`, so the in-place path is covered too
- **a zero total with an unfixed dimension raises** — `reshape(0, nil)` and `reshape(0, true)`
- **an overflowing total raises** — `reshape(2**30, 2**30, 16, nil)`
- **a valid reshape is unaffected** — positive control: explicit shapes, both unfixed-dimension forms, and the three `ArgumentError`s that were already correct (`reshape(4, nil)`, `reshape(nil, nil)`, `reshape(0, 6)`)

Verified on real hardware (RTX A4000, CUDA 13.0): each invalid form is accepted or aborts on SIGFPE before the patch and raises `ArgumentError` after it. Full suite: 887 tests, 10943 assertions, 0 failures.

## Reference

Backport of [yoshoku/numo-narray-alt#15](https://github.com/yoshoku/numo-narray-alt/pull/15). `na_check_reshape` is pure shape arithmetic and never touches device memory, so the C change is upstream's verbatim; the tests are adapted to cumo's test-unit style.
