### PR TITLE
Return a freed chunk to the arena of its own stream

### DIFF
--- a/ext/cumo/cuda/memory_pool.cpp
+++ b/ext/cumo/cuda/memory_pool.cpp
@@ -56,7 +56,6 @@ cumo_cuda_runtime_free(char *ptr)
     // releases memory the pool still hands out, and fails outright for a chunk
     // which is not at the head of its buffer.
     try {
-        // TODO(sonots): Get current CUDA stream and pass it
         if (pool.Free(reinterpret_cast<intptr_t>(ptr))) {
             return;
         }

--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -193,7 +193,7 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
     return chunk->ptr();
 }
 
-bool SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
+bool SingleDeviceMemoryPool::Free(intptr_t ptr) {
     std::shared_ptr<Chunk> chunk = nullptr;
 
     // The whole body runs under the lock. Walking prev/next and merging is a
@@ -223,6 +223,14 @@ bool SingleDeviceMemoryPool::Free(intptr_t ptr, cudaStream_t stream_ptr) {
         }
         chunk->set_in_use(false);
     }
+
+    // A chunk belongs to the arena of the stream it was allocated on. That is
+    // what makes reuse safe: the next allocation from that arena is queued on
+    // the same stream as the work that last used the chunk, so the two are
+    // ordered. Returning it to another stream's arena hands it to work with no
+    // such ordering. Malloc and Merge each state the invariant in an assert,
+    // but ruby.h defines NDEBUG, so neither ever runs.
+    const cudaStream_t stream_ptr = chunk->stream_ptr();
 
     if (chunk->next() != nullptr && !chunk->next()->in_use()) {
         if (RemoveFromFreeList(chunk->next()->size(), chunk->next(), stream_ptr)) {

--- a/ext/cumo/cuda/memory_pool_impl.hpp
+++ b/ext/cumo/cuda/memory_pool_impl.hpp
@@ -174,7 +174,10 @@ public:
 
     // Returns false if this pool did not allocate the pointer, in which case
     // nothing was freed.
-    bool Free(intptr_t ptr, cudaStream_t stream_ptr = 0);
+    //
+    // There is no stream parameter: the chunk records the stream it was
+    // allocated on, and that is the only arena it may be returned to.
+    bool Free(intptr_t ptr);
 
     // Free all **non-split** chunks in all arenas
     void FreeAllBlocks();
@@ -344,11 +347,13 @@ public:
     //
     // Args:
     //     ptr (intptr_t): Pointer of the memory buffer
-    //     stream_ptr (cudaStream_t): Return the memory to the arena of given stream
     // Returns:
     //     bool: false if no pool allocated the pointer, in which case nothing
     //           was freed and the caller has to free it by its own means.
-    bool Free(intptr_t ptr, cudaStream_t stream_ptr = 0) {
+    //
+    // The stream is not a parameter: the chunk records the stream it was
+    // allocated on, and that is the only arena it may be returned to.
+    bool Free(intptr_t ptr) {
         int current_device_id = device_id();
 
         // Take the pointers out under the lock and release it before freeing:
@@ -369,14 +374,14 @@ public:
             }
         }
 
-        if (current != nullptr && current->Free(ptr, stream_ptr)) {
+        if (current != nullptr && current->Free(ptr)) {
             return true;
         }
         // The current device may have been switched since the allocation.
         // cudaMallocManaged hands out addresses which are unique across the
         // host and every device, so the pointer identifies its pool on its own.
         for (SingleDeviceMemoryPool* mp : others) {
-            if (mp->Free(ptr, stream_ptr)) {
+            if (mp->Free(ptr)) {
                 return true;
             }
         }

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -140,6 +140,7 @@ public:
         TearDown(); SetUp(); TestGetBinIndex();
         TearDown(); SetUp(); TestGetArenaIndexWithHugeSize();
         TearDown(); SetUp(); TestMallocOnAnotherStream();
+        TearDown(); SetUp(); TestFreeReturnsChunkToItsOwnStream();
         TearDown(); SetUp(); TestAppendToFreeList();
         TearDown(); SetUp(); TestRemoveFromFreeList();
         TearDown(); SetUp(); TestMalloc();
@@ -214,6 +215,25 @@ public:
         // buffer cannot back -- which used to underflow GetFreeBytes.
         assert(pool_->GetFreeBytes() == kRoundSize);
         assert(small->size() == kRoundSize);
+    }
+
+    // Free used to append the chunk to the arena of the stream it was passed,
+    // and cumo_cuda_runtime_free passes none, so anything allocated on another
+    // stream was returned to stream 0's arena -- where a later Malloc on
+    // stream 0 would reuse memory it never ordered against.
+    void TestFreeReturnsChunkToItsOwnStream() {
+        cudaStream_t other = reinterpret_cast<cudaStream_t>(1);
+
+        auto p = pool_->Malloc(kRoundSize, other);
+        pool_->Free(p);
+        assert(pool_->GetNumFreeBlocks() == 1);
+        assert(!pool_->HasArena(stream_ptr_));
+
+        // The owning stream gets its own chunk back rather than cudaMalloc'ing
+        // a second one, which is the same thing seen from the other side.
+        auto q = pool_->Malloc(kRoundSize, other);
+        assert(q == p);
+        assert(pool_->GetTotalBytes() == kRoundSize);
     }
 
     void TestAppendToFreeList() {


### PR DESCRIPTION
`SingleDeviceMemoryPool::Free` appended the chunk to the arena of the stream it was *passed*, never comparing that with `chunk->stream_ptr()`. Since `cumo_cuda_runtime_free` calls `Free` with no stream at all, anything allocated on a stream other than 0 was returned to stream 0's arena.

Measured with an `NDEBUG` build, which is how the extension ships:

```
before: after Free: stream0 arena bins=1  otherStream arena bins=0
        Malloc(stream 0)     -> REUSED the other stream's chunk
        Malloc(other stream) -> fresh chunk (had to cudaMalloc)

after:  after Free: stream0 arena bins=0  otherStream arena bins=1
        Malloc(stream 0)     -> fresh chunk
        Malloc(other stream) -> its own chunk
```

A chunk belongs to the arena of the stream it was allocated on, and that is what makes reuse safe: the next allocation from that arena is queued on the same stream as the work that last used the chunk, so the two are ordered. Handing it to another stream drops that ordering — the one guarantee per-stream arenas exist to provide — and the new owner can start writing while the previous owner's kernels are still reading. The owning stream, meanwhile, cannot get its own memory back and has to `cudaMalloc` a second buffer.

## Fix

Take the stream from the chunk. The parameter then has no correct value a caller could pass, so it is dropped from both `Free` overloads — no caller ever passed one — and with it the `TODO(sonots): Get current CUDA stream and pass it` above `cumo_cuda_runtime_free`'s call, which asked for exactly the argument that caused this.

## About the asserts

`Malloc` and `Merge` each state this invariant already:

```c
assert(chunk->stream_ptr() == stream_ptr);              // memory_pool_impl.cpp:186
assert(self->stream_ptr_ == remaining->stream_ptr());   // memory_pool_impl.cpp:64
```

Neither has ever run. `memory_pool_impl.cpp` includes `<ruby.h>`, which pulls in `ruby/assert.h`, which defines `NDEBUG` — so every `assert` in that translation unit is compiled out. That holds in the C++ test harness too, not only in the extension; only the asserts written in the header are live there, because `memory_pool_impl_test.cpp` does not include `<ruby.h>`. Worth knowing before relying on an assert in that file. I have not touched the include here: making those asserts live would also make them live in the shipped extension, which is a separate decision.

## Reachability

Latent today. cumo allocates on stream 0 only — the `TODO(sonots): Get current CUDA stream and pass it` at `memory_pool.cpp:27` is still open — and a chunk allocated on stream 0 returns to stream 0's arena either way. Nothing in the Ruby API reaches `Malloc` with another stream.

## Tests

`TestFreeReturnsChunkToItsOwnStream` in `ext/cumo/cuda/memory_pool_impl_test.cpp` (`rake ctest`). It allocates on a non-default stream, frees, and asserts that stream 0 has no arena at all while the chunk sits in its own stream's free list, then that the owning stream gets that same chunk back instead of a second `cudaMalloc`. The C++ harness is the only place a stream can be passed to `Malloc`.

Verified on real hardware (RTX A4000, CUDA 13.0). The new test fails 3/3 on the code it replaces and passes 3/3 on this one; `rake test` is 889 tests, 10957 assertions, 0 failures.

## Relation to #186

Independent, and this branch is cut from master rather than stacked on it. #186 fixes which *bin* `Malloc` starts searching in; this fixes which *arena* `Free` returns a chunk to. Whichever merges second may need a trivial rebase — both add a line to `TestSingleDeviceMemoryPool::Run()` and a test method next to it.
