### PR TITLE
Reject CUDA handles this process did not create

### DIFF
--- a/ext/cumo/cuda/driver.c
+++ b/ext/cumo/cuda/driver.c
@@ -3,11 +3,15 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include "cumo/cuda/driver.h"
+#include "cumo/cuda/handle.h"
 
 VALUE cumo_cuda_eDriverError;
 VALUE cumo_cuda_mDriver;
 #define eDriverError cumo_cuda_eDriverError
 #define mDriver cumo_cuda_mDriver
+
+static cumo_cuda_handle_set_t link_states;
+static cumo_cuda_handle_set_t modules;
 
 static void
 check_status(CUresult status)
@@ -100,13 +104,13 @@ cuLinkAddData_without_gvl_cb(void *param)
 static VALUE
 rb_cuLinkAddData(VALUE self, VALUE state, VALUE type, VALUE data, VALUE name)
 {
-    CUlinkState _state = (CUlinkState)NUM2SIZET(state);
     CUjitInputType _type = (CUjitInputType)NUM2INT(type);
     // The image may be a cubin, so it is taken by length and allowed to hold
     // NUL bytes; the name is a plain C string cuLinkAddData reports errors with.
     void* _data = (void *)StringValuePtr(data);
     size_t _size = RSTRING_LEN(data);
     const char* _name = StringValueCStr(name);
+    CUlinkState _state = (CUlinkState)cumo_cuda_handle_get(&link_states, state, "CUlinkState");
     CUresult status;
 
     struct cuLinkAddDataParam param = {_state, _type, _data, _size, _name, 0, (CUjit_option*)0, (void**)0};
@@ -141,9 +145,9 @@ cuLinkAddFile_without_gvl_cb(void *param)
 static VALUE
 rb_cuLinkAddFile(VALUE self, VALUE state, VALUE type, VALUE path)
 {
-    CUlinkState _state = (CUlinkState)NUM2SIZET(state);
     CUjitInputType _type = (CUjitInputType)NUM2INT(type);
     const char* _path = StringValueCStr(path);
+    CUlinkState _state = (CUlinkState)cumo_cuda_handle_get(&link_states, state, "CUlinkState");
     CUresult status;
 
     struct cuLinkAddFileParam param = {_state, _type, _path, 0, (CUjit_option*)0, (void **)0};
@@ -173,7 +177,7 @@ cuLinkComplete_without_gvl_cb(void *param)
 static VALUE
 rb_cuLinkComplete(VALUE self, VALUE state)
 {
-    CUlinkState _state = (CUlinkState)NUM2SIZET(state);
+    CUlinkState _state = (CUlinkState)cumo_cuda_handle_get(&link_states, state, "CUlinkState");
     void* _cubinOut;
     size_t _sizeOut;
     CUresult status;
@@ -214,6 +218,7 @@ rb_cuLinkCreate(VALUE self)
     //status = cuLinkCreate(0, (CUjit_option*)0, (void**)0, &state);
 
     check_status(status);
+    cumo_cuda_handle_set_add(&link_states, (size_t)state);
     return SIZET2NUM((size_t)state);
 }
 
@@ -233,7 +238,7 @@ cuLinkDestroy_without_gvl_cb(void *param)
 static VALUE
 rb_cuLinkDestroy(VALUE self, VALUE state)
 {
-    CUlinkState _state = (CUlinkState)NUM2SIZET(state);
+    CUlinkState _state = (CUlinkState)cumo_cuda_handle_take(&link_states, state, "CUlinkState");
     CUresult status;
 
     struct cuLinkDestroyParam param = {_state};
@@ -263,8 +268,8 @@ static VALUE
 rb_cuModuleGetFunction(VALUE self, VALUE hmod, VALUE name)
 {
     CUfunction _hfunc;
-    CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
     const char* _name = StringValueCStr(name);
+    CUmodule _hmod = (CUmodule)cumo_cuda_handle_get(&modules, hmod, "CUmodule");
     CUresult status;
 
     struct cuModuleGetFunctionParam param = {&_hfunc, _hmod, _name};
@@ -297,8 +302,8 @@ rb_cuModuleGetGlobal(VALUE self, VALUE hmod, VALUE name)
 {
     CUdeviceptr _dptr;
     size_t _bytes;
-    CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
     const char* _name = StringValueCStr(name);
+    CUmodule _hmod = (CUmodule)cumo_cuda_handle_get(&modules, hmod, "CUmodule");
     CUresult status;
     VALUE ret;
 
@@ -342,6 +347,7 @@ rb_cuModuleLoad(VALUE self, VALUE fname)
 
     RB_GC_GUARD(fname);
     check_status(status);
+    cumo_cuda_handle_set_add(&modules, (size_t)_module);
     return SIZET2NUM((size_t)_module);
 }
 
@@ -373,6 +379,7 @@ rb_cuModuleLoadData(VALUE self, VALUE image)
 
     RB_GC_GUARD(image);
     check_status(status);
+    cumo_cuda_handle_set_add(&modules, (size_t)_module);
     return SIZET2NUM((size_t)_module);
 }
 
@@ -392,7 +399,7 @@ cuModuleUnload_without_gvl_cb(void *param)
 static VALUE
 rb_cuModuleUnload(VALUE self, VALUE hmod)
 {
-    CUmodule _hmod = (CUmodule)NUM2SIZET(hmod);
+    CUmodule _hmod = (CUmodule)cumo_cuda_handle_take(&modules, hmod, "CUmodule");
     CUresult status;
 
     struct cuModuleUnloadParam param = {_hmod};
@@ -413,6 +420,9 @@ Init_cumo_cuda_driver()
     VALUE mCUDA = rb_define_module_under(mCumo, "CUDA");
     mDriver = rb_define_module_under(mCUDA, "Driver");
     eDriverError = rb_define_class_under(mCUDA, "DriverError", rb_eStandardError);
+
+    cumo_cuda_handle_set_init(&link_states);
+    cumo_cuda_handle_set_init(&modules);
 
     rb_define_singleton_method(mDriver, "cuCtxGetCurrent", rb_cuCtxGetCurrent, 0);
     rb_define_singleton_method(mDriver, "cuLinkAddData",   rb_cuLinkAddData,   4);

--- a/ext/cumo/cuda/nvrtc.c
+++ b/ext/cumo/cuda/nvrtc.c
@@ -4,11 +4,14 @@
 #include <limits.h>
 #include <nvrtc.h>
 #include "cumo/cuda/nvrtc.h"
+#include "cumo/cuda/handle.h"
 
 VALUE cumo_cuda_eNVRTCError;
 VALUE cumo_cuda_mNVRTC;
 #define eNVRTCError cumo_cuda_eNVRTCError
 #define mNVRTC cumo_cuda_mNVRTC
+
+static cumo_cuda_handle_set_t programs;
 
 static void
 check_status(nvrtcResult status)
@@ -152,6 +155,7 @@ rb_nvrtcCreateProgram(
     free(_headers);
     RB_GC_GUARD(strings);
     check_status(status);
+    cumo_cuda_handle_set_add(&programs, (size_t)_prog);
     return SIZET2NUM((size_t)_prog);
 }
 
@@ -172,7 +176,7 @@ static VALUE
 rb_nvrtcDestroyProgram(VALUE self, VALUE prog)
 {
     nvrtcResult status;
-    nvrtcProgram _prog = (nvrtcProgram)NUM2SIZET(prog);
+    nvrtcProgram _prog = (nvrtcProgram)cumo_cuda_handle_take(&programs, prog, "nvrtcProgram");
 
     struct nvrtcDestroyProgramParam param = {&_prog};
     status = (nvrtcResult)rb_thread_call_without_gvl(nvrtcDestroyProgram_without_gvl_cb, &param, NULL, NULL);
@@ -200,7 +204,7 @@ static VALUE
 rb_nvrtcCompileProgram(VALUE self, VALUE prog, VALUE options)
 {
     nvrtcResult status;
-    nvrtcProgram _prog = (nvrtcProgram)NUM2SIZET(prog);
+    nvrtcProgram _prog = (nvrtcProgram)cumo_cuda_handle_get(&programs, prog, "nvrtcProgram");
     int _numOptions = ary_len(options, "options");
     const char** _options = NULL;
     VALUE strings;
@@ -228,7 +232,7 @@ static VALUE
 rb_nvrtcGetPTX(VALUE self, VALUE prog)
 {
     nvrtcResult status;
-    nvrtcProgram _prog = (nvrtcProgram)NUM2SIZET(prog);
+    nvrtcProgram _prog = (nvrtcProgram)cumo_cuda_handle_get(&programs, prog, "nvrtcProgram");
     size_t _ptxSizeRet;
     char *_ptx;
     VALUE ptx;
@@ -248,7 +252,7 @@ static VALUE
 rb_nvrtcGetProgramLog(VALUE self, VALUE prog)
 {
     nvrtcResult status;
-    nvrtcProgram _prog = (nvrtcProgram)NUM2SIZET(prog);
+    nvrtcProgram _prog = (nvrtcProgram)cumo_cuda_handle_get(&programs, prog, "nvrtcProgram");
     size_t _logSizeRet;
     char *_log;
     VALUE log;
@@ -271,6 +275,8 @@ Init_cumo_cuda_nvrtc()
     VALUE mCUDA = rb_define_module_under(mCumo, "CUDA");
     mNVRTC = rb_define_module_under(mCUDA, "NVRTC");
     eNVRTCError = rb_define_class_under(mCUDA, "NVRTCError", rb_eStandardError);
+
+    cumo_cuda_handle_set_init(&programs);
 
     rb_define_singleton_method(mNVRTC, "nvrtcVersion", rb_nvrtcVersion, 0);
     rb_define_singleton_method(mNVRTC, "nvrtcCreateProgram", rb_nvrtcCreateProgram, 4);

--- a/ext/cumo/include/cumo/cuda/handle.h
+++ b/ext/cumo/include/cumo/cuda/handle.h
@@ -1,0 +1,85 @@
+#ifndef CUMO_CUDA_HANDLE_H
+#define CUMO_CUDA_HANDLE_H
+#include <ruby.h>
+#include <ruby/st.h>
+#include <ruby/thread_native.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+// The driver and NVRTC hand their handles to Ruby as plain Integers, so a
+// made-up or already destroyed one arrives back here as a pointer the CUDA API
+// dereferences without checking. Keeping the live ones is what lets those be
+// told apart from a valid handle.
+//
+// The lock is here because a Ractor gets its own GVL, so two of them can reach
+// the table at once.
+typedef struct {
+    st_table *table;
+    rb_nativethread_lock_t lock;
+} cumo_cuda_handle_set_t;
+
+static inline void
+cumo_cuda_handle_set_init(cumo_cuda_handle_set_t *set)
+{
+    set->table = st_init_numtable();
+    rb_nativethread_lock_initialize(&set->lock);
+}
+
+static inline void
+cumo_cuda_handle_set_add(cumo_cuda_handle_set_t *set, size_t handle)
+{
+    rb_nativethread_lock_lock(&set->lock);
+    st_insert(set->table, (st_data_t)handle, (st_data_t)1);
+    rb_nativethread_lock_unlock(&set->lock);
+}
+
+// Raises unless the Integer names a handle this process created and has not
+// destroyed. NUM2SIZET rejects non-Integers first.
+static inline size_t
+cumo_cuda_handle_get(cumo_cuda_handle_set_t *set, VALUE v, const char *what)
+{
+    size_t handle = NUM2SIZET(v);
+    int found;
+
+    rb_nativethread_lock_lock(&set->lock);
+    found = st_lookup(set->table, (st_data_t)handle, 0);
+    rb_nativethread_lock_unlock(&set->lock);
+
+    if (!found) {
+        rb_raise(rb_eArgError, "not a live %s", what);
+    }
+    return handle;
+}
+
+// Same, and forgets the handle, so a second destroy raises instead of handing
+// the driver a pointer it has already released.
+static inline size_t
+cumo_cuda_handle_take(cumo_cuda_handle_set_t *set, VALUE v, const char *what)
+{
+    size_t handle = NUM2SIZET(v);
+    st_data_t key = (st_data_t)handle;
+    int found;
+
+    rb_nativethread_lock_lock(&set->lock);
+    found = st_delete(set->table, &key, 0);
+    rb_nativethread_lock_unlock(&set->lock);
+
+    if (!found) {
+        rb_raise(rb_eArgError, "not a live %s", what);
+    }
+    return handle;
+}
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+
+#endif /* ifndef CUMO_CUDA_HANDLE_H */

--- a/lib/cumo/cuda/nvrtc_program.rb
+++ b/lib/cumo/cuda/nvrtc_program.rb
@@ -12,7 +12,9 @@ module Cumo::CUDA
     end
 
     def destroy
-      NVRTC.nvrtcDestroyProgram(@ptr) if @ptr
+      return unless @ptr
+      NVRTC.nvrtcDestroyProgram(@ptr)
+      @ptr = nil
     end
 
     def compile(options: [])

--- a/test/cuda/driver_test.rb
+++ b/test/cuda/driver_test.rb
@@ -51,6 +51,33 @@ module Cumo::CUDA
       end
     end
 
+    # Handles cross into Ruby as plain Integers, so a made-up one used to reach
+    # the driver as a pointer and segfault.
+    def test_unknown_handles_are_rejected
+      assert_raise(ArgumentError) { Driver.cuLinkDestroy(1) }
+      assert_raise(ArgumentError) { Driver.cuLinkComplete(1) }
+      assert_raise(ArgumentError) { Driver.cuLinkAddFile(1, Driver::CU_JIT_INPUT_PTX, "k.ptx") }
+      assert_raise(ArgumentError) { Driver.cuLinkAddData(1, Driver::CU_JIT_INPUT_PTX, "", "k.ptx") }
+      assert_raise(ArgumentError) { Driver.cuModuleUnload(1) }
+      assert_raise(ArgumentError) { Driver.cuModuleGetFunction(1, "f") }
+      assert_raise(ArgumentError) { Driver.cuModuleGetGlobal(1, "g") }
+    end
+
+    def test_link_state_is_not_destroyed_twice
+      state = Driver.cuLinkCreate
+      Driver.cuLinkDestroy(state)
+      assert_raise(ArgumentError) { Driver.cuLinkDestroy(state) }
+      assert_raise(ArgumentError) { Driver.cuLinkComplete(state) }
+    end
+
+    def test_module_is_not_unloaded_twice
+      ptx = Compiler.new.compile_using_nvrtc(SOURCE)
+      hmod = Driver.cuModuleLoadData(ptx)
+      Driver.cuModuleUnload(hmod)
+      assert_raise(ArgumentError) { Driver.cuModuleUnload(hmod) }
+      assert_raise(ArgumentError) { Driver.cuModuleGetGlobal(hmod, "cumo_test_global") }
+    end
+
     def test_link_state_arguments_are_type_checked
       NON_STRINGS.each do |bad|
         LinkState.new do |link|

--- a/test/cuda/nvrtc_test.rb
+++ b/test/cuda/nvrtc_test.rb
@@ -68,6 +68,20 @@ module Cumo::CUDA
       end
     end
 
+    def test_unknown_program_is_rejected
+      assert_raise(ArgumentError) { NVRTC.nvrtcDestroyProgram(1) }
+      assert_raise(ArgumentError) { NVRTC.nvrtcCompileProgram(1, []) }
+      assert_raise(ArgumentError) { NVRTC.nvrtcGetPTX(1) }
+      assert_raise(ArgumentError) { NVRTC.nvrtcGetProgramLog(1) }
+    end
+
+    def test_destroyed_program_is_rejected
+      prog = test_nvrtcCreateProgram
+      NVRTC.nvrtcDestroyProgram(prog)
+      assert_raise(ArgumentError) { NVRTC.nvrtcDestroyProgram(prog) }
+      assert_raise(ArgumentError) { NVRTC.nvrtcGetPTX(prog) }
+    end
+
     def test_nvrtcCompileProgram
       prog = test_nvrtcCreateProgram
       options = []


### PR DESCRIPTION
## Reject CUDA handles this process did not create

`CUlinkState`, `CUmodule` and `nvrtcProgram` cross into Ruby as plain Integers, so `NUM2SIZET` turned whatever came back into a pointer and handed it to the CUDA API, which does not check it. Measured on RTX A4000 / CUDA 13.0, master `ab47126` — every one of these segfaults today:

```
Driver.cuLinkDestroy(1)        Driver.cuModuleUnload(1)         NVRTC.nvrtcDestroyProgram(1)
Driver.cuLinkComplete(1)       Driver.cuModuleGetFunction(1,…)  NVRTC.nvrtcCompileProgram(1, [])
Driver.cuLinkAddData(1,…)      Driver.cuModuleGetGlobal(1,…)    NVRTC.nvrtcGetPTX(1)
                                                                NVRTC.nvrtcGetProgramLog(1)
```

`cuLinkAddFile(1, …)` is the eleventh. The realistic one is not a made-up Integer though — it is destroying twice:

```ruby
state = Driver.cuLinkCreate
Driver.cuLinkDestroy(state)
Driver.cuLinkDestroy(state)   # abort (exit 134)
```

Live handles now go into a set, and each entry point looks its argument up on the way in. `cuLinkDestroy` / `cuModuleUnload` / `nvrtcDestroyProgram` take the handle out of the set, so a second call raises `ArgumentError` instead of releasing the same pointer again. The set is locked because a Ractor gets its own GVL.

Argument type checks still run first, so `cuModuleGetGlobal(0, [1,2])` keeps raising `TypeError` as before — the existing type-check tests pass unchanged.

`NVRTCProgram#destroy` now clears `@ptr` the way `Module#unload` already did, so calling it twice stays a no-op rather than becoming an `ArgumentError`.

`rake test` is 917 tests / 11038 assertions / 0 failures. The new tests take the process down on master.
