### PR TITLE
Format a RObject element without the fixed 48 byte buffer

### DIFF
--- a/ext/cumo/include/cumo/types/robj_macro.h
+++ b/ext/cumo/include/cumo/types/robj_macro.h
@@ -60,13 +60,6 @@
 
 #define m_mulsum_init INT2FIX(0)
 
-#define m_sprintf(s,x) robj_sprintf(s,x)
-
-static inline int robj_sprintf(char *s, VALUE x) {
-    VALUE v = rb_funcall(x,rb_intern("to_s"),0);
-    return sprintf(s,"%s",StringValuePtr(v));
-}
-
 #define m_sqrt(x)                                          \
     rb_funcall(rb_const_get(rb_mKernel,rb_intern("Math")), \
                rb_intern("sqrt"),1,x);

--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -41,6 +41,7 @@ if is_object
   def_id "nan?"
   def_id "infinite?"
   def_id "finite?"
+  def_id "to_s"
   def_id "-@", "minus"
   def_id "==", "eq"
   def_id "!=", "ne"

--- a/ext/cumo/narray/gen/tmpl/format.c
+++ b/ext/cumo/narray/gen/tmpl/format.c
@@ -1,6 +1,13 @@
 static VALUE
 format_<%=type_name%>(VALUE fmt, dtype* x)
 {
+<% if is_object %>
+    if (NIL_P(fmt)) {
+        VALUE v = rb_funcall(*x, cumo_id_to_s, 0);
+        StringValue(v);
+        return rb_str_new(RSTRING_PTR(v), RSTRING_LEN(v));
+    }
+<% else %>
     // fix-me
     char s[48];
     int n;
@@ -9,6 +16,7 @@ format_<%=type_name%>(VALUE fmt, dtype* x)
         n = m_sprintf(s,*x);
         return rb_str_new(s,n);
     }
+<% end %>
     return rb_funcall(fmt, '%', 1, m_data_to_num(*x));
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -883,6 +883,20 @@ class NArrayTest < Test::Unit::TestCase
                  Cumo::DFloat.cast(Cumo::RObject[1, nil, 3]).format_to_a)
   end
 
+  test "Cumo::RObject#format with a long element" do
+    ['A' * 47, 'A' * 48, 'A' * 4096].each do |src|
+      a = Cumo::RObject[src]
+
+      formatted = a.format
+      assert_kind_of(Cumo::RObject, formatted)
+      assert_equal([src], formatted.to_a)
+
+      formatted = a.format_to_a
+      assert_kind_of(Array, formatted)
+      assert_equal([src], formatted)
+    end
+  end
+
   test "single element array" do
     assert { Cumo::SFloat[1].mean == 1.0 }
     assert { Cumo::DFloat[1].mean == 1.0 }


### PR DESCRIPTION
## Format a RObject element without the fixed 48 byte buffer

`format_robject` wrote the element's `to_s` into a `char s[48]` on the stack through `m_sprintf` / `robj_sprintf`. A RObject element is an arbitrary Ruby object, so the length of its `to_s` is not bounded by anything this side controls.

Measured on master before the fix, with an element of `'A' * n`:

- `n <= 47` — fits (47 chars + NUL)
- `48 <= n <= 56` — writes past the buffer, silently
- `n >= 57` — `*** stack smashing detected ***`, abort (exit 134)

`format` and `format_to_a` both reach it; `inspect` and `to_a` take other paths and were never affected.

`gen/tmpl/format.c` is one template for every type, so the fix branches on `is_object` and builds the string from the `to_s` result directly. `robj_sprintf` has no other caller and is removed.

Backport of yoshoku/numo-narray-alt#18 (merge `e8aaa57`), adapted to cumo's template layout.

Verified on RTX A4000 / CUDA 13.0: `Cumo::RObject['A' * 65536].format` is correct after the fix, and `rake test` is 890 tests / 10969 assertions / 0 failures.
