### PR TITLE
Search the free list of the stream Malloc was asked for

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -132,7 +132,7 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
 
         // find best-fit, or a smallest larger allocation
         Arena& arena = GetArena(stream_ptr);
-        size_t arena_index = GetArenaIndex(size);
+        size_t arena_index = GetArenaIndex(size, stream_ptr);
         size_t arena_length = arena.size();
         for (size_t i = arena_index; i < arena_length; ++i) {
             FreeList& free_list = arena[i];

--- a/ext/cumo/cuda/memory_pool_impl.hpp
+++ b/ext/cumo/cuda/memory_pool_impl.hpp
@@ -216,7 +216,12 @@ public:
         return (size - 1) / kRoundSize;
     }
 
-    size_t GetArenaIndex(size_t size, cudaStream_t stream_ptr = 0) {
+    // Returns where a chunk of `size` belongs in the arena of `stream_ptr`.
+    //
+    // The stream is not optional: an index taken from one stream's index map
+    // means nothing in another stream's arena, and defaulting it silently
+    // started the free list search at the wrong bin.
+    size_t GetArenaIndex(size_t size, cudaStream_t stream_ptr) {
         size_t bin_index = GetBinIndex(size);
         ArenaIndexMap& arena_index_map = GetArenaIndexMap(stream_ptr);
         return std::lower_bound(arena_index_map.begin(), arena_index_map.end(), bin_index) - arena_index_map.begin();
@@ -267,14 +272,14 @@ public:
         return true;
     }
 
-    void AppendToFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr = 0);
+    void AppendToFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr);
 
     // Removes the chunk from the free list.
     //
     // @return true if the chunk can successfully be removed from
     //         the free list. false` otherwise (e.g., the chunk could not
     //         be found in the free list as the chunk is allocated.)
-    bool RemoveFromFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr = 0);
+    bool RemoveFromFreeList(size_t size, std::shared_ptr<Chunk>& chunk, cudaStream_t stream_ptr);
 
     void CompactIndex(cudaStream_t stream_ptr, bool free);
 };

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -139,6 +139,7 @@ public:
         TearDown(); SetUp(); TestGetRoundedSize();
         TearDown(); SetUp(); TestGetBinIndex();
         TearDown(); SetUp(); TestGetArenaIndexWithHugeSize();
+        TearDown(); SetUp(); TestMallocOnAnotherStream();
         TearDown(); SetUp(); TestAppendToFreeList();
         TearDown(); SetUp(); TestRemoveFromFreeList();
         TearDown(); SetUp(); TestMalloc();
@@ -185,6 +186,34 @@ public:
         // smaller arena index, or the free list search would pick this chunk.
         assert(pool_->GetArenaIndex(size_t(1) << 41, stream_ptr_) == 1);
         assert(pool_->GetArenaIndex(kMaxAllocationSize, stream_ptr_) == 1);
+    }
+
+    // Malloc used to take the starting arena index from stream 0's index map
+    // and then index the requested stream's arena with it. The two index maps
+    // are unrelated, so the search could start below the requested size and
+    // hand out a chunk too small for it.
+    void TestMallocOnAnotherStream() {
+        cudaStream_t other = reinterpret_cast<cudaStream_t>(1);
+
+        auto small_mem = std::make_shared<Memory>(kRoundSize);
+        auto small = std::make_shared<Chunk>(small_mem, 0, small_mem->size(), other);
+        pool_->AppendToFreeList(small->size(), small, other);
+
+        auto big_mem = std::make_shared<Memory>(kRoundSize * 4);
+        auto big = std::make_shared<Chunk>(big_mem, 0, big_mem->size(), other);
+        pool_->AppendToFreeList(big->size(), big, other);
+
+        // stream 0 has no bins at all here, so its index is 0 for any size.
+        assert(pool_->GetArenaIndex(kRoundSize * 4, stream_ptr_) == 0);
+        assert(pool_->GetArenaIndex(kRoundSize * 4, other) == 1);
+
+        auto p = pool_->Malloc(kRoundSize * 4, other);
+        assert(p == big->ptr());
+        assert(pool_->GetUsedBytes() == kRoundSize * 4);
+        // The small chunk is untouched, and no chunk was split to a size its
+        // buffer cannot back -- which used to underflow GetFreeBytes.
+        assert(pool_->GetFreeBytes() == kRoundSize);
+        assert(small->size() == kRoundSize);
     }
 
     void TestAppendToFreeList() {


### PR DESCRIPTION
`SingleDeviceMemoryPool::Malloc` took the arena of the requested stream but computed the index to start searching it from with `GetArenaIndex(size)`, whose stream parameter defaulted to `0`:

```c
Arena& arena = GetArena(stream_ptr);
size_t arena_index = GetArenaIndex(size);   // stream_ptr defaults to 0
```

Each stream keeps its own sparse index map — `arena[k]` holds the bin named by `arena_index_map[k]`, and the two maps are built independently — so an index derived from stream 0's map says nothing about where a size sits in another stream's arena. Every other index operation in the same function (`GetArena`, `AppendToFreeList`) passes the stream; only this one did not.

## What it costs

When stream 0's map is the shorter one, the search starts *below* the requested size, and the first non-empty bin it finds may hold a chunk too small for the request:

```c
pool.AppendToFreeList(512,  small, other);
pool.AppendToFreeList(2048, big,   other);
pool.Malloc(2048, other);   // => the 512-byte chunk
```

Measured with an `NDEBUG` build, which is how the extension ships:

```
before: arena index for 2048 bytes: stream0=0 streamS=1
        requested 2048 bytes -> SMALL (wrong) chunk
        used_bytes=2048 (backed by 512)  free_bytes=512

after:  arena index for 2048 bytes: stream0=0 streamS=1
        requested 2048 bytes -> big (ok) chunk
        used_bytes=2048 (backed by 2048)  free_bytes=512
```

`Split` then sets the chunk's size to 2048 while 512 bytes back it, so the caller receives 1536 bytes of device memory it does not own. The remaining chunk is constructed with `512 - 2048` as its size, which underflows, and a chunk of ~1.8e19 bytes goes into the free list for a later request to pick up — the `free_bytes=512` above is that value wrapping around. It is the same shape as the `GetBinIndex` truncation fixed in #170.

In the other direction, when stream 0's map is the longer one, the search starts past bins that could have served the request, so a usable chunk is skipped and `cudaMalloc` is called instead. That one only wastes memory.

## Fix

Pass the stream. Beyond that, drop the default from `GetArenaIndex`, `AppendToFreeList` and `RemoveFromFreeList` — the omission was only possible because the parameter was optional, and every call site already passes it explicitly. With the default gone, the old call does not compile.

`Malloc`/`Free` keep their `stream_ptr = 0` defaults: those are the public entry points and `memory_pool.cpp` relies on them.

## Reachability

Latent today. cumo only ever allocates on stream 0 — the `TODO(sonots): Get current CUDA stream and pass it` at `memory_pool.cpp:27` is still open — and one stream cannot disagree with itself. Nothing in the Ruby API reaches `Malloc` with another stream; `MemoryPool.free_all_blocks(stream)` takes one, but that path does not allocate.

## Tests

`TestMallocOnAnotherStream` in `ext/cumo/cuda/memory_pool_impl_test.cpp` (`rake ctest`). It puts a 512-byte and a 2048-byte chunk in a non-default stream's free list, leaves stream 0 with no bins at all so its index is 0 for any size, and asserts the 2048-byte request gets the big chunk, that `GetFreeBytes()` did not underflow, and that the small chunk was not resized. The C++ harness is the only place this can be exercised, since the Ruby API cannot pass a stream to `Malloc`.

Verified on real hardware (RTX A4000, CUDA 13.0). The new test fails 3/3 on the code it replaces and passes 3/3 on this one; `rake test` is 889 tests, 10957 assertions, 0 failures.

## Left alone

The remaining stream item in this file: `Free` appends to the arena of the stream it was passed without comparing `chunk->stream_ptr()`, so a chunk allocated on one stream can be returned to another stream's free list. Also latent while cumo uses one stream, and a separate change.
