### PR TITLE
Raise ArgumentError for non-numeric tokens in parse

### DIFF
--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -145,6 +145,10 @@ module Cumo
     #   # [[2, -3, 5],
     #   #  [4, 9, 7],
     #   #  [2, -1, 6]]
+    # @example
+    #   a = Cumo::NArray.parse('true false nil')
+    #   # => Cumo::Bit#shape=[1,3]
+    #   # [[1, 0, 0]]
 
     def self.parse(str, split1d:/\s+/, split2d:/;?$|;/,
                    split3d:/\s*\n(\s*\n)+/m)
@@ -158,7 +162,8 @@ module Cumo
           if !line.empty?
             c = []
             line.split(split1d).each do |item|
-              c << eval(item.strip) if !item.empty?
+              item = item.strip
+              c << parse_token(item) if !item.empty?
             end
             b << c if !c.empty?
           end
@@ -171,6 +176,42 @@ module Cumo
         self.cast(a)
       end
     end
+
+    # Convert one token of {parse} input into a value.
+    #
+    # Only the literals that describe an element are accepted: integer, float
+    # and complex numbers, and +true+, +false+ and +nil+, which {cast} turns
+    # into a {Cumo::Bit}. Anything else -- an expression, a method call, a bare
+    # word -- raises ArgumentError, so text handed to {parse} is never executed
+    # as Ruby code.
+    #
+    # @param item [String] one whitespace-delimited token, already stripped
+    # @return [Integer, Float, Complex, true, false, nil] the parsed value
+    # @raise [ArgumentError] if the token is not one of those literals
+    def self.parse_token(item)
+      case item
+      when 'true' then return true
+      when 'false' then return false
+      when 'nil' then return nil
+      end
+
+      v = Integer(item, exception: false)
+      return v if v
+
+      v = Float(item, exception: false)
+      return v if v
+
+      if item.end_with?('i')
+        begin
+          return Complex(item)
+        rescue ArgumentError, TypeError
+          nil
+        end
+      end
+
+      raise ArgumentError, "invalid literal: #{item.inspect}"
+    end
+    private_class_method :parse_token
 
 
     # Iterate over an axis

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -916,6 +916,47 @@ class NArrayTest < Test::Unit::TestCase
     assert { empty.concatenate(empty) == [] }
   end
 
+  test "parse" do
+    assert { Cumo::DFloat.parse("2 -3 5\n4 9 7\n2 -1 6") == Cumo::DFloat[[2, -3, 5], [4, 9, 7], [2, -1, 6]] }
+    assert { Cumo::DFloat.parse("1 2; 3 4") == Cumo::DFloat[[1, 2], [3, 4]] }
+  end
+
+  test "parse rejects non-literal tokens" do
+    ['system("id")', '`id`', 'Kernel.exit', '$stdout', 'self', 'x', 'TRUE', 'True', '[1, 2]'].each do |src|
+      assert_raise(ArgumentError) { Cumo::DFloat.parse(src) }
+    end
+  end
+
+  test "parse rejects expressions" do
+    ['1+1', '2*3', '3/4', '3r', '1/3r'].each do |src|
+      assert_raise(ArgumentError) { Cumo::DFloat.parse(src) }
+    end
+  end
+
+  test "parse error names the token" do
+    error = assert_raise(ArgumentError) { Cumo::DFloat.parse('1 2 oops 4') }
+    assert { error.message.include?('oops') }
+  end
+
+  test "parse integer literals" do
+    assert { Cumo::Int64.parse('1 -3 +4 1_000') == Cumo::Int64[[1, -3, 4, 1000]] }
+    assert { Cumo::Int64.parse('0x1f -0x1f 0b101 0o17 017') == Cumo::Int64[[31, -31, 5, 15, 15]] }
+  end
+
+  test "parse float literals" do
+    assert { Cumo::DFloat.parse('1.5 -2.5 1e5 1.2e-3') == Cumo::DFloat[[1.5, -2.5, 100_000.0, 0.0012]] }
+  end
+
+  test "parse complex literals" do
+    expected = Cumo::DComplex[[Complex(0, 2), Complex(2, 3), Complex(0, -2), Complex(0, 1.5)]]
+    assert { Cumo::DComplex.parse('2i 2+3i -2i 1.5i') == expected }
+  end
+
+  test "parse boolean literals" do
+    assert { Cumo::NArray.parse('true false nil') == Cumo::Bit[[1, 0, 0]] }
+    assert { Cumo::NArray.parse("true false\nfalse true") == Cumo::Bit[[1, 0], [0, 1]] }
+  end
+
   test "argmax/argmin" do
     [Cumo::DFloat, Cumo::Int32, Cumo::UInt8].each do |dtype|
       a = dtype[3, 4, 1, 2]


### PR DESCRIPTION
## Raise ArgumentError for non-numeric tokens in `parse`

`parse` ran `eval` on every whitespace-delimited token, so any text handed to it was executed as Ruby code. `Cumo::DFloat.parse('($x = 42)')` set `$x` on master.

Tokens now go through a private `parse_token` that accepts only the literals describing an element: integer, float and complex numbers, and `true`/`false`/`nil`, which `cast` turns into a `Cumo::Bit`. Anything else raises `ArgumentError` naming the token.

Behaviour changes:

- `parse('3/4')` returned `[[0]]` (integer division, silently) and now raises. Same for `1+1`, `2*3`, `3r`.
- A whitespace-only token used to become `nil` and blow up later in `cast`; it is skipped now.

Backport of yoshoku/numo-narray-alt#16 (merge `0559024`). `true`/`false`/`nil` are kept accepted, which is what the upstream review settled on.

cumo had no tests for `parse` at all, so this adds them: the matlab-style positive cases plus each rejected form. `rake test` is 897 tests / 10981 assertions / 0 failures on RTX A4000 / CUDA 13.0.
