### PR TITLE
Hold the pool lock across the chunk graph and guard pools_

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -143,15 +143,22 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
             // TODO(sonots): compact_index
             break;
         }
+
+        // Splitting rewrites the prev/next pointers of the neighbouring
+        // chunks, which other threads reach through the free lists, so it has
+        // to happen under the same lock as the search above.
+        if (chunk != nullptr) {
+            std::shared_ptr<Chunk> remaining = Split(chunk, size);
+            if (remaining != nullptr) {
+                AppendToFreeList(remaining->size(), remaining, stream_ptr);
+            }
+        }
     }
 
-    if (chunk != nullptr) {
-        std::shared_ptr<Chunk> remaining = Split(chunk, size);
-        if (remaining != nullptr) {
-            AppendToFreeList(remaining->size(), remaining, stream_ptr);
-        }
-    } else {
-        // cudaMalloc if a cache is not found
+    if (chunk == nullptr) {
+        // cudaMalloc if a cache is not found. This stays outside the lock: it
+        // is slow, and a chunk of a fresh allocation has no neighbours for
+        // another thread to reach it through.
         std::shared_ptr<Memory> mem = nullptr;
         try {
             mem = std::make_shared<Memory>(size);
@@ -189,9 +196,20 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
 bool SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
     std::shared_ptr<Chunk> chunk = nullptr;
 
-    {
-        std::lock_guard<std::recursive_mutex> lock{mutex_};
+    // The whole body runs under the lock. Walking prev/next and merging is a
+    // read-modify-write of the chunk graph, which is shared: a neighbour can
+    // be split by a concurrent Malloc while this reads its prev/next.
+    //
+    // The lost merge is the part that shows: two threads freeing neighbouring
+    // chunks each look for the other in the free list before the other has
+    // appended itself, so both merges fail and the two chunks stay split for
+    // good. Fragmentation accumulates from there.
+    //
+    // mutex_ is recursive, so the RemoveFromFreeList/AppendToFreeList calls
+    // below can take it again.
+    std::lock_guard<std::recursive_mutex> lock{mutex_};
 
+    {
         // find rather than operator[], which would insert an empty entry for
         // every pointer this pool does not own.
         auto it = in_use_.find(ptr);

--- a/ext/cumo/cuda/memory_pool_impl.hpp
+++ b/ext/cumo/cuda/memory_pool_impl.hpp
@@ -304,6 +304,20 @@ private:
     }
 
     std::unordered_map<int, SingleDeviceMemoryPool> pools_;
+    std::mutex pools_mutex_;
+
+    // Returns the pool of the current device, creating it on first use.
+    //
+    // The lock only has to cover the lookup: pools_ is never erased from
+    // before destruction, and unordered_map keeps references to its elements
+    // valid across a rehash, so the returned reference outlives the lock.
+    // Without it, the insert operator[] performs on first use could rehash the
+    // map underneath another thread walking it.
+    SingleDeviceMemoryPool& GetPool() {
+        int id = device_id();  // a CUDA call, so keep it out of the lock
+        std::lock_guard<std::mutex> lock{pools_mutex_};
+        return pools_[id];  // find or create
+    }
 
 public:
     MemoryPool() {}
@@ -318,8 +332,7 @@ public:
     // Returns:
     //     intptr_t: Pointer address to the allocated buffer.
     intptr_t Malloc(size_t size, cudaStream_t stream_ptr = 0) {
-        auto& mp = pools_[device_id()];
-        return mp.Malloc(size, stream_ptr);
+        return GetPool().Malloc(size, stream_ptr);
     }
 
     // Frees the memory, to the pool
@@ -331,22 +344,34 @@ public:
     //     bool: false if no pool allocated the pointer, in which case nothing
     //           was freed and the caller has to free it by its own means.
     bool Free(intptr_t ptr, cudaStream_t stream_ptr = 0) {
-        if (pools_.empty()) {  // nothing has ever been allocated from a pool
-            return false;
-        }
         int current_device_id = device_id();
-        auto it = pools_.find(current_device_id);
-        if (it != pools_.end() && it->second.Free(ptr, stream_ptr)) {
+
+        // Take the pointers out under the lock and release it before freeing:
+        // an element of pools_ stays put once inserted, so the pointers remain
+        // valid, and this keeps a Free of one device's pool from blocking a
+        // Malloc on another. `others` does not allocate in the usual
+        // single-device case, where it stays empty.
+        SingleDeviceMemoryPool* current = nullptr;
+        std::vector<SingleDeviceMemoryPool*> others;
+        {
+            std::lock_guard<std::mutex> lock{pools_mutex_};
+            for (auto& entry : pools_) {
+                if (entry.first == current_device_id) {
+                    current = &entry.second;
+                } else {
+                    others.emplace_back(&entry.second);
+                }
+            }
+        }
+
+        if (current != nullptr && current->Free(ptr, stream_ptr)) {
             return true;
         }
         // The current device may have been switched since the allocation.
         // cudaMallocManaged hands out addresses which are unique across the
         // host and every device, so the pointer identifies its pool on its own.
-        for (auto& entry : pools_) {
-            if (entry.first == current_device_id) {
-                continue;
-            }
-            if (entry.second.Free(ptr, stream_ptr)) {
+        for (SingleDeviceMemoryPool* mp : others) {
+            if (mp->Free(ptr, stream_ptr)) {
                 return true;
             }
         }
@@ -355,8 +380,7 @@ public:
 
     // Free all **non-split** chunks in all arenas
     void FreeAllBlocks() {
-        auto& mp = pools_[device_id()];
-        return mp.FreeAllBlocks();
+        return GetPool().FreeAllBlocks();
     }
 
     // Free all **non-split** chunks in specified arena
@@ -364,8 +388,7 @@ public:
     // Args:
     //     stream_ptr (cudaStream_t): Release free blocks in the arena of given stream
     void FreeAllBlocks(cudaStream_t stream_ptr) {
-        auto& mp = pools_[device_id()];
-        return mp.FreeAllBlocks(stream_ptr);
+        return GetPool().FreeAllBlocks(stream_ptr);
     }
 
     // Count the total number of free blocks.
@@ -373,8 +396,7 @@ public:
     // Returns:
     //     size_t: The total number of free blocks.
     size_t GetNumFreeBlocks() {
-        auto& mp = pools_[device_id()];
-        return mp.GetNumFreeBlocks();
+        return GetPool().GetNumFreeBlocks();
     }
 
     // Get the total number of bytes used.
@@ -382,8 +404,7 @@ public:
     // Returns:
     //     size_t: The total number of bytes used.
     size_t GetUsedBytes() {
-        auto& mp = pools_[device_id()];
-        return mp.GetUsedBytes();
+        return GetPool().GetUsedBytes();
     }
 
     // Get the total number of bytes acquired but not used in the pool.
@@ -391,8 +412,7 @@ public:
     // Returns:
     //     size_t: The total number of bytes acquired but not used in the pool.
     size_t GetFreeBytes() {
-        auto& mp = pools_[device_id()];
-        return mp.GetFreeBytes();
+        return GetPool().GetFreeBytes();
     }
 
     // Get the total number of bytes acquired in the pool.
@@ -400,8 +420,7 @@ public:
     // Returns:
     //     size_t: The total number of bytes acquired in the pool.
     size_t GetTotalBytes() {
-        auto& mp = pools_[device_id()];
-        return mp.GetTotalBytes();
+        return GetPool().GetTotalBytes();
     }
 };
 

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -1,8 +1,12 @@
 #include "memory_pool_impl.hpp"
 
+#include <atomic>
 #include <cassert>
+#include <cstring>
 #include <memory>
 #include <iostream>
+#include <thread>
+#include <vector>
 
 // TODO(sonots): Use googletest?
 // TODO(sonots): Provide clean way to build this test outside extconf.rb
@@ -620,6 +624,95 @@ public:
     }
 };
 
+// The pool is reachable from several threads at once: cumo.c declares the
+// extension Ractor-safe, and a Ractor does not hold the GVL that serializes
+// ordinary Ruby threads.
+class TestConcurrency {
+private:
+    static const int kThreads = 8;
+    static const int kRounds = 400;
+    static const int kPerThread = 8;
+
+public:
+    void Run() {
+        TestConcurrentSplitAndMerge();
+        TestConcurrentPools();
+    }
+
+    // Chunks are only neighbours when they were Split from a common
+    // allocation, so prime the pool with one large free chunk: every Malloc
+    // below splits off it, and each thread then frees chunks sitting next to
+    // chunks other threads still hold. That is the state Free walks over.
+    void TestConcurrentSplitAndMerge() {
+        SingleDeviceMemoryPool pool;
+        const size_t total = size_t{kRoundSize} * kThreads * kPerThread * 2;
+        intptr_t big = pool.Malloc(total);
+        pool.Free(big);
+        assert(pool.GetNumFreeBlocks() == 1);
+
+        std::atomic<int> corrupted{0};
+        std::vector<std::thread> threads;
+        for (int t = 0; t < kThreads; ++t) {
+            threads.emplace_back([&pool, &corrupted, t] {
+                std::vector<intptr_t> ptrs(kPerThread);
+                for (int round = 0; round < kRounds; ++round) {
+                    for (int k = 0; k < kPerThread; ++k) {
+                        ptrs[k] = pool.Malloc(kRoundSize);
+                        // Stamp the chunk with a value no other thread uses.
+                        // Merging across a chunk which is still in use hands
+                        // the same bytes out twice, and the second holder's
+                        // stamp overwrites the first one's.
+                        std::memset(reinterpret_cast<void*>(ptrs[k]),
+                                    Stamp(t, k), kRoundSize);
+                    }
+                    for (int k = 0; k < kPerThread; ++k) {
+                        auto* p = reinterpret_cast<unsigned char*>(ptrs[k]);
+                        for (size_t i = 0; i < kRoundSize; ++i) {
+                            if (p[i] != Stamp(t, k)) {
+                                ++corrupted;
+                                break;
+                            }
+                        }
+                        pool.Free(ptrs[k]);
+                    }
+                }
+            });
+        }
+        for (auto& thread : threads) thread.join();
+
+        assert(corrupted == 0);
+        assert(pool.GetUsedBytes() == 0);
+        // Free merges a chunk with any free neighbour, so once every chunk is
+        // freed they all collapse back into the single block they came from.
+        // A lost merge leaves the pool fragmented forever.
+        assert(pool.GetNumFreeBlocks() == 1);
+        assert(pool.GetFreeBytes() == total);
+    }
+
+    // MemoryPool::pools_ is inserted into on first use of a device.
+    void TestConcurrentPools() {
+        MemoryPool pool;
+        std::vector<std::thread> threads;
+        for (int t = 0; t < kThreads; ++t) {
+            threads.emplace_back([&pool] {
+                for (int round = 0; round < kRounds; ++round) {
+                    intptr_t p = pool.Malloc(kRoundSize);
+                    assert(p != 0);
+                    pool.Free(p);
+                }
+            });
+        }
+        for (auto& thread : threads) thread.join();
+
+        assert(pool.GetUsedBytes() == 0);
+    }
+
+private:
+    static unsigned char Stamp(int t, int k) {
+        return static_cast<unsigned char>(t * kPerThread + k + 1);
+    }
+};
+
 // Resets the CUDA device, so it has to run after every other test.
 class TestMemoryDestructor {
 public:
@@ -650,6 +743,7 @@ int main() {
     cumo::internal::TestChunk{}.Run();
     cumo::internal::TestSingleDeviceMemoryPool{}.Run();
     cumo::internal::TestMemoryPool{}.Run();
+    cumo::internal::TestConcurrency{}.Run();
     cumo::internal::TestMemoryDestructor{}.Run();
     return 0;
 }


### PR DESCRIPTION
The memory pool's chunk graph was read and modified with no lock held, and `MemoryPool::pools_` had no lock at all.

`SingleDeviceMemoryPool::Free` released `mutex_` after erasing the chunk from `in_use_`, then walked `chunk->prev()`/`chunk->next()`, called `RemoveFromFreeList` and `Merge`, and only re-took the lock inside those calls.
`Malloc` had the symmetric hole: it popped a chunk under the lock, released it, and then let `Split` rewrite the neighbouring chunks' `prev`/`next` pointers. Both touch the doubly-linked graph that every thread reaches through the free lists.

## What that costs, measured

8 threads, each allocating and freeing 8 chunks per round for 400 rounds, all split from one primed block so the chunks really are neighbours of chunks other threads hold:

| | before | after |
|---|---|---|
| ThreadSanitizer, chunk graph | 4–14 races/run (3/3 runs) | 0 (3/3) |
| `EraseFromFreeList`'s `assert(!chunk->in_use())` | aborts, 5/5 runs | passes, 5/5 |
| free blocks left at the end (NDEBUG) | 56–58 (5/5 runs) | 1 (5/5) |
| device memory held at the end (NDEBUG) | 93,696–94,720 bytes | 65,536 bytes |
| ThreadSanitizer, `pools_` | 40–82 races/run (3/3) | 0 (3/3) |

Three distinct problems show up:

- **Undefined behaviour.** The `prev_`/`next_` races are on a `std::shared_ptr`, so a lost refcount update can drop a `Chunk` another thread still holds. `size_` and `in_use_` are raced on too.
- **The `in_use()` test is stale.** By the time `RemoveFromFreeList` runs, a concurrent `Malloc` may have handed the neighbour out. With asserts enabled — which is how the C++ harness builds — `EraseFromFreeList`'s `assert(!chunk->in_use())` aborts the process.
- **Lost merges, which is the part that shows in a release build.** Two threads freeing neighbouring chunks each look for the other in the free list *before* the other has appended itself, so both merges fail and the pair stays split for good. Built with `NDEBUG`, as the extension is, the run ends with the pool holding 43% more device memory than it needs, fragmented into 57 blocks instead of 1. It only grows with runtime.

**One thing that does *not* happen**, contrary to what I had recorded from reading the code: the merge never swallows a live allocation. `Malloc` pops a chunk out of the free list before marking it in use, so a chunk is never both in use and findable in a free list, and the stale `in_use()` test can only make `RemoveFromFreeList` fail — never succeed wrongly. The stamp check in the new test (each thread fills its chunks with a value no other thread uses) reports zero mismatches on the old code, 5/5 runs. The harm is fragmentation and UB, not overlapping allocations.

## Fix

- `Free` holds the lock for its whole body. `mutex_` is recursive, so the `RemoveFromFreeList`/`AppendToFreeList` calls inside can take it again.
- `Malloc` splits under the same lock it searched with. `cudaMalloc` stays outside the lock: it is slow, and a chunk of a fresh allocation has no neighbours for another thread to reach it through.
- `MemoryPool` gains a `pools_mutex_` and a `GetPool()` helper. The lock covers only the lookup, not the allocation: `pools_` is never erased from before destruction, and `unordered_map` keeps references to its elements valid across a rehash, so the returned reference outlives the lock. `Free` snapshots the pointers under the lock and frees outside it, which also keeps `others` from allocating in the usual single-device case.

## Reachability

None of this is reachable from ordinary Ruby threads — the GVL serializes them. `cumo.c:118` declares the extension Ractor-safe, and a Ractor does not hold the GVL, which is what makes the pool genuinely shared.

To be clear about what this is not: **it is not the cause of the Ractor corruption in #180.** That reproduces with `CUMO_MEMORY_POOL=OFF`, i.e. with this code not running at all, and slightly worse. #180 is about host access to managed memory racing with kernel execution; this is a plain data structure lock.

## Tests

`TestConcurrency` in `ext/cumo/cuda/memory_pool_impl_test.cpp` (`rake ctest`), two cases:

- **`TestConcurrentSplitAndMerge`** — primes the pool with one large free chunk so every later `Malloc` splits off it, then hammers it from 8 threads. Each thread stamps its chunks with a value no other thread uses and verifies the stamp before freeing. Afterwards it asserts the graph collapsed back to the single block it came from: `GetUsedBytes() == 0`, `GetNumFreeBlocks() == 1`, `GetFreeBytes() == total`. That last one is the assertion that fails on the old code — `Free` merges a chunk with any free neighbour, so once every chunk is freed they must all collapse back, and a lost merge leaves the pool fragmented forever.
- **`TestConcurrentPools`** — 8 threads through `MemoryPool`, whose `pools_` is inserted into on first use of a device.

Verified on real hardware (RTX A4000, CUDA 13.0). The new harness fails 5/5 on the code it replaces and passes 5/5 on this one; `rake test` is 889 tests, 10957 assertions, 0 failures.

## Left alone

Two neighbouring items in the same file are separate problems and are not touched here: `Malloc` calls `GetArenaIndex(size)` without a `stream_ptr` (so it indexes the right stream's arena with the stream-0 index), and `Free` appends to the arena of the stream it was passed without comparing `chunk->stream_ptr()`. Both are latent while cumo only ever uses stream 0.
