### PR TITLE
Free NArray data with the allocator that allocated it

### DIFF
--- a/ext/cumo/narray/gen/tmpl/alloc_func.c
+++ b/ext/cumo/narray/gen/tmpl/alloc_func.c
@@ -30,7 +30,11 @@ static void
 
     if (na->ptr != NULL) {
         if (na->owned) {
+  <% if is_object %>
+            xfree(na->ptr);
+  <% else %>
             cumo_cuda_runtime_free(na->ptr);
+  <% end %>
         }
         na->ptr = NULL;
     }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -580,6 +580,20 @@ cumo_na_s_eye(int argc, VALUE *argv, VALUE klass)
 #define READ 1
 #define WRITE 2
 
+// allocate() takes xmalloc for RObject and the CUDA allocator for every other
+// type, so the deallocator has to be picked the same way. cudaFree() on host
+// memory raises, and xfree() on device memory reads a malloc header that is not
+// there.
+static void
+cumo_na_free_owned_ptr(VALUE self, void *ptr)
+{
+    if (rb_obj_class(self) == cumo_cRObject) {
+        xfree(ptr);
+    } else {
+        cumo_cuda_runtime_free(ptr);
+    }
+}
+
 static void
 cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
 {
@@ -596,7 +610,7 @@ cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
     case CUMO_NARRAY_DATA_T:
         if (CUMO_NA_SIZE(na) > 0) {
             if (CUMO_NA_DATA_PTR(na) != NULL && CUMO_NA_DATA_OWNED(na)) {
-                xfree(CUMO_NA_DATA_PTR(na));
+                cumo_na_free_owned_ptr(self, CUMO_NA_DATA_PTR(na));
             }
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = FALSE;
@@ -612,7 +626,7 @@ cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
         case CUMO_NARRAY_DATA_T:
             if (CUMO_NA_SIZE(na) > 0) {
                 if (CUMO_NA_DATA_PTR(na) != NULL && CUMO_NA_DATA_OWNED(na)) {
-                    xfree(CUMO_NA_DATA_PTR(na));
+                    cumo_na_free_owned_ptr(obj, CUMO_NA_DATA_PTR(na));
                 }
                 CUMO_NA_DATA_PTR(na) = ptr;
                 CUMO_NA_DATA_OWNED(na) = FALSE;
@@ -1983,12 +1997,10 @@ cumo_na_free_data(VALUE self)
 
     if (na->type == CUMO_NARRAY_DATA_T) {
         void *ptr = CUMO_NA_DATA_PTR(na);
-        if (ptr != NULL) {
-            if (cumo_cuda_runtime_is_device_memory(ptr)) {
-                cumo_cuda_runtime_free(ptr);
-            } else {
-                xfree(ptr);
-            }
+        // Not owned means the data belongs to something else -- store_binary()
+        // points a frozen String's bytes at it -- so there is nothing to free.
+        if (ptr != NULL && CUMO_NA_DATA_OWNED(na)) {
+            cumo_na_free_owned_ptr(self, ptr);
             CUMO_NA_DATA_PTR(na) = NULL;
             return Qtrue;
         }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -804,6 +804,17 @@ class NArrayTest < Test::Unit::TestCase
         assert { data == original_data }
       end
 
+      test "frozen string into an allocated array" do
+        shape = [2, 5]
+        a = dtype.new(*shape)
+        a.rand(0, 10)
+        data = a.to_binary.freeze
+        restored_a = dtype.new(*shape).seq
+        restored_a.store_binary(data)
+        assert { restored_a == a }
+        assert { !restored_a.free }
+      end
+
       test "not frozen string" do
         shape = [2, 5]
         a = dtype.new(*shape)
@@ -881,6 +892,18 @@ class NArrayTest < Test::Unit::TestCase
   test "Cumo::DFloat.cast(Cumo::RObject[1, nil, 3])" do
     assert_equal(Cumo::DFloat[1, Float::NAN, 3].format_to_a,
                  Cumo::DFloat.cast(Cumo::RObject[1, nil, 3]).format_to_a)
+  end
+
+  test "Cumo::RObject#free" do
+    a = Cumo::RObject.new(3)
+    a.seq
+    assert { a.free }
+    assert { !a.free }
+  end
+
+  test "GC does not raise with Cumo::RObject" do
+    5.times { Cumo::RObject.new(1000).seq.sum }
+    assert_nothing_raised { GC.start }
   end
 
   test "Cumo::RObject#format with a long element" do


### PR DESCRIPTION
## Free NArray data with the allocator that allocated it

`allocate` takes `xmalloc` for RObject and `cumo_cuda_runtime_malloc` for every other type (`gen/tmpl/allocate.c:22`). The three places that release the data did not make the same distinction, so each of them mixed the two allocators. Measured on RTX A4000 / CUDA 13.0, master `321d3fa`:

| | before | after |
|---|---|---|
| `Cumo::RObject.new(1000).seq.sum` × 5, then `GC.start` | `Cumo::CUDA::RuntimeError: invalid argument (error=1)` raised **out of GC** | no raise |
| `Cumo::DFloat.new(*shape).seq.store_binary(frozen)` | `free(): invalid size` → abort (a SEGV at `ptr-8` when glibc does not catch it) | correct values |
| `Cumo::RObject.new(3).seq.free` | `Cumo::CUDA::RuntimeError` | `true` |
| `a.store_binary(frozen); a.free` | tried to free the String's buffer | `false` |

The GC one is the worst of the three: any program that lets an RObject array become garbage can have `GC.start` — or any allocation that happens to trigger a sweep — raise from a place with no relation to the code that ran.

`NArray#free` chose its deallocator with `cumo_cuda_runtime_is_device_memory()`. That predicate is not usable for this: since CUDA 11 `cudaPointerGetAttributes` succeeds for unregistered host memory instead of returning `cudaErrorInvalidValue`, so it answers true for any non-null pointer. It is left alone here because its other caller, `ndloop.c`, allocates and frees through the same predicate and so stays consistent either way; a separate change should make it accurate. `free` now goes by ownership instead, which is exact: only `allocate` sets `owned`, and it is the function that picked the allocator.

`rake test` is 912 tests / 11020 assertions / 0 failures. The three new tests fail on master — two by raising, and the `store_binary` one by aborting the process.
