### PR TITLE
Compile the memory pool test harness in CI and run it from rake test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,5 +85,6 @@ jobs:
           ccache -z
 
           bundle exec rake compile
+          bundle exec rake build_ctest
 
           ccache -s

--- a/Rakefile
+++ b/Rakefile
@@ -12,9 +12,18 @@ end
 require "rake/extensiontask"
 Rake::ExtensionTask.new("cumo")
 
-task :ctest do
-  sh 'cd ext/cumo && ruby extconf.rb && make && make build-ctest && make run-ctest'
+desc 'Build the C++ memory pool test harness without running it (running it needs a GPU)'
+task :build_ctest do
+  sh 'cd ext/cumo && ruby extconf.rb && make build-ctest'
 end
+
+task :ctest => :build_ctest do
+  sh 'cd ext/cumo && make run-ctest'
+end
+
+# Both need a GPU, so CI runs neither. Tie them together so the one place
+# they do run does not skip half of them.
+task :test => :ctest
 
 task :docs do
   dir = "ext/cumo"


### PR DESCRIPTION
`ext/cumo/cuda/memory_pool_impl_test.cpp` is not reached by `rake compile`, so nothing in CI has ever built it. It is where every memory pool test lives, and three of them were added in the last few days (#185, #186, #187) — a syntax error or a stale call in that file passes CI untouched. The most recent one was caught only because the file happened to get built by hand while resolving a rebase.

Running the harness needs a GPU the runner does not have:

```
$ CUDA_VISIBLE_DEVICES="" ext/cumo/cuda/memory_pool_impl_test.exe
terminate called after throwing an instance of 'cumo::internal::CUDARuntimeError'
  what():  no CUDA-capable device is detected
```

`SingleDeviceMemoryPool`'s constructor calls `cudaGetDevice`, so it aborts before the first test. Compiling it, though, needs only nvcc. So the compile is split out of `ctest` into `build_ctest`, and that half is added to the existing build step.

## `rake test` now runs `ctest` too

Running the harness only happens on a machine with a GPU, and that is the same machine that runs `rake test`. Keeping them apart meant half the pool's coverage was reachable only by remembering to type a second command. `test` now depends on `ctest`, so the C++ tests run first and a failure stops the run before the Ruby suite starts.

## `rake ctest` no longer runs a full in-tree `make`

`ctest` ran `ruby extconf.rb && make && make build-ctest && make run-ctest`. That `make` was never needed — `build-ctest` is a single nvcc invocation over two files and wants nothing from it but the Makefile `extconf.rb` generates. Dropping it also stops `rake ctest` from leaving ~50 `.o` files and a `cumo.so` in `ext/cumo`, which made the next `rake compile` print

```
WARNING: rake-compiler found compiled files in 'ext/cumo' directory. Please remove them.
```

and then fail to link.

## Verified

On real hardware (RTX A4000, CUDA 13.0):

- `rake build_ctest` compiles and links the harness without running it, and leaves no `.o` files.
- `rake test` runs the C++ harness and then the Ruby suite — 889 tests, 10957 assertions, 0 failures.
- Appending a call to an undeclared function to `memory_pool_impl_test.cpp` makes `rake build_ctest` exit non-zero, which is the point: CI would now fail. Restoring the file makes it pass again.
- Adding a failing `assert` to a harness test makes `rake test` exit non-zero **before** the Ruby suite runs.
- After `rake ctest`, `ext/cumo` holds zero `.o` files and no `cumo.so`, and `rake compile` is clean.
