### PR TITLE
Fix a SIGFPE on fractional range steps and an out-of-bounds read on newaxis

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -209,7 +209,13 @@ cumo_na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, cumo_
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
     rb_arithmetic_sequence_components_t x;
     rb_arithmetic_sequence_extract(range, &x);
+    if (!RB_INTEGER_TYPE_P(x.step)) {
+        rb_raise(rb_eArgError, "step must be an Integer");
+    }
     step = NUM2SSIZET(x.step);
+    if (step == 0) {
+        rb_raise(rb_eArgError, "step must not be zero");
+    }
 
     beg = beg_orig = NUM2SSIZET(x.begin);
     if (beg < 0) {

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -471,13 +471,18 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
     cumo_na_get_strides_nadata(na1, strides_na1, elmsz);
 
     for (i=j=0; i<ndim; i++) {
-        stride1 = strides_na1[q[i].orig_dim];
+        const int orig_dim = q[i].orig_dim;
+        stride1 = 0;
 
-        // numeric index -- trim dimension
-        if (!keep_dim && q[i].n==1 && q[i].step==0) {
-            beg  = q[i].beg;
-            na2->offset += stride1 * beg;
-            continue;
+        if (orig_dim < na1->base.ndim) {
+            stride1 = strides_na1[orig_dim];
+
+            // numeric index -- trim dimension
+            if (!keep_dim && q[i].n==1 && q[i].step==0) {
+                beg  = q[i].beg;
+                na2->offset += stride1 * beg;
+                continue;
+            }
         }
 
         na2->base.shape[j] = size = q[i].n;
@@ -487,8 +492,12 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
             na2->base.reduce = rb_funcall(m,'|',1,na2->base.reduce);
         }
 
+        if (orig_dim >= na1->base.ndim) {
+            // new dimension
+            CUMO_SDX_SET_STRIDE(na2->stridx[j], elmsz);
+        }
         // array index
-        if (q[i].idx != NULL) {
+        else if (q[i].idx != NULL) {
             index = q[i].idx;
             CUMO_SDX_SET_INDEX(na2->stridx[j],index);
             q[i].idx = NULL;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1239,6 +1239,23 @@ class NArrayTest < Test::Unit::TestCase
     assert { a[Cumo::Bit[1, 0, 1, 0, 1, 0]] == [0, 2, 4] }
   end
 
+  test "a non-Integer step raises" do
+    # cumo_na_parse_range() took the step through NUM2SSIZET(), which truncates
+    # a Float, and then divided by it: a step under 1 truncated to 0 and killed
+    # the process with SIGFPE, which Ruby cannot rescue, while a step above 1
+    # was silently truncated and walked with a step the caller never asked for.
+    a = Cumo::DFloat.new(10).seq
+
+    assert_raise(ArgumentError) { a[(0..9).step(0.5)] }
+    assert_raise(ArgumentError) { a[(0..9).step(1.5)] }
+    assert_raise(ArgumentError) { a[(0..9) % 0.5] }
+    assert_raise(ArgumentError) { a.at((0..9).step(0.5)) }
+
+    assert { a[(0..9).step(2)] == [0, 2, 4, 6, 8] }
+    assert { a[(0..9) % 3] == [0, 3, 6, 9] }
+    assert { a[9.step(0, -2)] == [9, 7, 5, 3, 1] }
+  end
+
   test "indexing by an array does not leak host memory" do
     # The index list was staged in pinned host memory released from a CUDA
     # stream callback, but a callback may not call the CUDA API: cudaFreeHost

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1256,6 +1256,29 @@ class NArrayTest < Test::Unit::TestCase
     assert { a[9.step(0, -2)] == [9, 7, 5, 3, 1] }
   end
 
+  test "a new axis on a data array does not read past the strides" do
+    # cumo_na_index_aref_nadata() indexes an ALLOCA_N buffer of exactly
+    # base.ndim entries with q[i].orig_dim, and a trailing :new leaves
+    # orig_dim == base.ndim (cumo_na_index_parse_args() advances j but not k
+    # for :new). The view path got this guard in #160; the data path, which is
+    # where a plain NArray is routed, did not. The read was 8 bytes past the
+    # end and nothing observable depended on it -- the value became the stride
+    # of a size-1 dimension whose only index is zero -- so the results below
+    # were already correct. They pin the behaviour the guard has to preserve.
+    a = Cumo::DFloat.new(4).seq
+    assert { a[true, :new].shape == [4, 1] }
+    assert { a[true, :new].to_a == [[0], [1], [2], [3]] }
+    assert { a[:new, true].shape == [1, 4] }
+    assert { a[:new, true].to_a == [[0, 1, 2, 3]] }
+
+    b = Cumo::DFloat.new(2, 3).seq
+    assert { b[true, true, :new].shape == [2, 3, 1] }
+    assert { b[true, true, :new].to_a == [[[0], [1], [2]], [[3], [4], [5]]] }
+
+    v = Cumo::DFloat.new(6).seq[0..3]
+    assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
+  end
+
   test "indexing by an array does not leak host memory" do
     # The index list was staged in pinned host memory released from a CUDA
     # stream callback, but a callback may not call the CUDA API: cudaFreeHost


### PR DESCRIPTION
Two independent defects in `index.c`, one commit each, both backported from [yoshoku/numo-narray-alt#17](https://github.com/yoshoku/numo-narray-alt/pull/17).

Upstream's third commit (`c3dfa20`, checking the type of `where()`'s result) does not apply here: cumo has no such `rb_bug` guard to fix. `cumo_na_parse_narray_index()` takes `nidx` from a freshly built `cumo_na_new(cIndex, ...)` (`index.c:168-171`), which is always `DATA_T`, and gates the Bit path on `rb_obj_class(a) == cumo_cBit` (`:160`), which a Bit *view* satisfies. The difference is structural — upstream's fast path that reads the caller's array directly was replaced in cumo by `cumo_na_new` + `cumo_na_store`.

## 1. Reject a non-Integer or zero step in range indexing

`cumo_na_parse_range()` read the step of a Range or ArithmeticSequence index with `NUM2SSIZET()`, which truncates a Float, and then divided by it at `index.c:265`:

```ruby
a = Cumo::DFloat.new(10).seq

a[(0..9).step(0.5)]        # => SIGFPE (exit 136)
a[(0..9) % 0.5]            # => SIGFPE (exit 136)
a.at((0..9).step(0.5))     # => SIGFPE (exit 136)

a[(0..9).step(1.5)].to_a   # => all ten elements — silently walked with step 1
```

A step under 1 truncates to zero and divides by zero, which aborts the process rather than raising something the caller can rescue. A step above 1 is silently truncated to a step the caller never asked for.

Rejecting a non-Integer step covers both. The zero check is separate and defensive: Ruby rejects `Range#step(0)` before we see it, but the division depends on the invariant and nothing guarantees every path into this function preserves it.

## 2. Bound-check `orig_dim` on the data-array indexing path

`cumo_na_index_aref_naview()` got this check in #160; the symmetric data-array path did not. `cumo_na_index_aref_nadata()` indexes an `ALLOCA_N` buffer of exactly `base.ndim` entries with `q[i].orig_dim`, and a trailing newaxis makes the two equal: `cumo_na_index_parse_args()` advances `j` but not `k` for `:new` (`index.c:420-423`), so the new axis inherits the `k` of the dimension past the end. `cumo_na_aref_md()` routes a plain (non-view) NArray here, so the view guard never covers it.

The most ordinary newaxis expression reads eight bytes past the buffer:

```ruby
Cumo::DFloat.new(4).seq[true, :new]
```

Instrumenting the read confirms it: `strides_na1[1]` out of a one-entry buffer, and the existing test suite already reaches it **136 times**. Nothing observable depends on the value — it becomes the stride of a size-1 dimension whose only index is zero — so results were already correct and Valgrind stays silent (memcheck reports an uninitialised value only once it reaches a branch, a syscall or an address computation).

This is the remaining half of a problem cumo already knew about. The comment at `index.c:930-933`, added in #161, describes the same root cause for `at()`, which resolves it by rejecting `:new` outright.

## Tests

- **a non-Integer step raises** — the three SIGFPE forms and the silently-truncated one, plus a positive control that integer steps (including a negative one via `9.step(0, -2)`) still work.
- **a new axis on a data array does not read past the strides** — 1-d and 2-d, leading and trailing `:new`, and the view path for contrast. These pin behaviour that was already correct, since the fix is not supposed to change any result.

Verified on real hardware (RTX A4000, CUDA 13.0). After the fix, re-instrumenting shows the same call sites taking the guarded branch **140 times** (136 existing + 4 from the new tests) instead of reading past the buffer, with every result unchanged. Full suite: 889 tests, 10957 assertions, 0 failures.
