### PR TITLE
Fix wrong Cumo::RObject results on host memory

### DIFF
--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -45,7 +45,10 @@ cumo_cuda_runtime_is_device_memory(void* ptr)
     if (!ptr) { return false; }
     status = cudaPointerGetAttributes(&attrs, ptr);
     cudaGetLastError(); // reset last error to success
-    return (status != cudaErrorInvalidValue);
+    // Since CUDA 11 this succeeds for host memory as well and reports the kind
+    // in attrs.type, so the status alone no longer tells the two apart.
+    if (status != cudaSuccess) { return false; }
+    return (attrs.type != cudaMemoryTypeUnregistered);
 }
 
 #if defined(__cplusplus)

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -52,7 +52,7 @@ static ID cumo_id_swap_byte;
 }
 
 void cumo_iter_copy_bytes_kernel_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, size_t n, int elmsz);
-// #define m_memcpy(src,dst) memcpy(dst,src,e)
+#define m_memcpy(src,dst) memcpy(dst,src,e)
 
 static void
 iter_copy_bytes(cumo_na_loop_t *const lp)
@@ -61,13 +61,22 @@ iter_copy_bytes(cumo_na_loop_t *const lp)
     ssize_t s1, s2;
     char   *p1, *p2;
     size_t *idx1, *idx2;
+    size_t  e;
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-    cumo_iter_copy_bytes_kernel_launch(p1, p2, s1, s2, idx1, idx2, n, lp->args[0].elmsz);
-    // size_t e;
-    // e = lp->args[0].elmsz;
-    // LOOP_UNARY_PTR(lp,m_memcpy);
+    if (cumo_cuda_runtime_is_device_memory(p2)) {
+        cumo_iter_copy_bytes_kernel_launch(p1, p2, s1, s2, idx1, idx2, n, lp->args[0].elmsz);
+        return;
+    }
+    // Cumo::RObject data is host memory. A kernel would write it asynchronously
+    // with nothing ordering that against the host reading it back.
+    if (idx1 || idx2) {
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("copy", "any");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    }
+    e = lp->args[0].elmsz;
+    LOOP_UNARY_PTR(lp,m_memcpy);
 }
 
 VALUE

--- a/ext/cumo/narray/gen/tmpl/new_dim0.c
+++ b/ext/cumo/narray/gen/tmpl/new_dim0.c
@@ -1,4 +1,6 @@
+<% unless is_object %>
 void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x);
+<% end %>
 
 static VALUE
 <%=c_func(:nodef)%>(dtype x)
@@ -8,7 +10,13 @@ static VALUE
 
     v = cumo_na_new(cT, 0, NULL);
     ptr = (dtype*)cumo_na_get_pointer_for_write(v);
+<% if is_object %>
+    // RObject data is host memory. A kernel would write it asynchronously with
+    // nothing ordering that against the host loop that reads it back.
+    *ptr = x;
+<% else %>
     <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(ptr, x);
+<% end %>
 
     cumo_na_release_lock(v);
     return v;

--- a/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
@@ -1,3 +1,4 @@
+<% unless is_object %>
 __global__ void <%="cumo_#{c_func(:nodef)}_kernel"%>(dtype *ptr, dtype x)
 {
     *ptr = x;
@@ -6,3 +7,4 @@ void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x)
 {
     <%="cumo_#{c_func(:nodef)}_kernel"%><<<1,1>>>(ptr,x);
 }
+<% end %>

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -25,6 +25,7 @@ typedef struct CUMO_NA_BUFFER_COPY {
     size_t *n;
     char *src_ptr;
     char *buf_ptr;
+    bool buf_on_device;
     cumo_na_loop_iter_t *src_iter;
     cumo_na_loop_iter_t *buf_iter;
 } cumo_na_buffer_copy_t;
@@ -468,7 +469,7 @@ ndloop_release(VALUE vlp)
         //printf("lp->xargs[%d].bufcp=%lx\n",j,(size_t)(lp->xargs[j].bufcp));
         if (lp->xargs[j].bufcp) {
             xfree(lp->xargs[j].bufcp->buf_iter);
-            if (cumo_cuda_runtime_is_device_memory(lp->xargs[j].bufcp->buf_ptr)) {
+            if (lp->xargs[j].bufcp->buf_on_device) {
                 cumo_cuda_runtime_free(lp->xargs[j].bufcp->buf_ptr);
             }
             else {
@@ -1120,7 +1121,8 @@ cumo_ndfunc_set_bufcp(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
             LARG(lp,j).iter = buf_iter;
             //printf("in cumo_ndfunc_set_bufcp(1): lp->user.args[%d].iter=%lx\n",j,(size_t)(LARG(lp,j).iter));
             LBUFCP(lp,j)->src_ptr = LARG(lp,j).ptr;
-            if (cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr)) {
+            LBUFCP(lp,j)->buf_on_device = cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr);
+            if (LBUFCP(lp,j)->buf_on_device) {
                 LARG(lp,j).ptr = LBUFCP(lp,j)->buf_ptr = cumo_cuda_runtime_malloc(sz);
             }
             else {
@@ -1196,17 +1198,45 @@ cumo_na_make_indexer_buffer_copy(cumo_na_buffer_copy_t* lp)
     return indexer;
 }
 
+// The index arrays live in device memory and are filled by kernels, so a host
+// loop must not read them until those kernels are done.
+static void
+ndloop_sync_src_index(cumo_na_buffer_copy_t *lp)
+{
+    int i;
+    for (i=0; i<lp->ndim; i++) {
+        if (LITER_SRC(lp,i).idx) {
+            CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop buffer copy", "any");
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            return;
+        }
+    }
+}
+
+// Same for the index arrays the user function itself walks, which it reads on
+// the host whenever the data it indexes is host memory.
+static void
+ndloop_sync_user_index(cumo_na_md_loop_t *lp)
+{
+    int i, j;
+    for (j=0; j<lp->narg; j++) {
+        if (LARG(lp,j).iter == NULL) continue;
+        for (i=0; i<LARG(lp,j).ndim; i++) {
+            if (LARG(lp,j).iter[i].idx == NULL) continue;
+            if (cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr)) break;
+            CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop", "any");
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            return;
+        }
+    }
+}
+
 void cumo_ndloop_copy_to_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo_na_indexer_t* indexer, char *buf, size_t elmsz);
 
 // Make contiguous memory for ops not supporting index or stride (step) loop
 static void
 ndloop_copy_to_buffer(cumo_na_buffer_copy_t *lp)
 {
-    cumo_na_iarray_stridx_t a = cumo_na_make_iarray_buffer_copy(lp);
-    cumo_na_indexer_t indexer = cumo_na_make_indexer_buffer_copy(lp);
-    cumo_ndloop_copy_to_buffer_kernel_launch(&a, &indexer, lp->buf_ptr, lp->elmsz);
-
-#if 0
     size_t *c;
     char *src, *buf;
     int  i;
@@ -1215,19 +1245,24 @@ ndloop_copy_to_buffer(cumo_na_buffer_copy_t *lp)
     size_t buf_pos = 0;
     DBG(size_t j);
 
+    if (lp->buf_on_device) {
+        cumo_na_iarray_stridx_t a = cumo_na_make_iarray_buffer_copy(lp);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer_buffer_copy(lp);
+        cumo_ndloop_copy_to_buffer_kernel_launch(&a, &indexer, lp->buf_ptr, lp->elmsz);
+        return;
+    }
+
+    // A host buffer is read by a host loop, which an async kernel is not
+    // ordered against, so copy it on the host as well.
+    ndloop_sync_src_index(lp);
+
     //printf("\nto_buf nd=%d elmsz=%ld\n",nd,elmsz);
     DBG(printf("<to buf> ["));
     // zero-dimension
     if (nd==0) {
         src = lp->src_ptr + LITER_SRC(lp,0).pos;
         buf = lp->buf_ptr;
-        if (cumo_cuda_runtime_is_device_memory(src) && cumo_cuda_runtime_is_device_memory(buf)) {
-            DBG(printf("DtoD] ["));
-            cumo_cuda_runtime_check_status(cudaMemcpyAsync(buf,src,elmsz,cudaMemcpyDeviceToDevice,0));
-        } else {
-            DBG(printf("HtoH] ["));
-            memcpy(buf,src,elmsz);
-        }
+        memcpy(buf,src,elmsz);
         DBG(for (j=0; j<elmsz/8; j++) {printf("%g,",((double*)(buf))[j]);});
         goto loop_end;
     }
@@ -1239,8 +1274,6 @@ ndloop_copy_to_buffer(cumo_na_buffer_copy_t *lp)
         // i-th dimension
         for (; i<nd; i++) {
             if (LITER_SRC(lp,i).idx) {
-                CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("ndloop_copy_to_buffer", "any");
-                cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
                 LITER_SRC(lp,i+1).pos = LITER_SRC(lp,i).pos + LITER_SRC(lp,i).idx[c[i]];
             } else {
                 LITER_SRC(lp,i+1).pos = LITER_SRC(lp,i).pos + LITER_SRC(lp,i).step*c[i];
@@ -1248,13 +1281,7 @@ ndloop_copy_to_buffer(cumo_na_buffer_copy_t *lp)
         }
         src = lp->src_ptr + LITER_SRC(lp,nd).pos;
         buf = lp->buf_ptr + buf_pos;
-        if (cumo_cuda_runtime_is_device_memory(src) && cumo_cuda_runtime_is_device_memory(buf)) {
-            DBG(printf("DtoD] ["));
-            cumo_cuda_runtime_check_status(cudaMemcpyAsync(buf,src,elmsz,cudaMemcpyDeviceToDevice,0));
-        } else {
-            DBG(printf("HtoH] ["));
-            memcpy(buf,src,elmsz);
-        }
+        memcpy(buf,src,elmsz);
         DBG(for (j=0; j<elmsz/8; j++) {printf("%g,",((double*)(buf))[j]);});
         buf_pos += elmsz;
         // count up
@@ -1268,7 +1295,6 @@ ndloop_copy_to_buffer(cumo_na_buffer_copy_t *lp)
  loop_end:
     ;
     DBG(printf("]\n"));
-#endif
 }
 
 void cumo_ndloop_copy_from_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo_na_indexer_t* indexer, char *buf, size_t elmsz);
@@ -1276,11 +1302,6 @@ void cumo_ndloop_copy_from_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo
 static void
 ndloop_copy_from_buffer(cumo_na_buffer_copy_t *lp)
 {
-    cumo_na_iarray_stridx_t a = cumo_na_make_iarray_buffer_copy(lp);
-    cumo_na_indexer_t indexer = cumo_na_make_indexer_buffer_copy(lp);
-    cumo_ndloop_copy_from_buffer_kernel_launch(&a, &indexer, lp->buf_ptr, lp->elmsz);
-
-#if 0
     size_t *c;
     char *src, *buf;
     int  i;
@@ -1289,19 +1310,22 @@ ndloop_copy_from_buffer(cumo_na_buffer_copy_t *lp)
     size_t buf_pos = 0;
     DBG(size_t j);
 
+    if (lp->buf_on_device) {
+        cumo_na_iarray_stridx_t a = cumo_na_make_iarray_buffer_copy(lp);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer_buffer_copy(lp);
+        cumo_ndloop_copy_from_buffer_kernel_launch(&a, &indexer, lp->buf_ptr, lp->elmsz);
+        return;
+    }
+
+    ndloop_sync_src_index(lp);
+
     //printf("\nfrom_buf nd=%d elmsz=%ld\n",nd,elmsz);
     DBG(printf("<from buf> ["));
     // zero-dimension
     if (nd==0) {
         src = lp->src_ptr + LITER_SRC(lp,0).pos;
         buf = lp->buf_ptr;
-        if (cumo_cuda_runtime_is_device_memory(src) && cumo_cuda_runtime_is_device_memory(buf)) {
-            DBG(printf("DtoD] ["));
-            cumo_cuda_runtime_check_status(cudaMemcpyAsync(src,buf,elmsz,cudaMemcpyDeviceToDevice,0));
-        } else {
-            DBG(printf("HtoH] ["));
-            memcpy(src,buf,elmsz);
-        }
+        memcpy(src,buf,elmsz);
         DBG(for (j=0; j<elmsz/8; j++) {printf("%g,",((double*)(src))[j]);});
         goto loop_end;
     }
@@ -1313,8 +1337,6 @@ ndloop_copy_from_buffer(cumo_na_buffer_copy_t *lp)
         // i-th dimension
         for (; i<nd; i++) {
             if (LITER_SRC(lp,i).idx) {
-                CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("ndloop_copy_from_buffer", "any");
-                cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
                 LITER_SRC(lp,i+1).pos = LITER_SRC(lp,i).pos + LITER_SRC(lp,i).idx[c[i]];
             } else {
                 LITER_SRC(lp,i+1).pos = LITER_SRC(lp,i).pos + LITER_SRC(lp,i).step*c[i];
@@ -1322,13 +1344,7 @@ ndloop_copy_from_buffer(cumo_na_buffer_copy_t *lp)
         }
         src = lp->src_ptr + LITER_SRC(lp,nd).pos;
         buf = lp->buf_ptr + buf_pos;
-        if (cumo_cuda_runtime_is_device_memory(src) && cumo_cuda_runtime_is_device_memory(buf)) {
-            DBG(printf("DtoD] ["));
-            cumo_cuda_runtime_check_status(cudaMemcpyAsync(src,buf,elmsz,cudaMemcpyDeviceToDevice,0));
-        } else {
-            DBG(printf("HtoH] ["));
-            memcpy(src,buf,elmsz);
-        }
+        memcpy(src,buf,elmsz);
         DBG(for (j=0; j<elmsz/8; j++) {printf("%g,",((double*)(src))[j]);});
         buf_pos += elmsz;
         // count up
@@ -1344,7 +1360,6 @@ ndloop_copy_from_buffer(cumo_na_buffer_copy_t *lp)
     }
  loop_end:
     DBG(printf("]\n"));
-#endif
 }
 
 
@@ -1516,6 +1531,8 @@ loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
     if (nd<0) {
         rb_bug("bug? lp->ndim = %d\n", lp->ndim);
     }
+
+    ndloop_sync_user_index(lp);
 
     if (nd==0 || CUMO_NDF_TEST(nf,CUMO_NDF_INDEXER_LOOP)) {
         for (j=0; j<lp->nin; j++) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -920,6 +920,34 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  test "Cumo::RObject with a scalar operand" do
+    a = Cumo::RObject.new(3)
+    a.store(1)
+    assert_equal([1, 1, 1], a.to_a)
+    assert_equal([1, 2, 3], (Cumo::RObject.new(3).seq + 1).to_a)
+  end
+
+  test "Cumo::RObject view" do
+    a = Cumo::RObject[0, 1, 2, 3, 4, 5]
+
+    assert_equal([0, 1, 2], a[0..2].copy.to_a)
+    assert_equal(3, a[0..2].sum)
+    assert_equal(6, a[[0, 2, 4]].sum)
+    assert_equal([0, 4, 8], (a[[0, 2, 4]] + a[[0, 2, 4]]).to_a)
+
+    a[[0, 2, 4]] = Cumo::RObject[10, 20, 30]
+    assert_equal([10, 1, 20, 3, 30, 5], a.to_a)
+  end
+
+  test "Cumo::RObject 2-d view" do
+    a = Cumo::RObject.new(3, 4).seq
+    b = a[true, [3, 1, 0, 2]]
+
+    assert_equal([[3, 1, 0, 2], [7, 5, 4, 6], [11, 9, 8, 10]], b.to_a)
+    assert_equal([[6, 2, 0, 4], [14, 10, 8, 12], [22, 18, 16, 20]], (b + b).to_a)
+    assert_equal([21, 15, 12, 18], b.sum(axis: 0).to_a)
+  end
+
   test "single element array" do
     assert { Cumo::SFloat[1].mean == 1.0 }
     assert { Cumo::DFloat[1].mean == 1.0 }


### PR DESCRIPTION
## Summary

`cumo_cuda_runtime_is_device_memory()` told host memory from device memory by whether `cudaPointerGetAttributes()` returned `cudaErrorInvalidValue`. Since CUDA 11 that call succeeds for host memory too and reports the kind in `attrs.type`, so the predicate answered `true` for every pointer, including plain `malloc()` and the stack.

`Cumo::RObject` is the only dtype whose data is host memory — `allocate` takes `xmalloc` for it and the CUDA allocator for everything else. With the predicate always saying "device", RObject arrays were handed to asynchronous kernels that nothing ordered the host loops reading the result against, so they silently produced `nil` and `false` elements.

Four sites, all reachable only because the predicate could not see host memory:

- `ndloop` allocated the buffer for an RObject argument with the CUDA allocator and filled it with a copy kernel. The host copy path in `ndloop.c` had been `#if 0`'d out because it could never be selected.
- `new_dim0` wrote the single element of a 0-dim array with a kernel, which is how every scalar operand is built.
- `iter_copy_bytes` copied with a kernel, which is `NArray#copy` and the contiguous copy a reduction over a view makes for itself.
- Host loops walk `idx` arrays, which are device memory filled by kernels, without synchronizing first. Zero-filled managed memory reads as index 0.

Reading `attrs.type` keeps pre-CUDA-11 drivers correct as well, since the old `cudaErrorInvalidValue` is not `cudaSuccess`. The predicate is now consulted once per `ndloop` buffer instead of once per element, and the per-element `cudaDeviceSynchronize()` the disabled copy path carried becomes one call before the loop.

## Problem

```ruby
a = Cumo::RObject[0, 1, 2, 3, 4, 5]

a[[0, 2, 4]] + a[[0, 2, 4]]   # NoMethodError: undefined method '+' for false
a[0..2].sum                   # NoMethodError: undefined method '+' for nil
a[0..2].copy.to_a             # [nil, nil, nil]

b = Cumo::RObject.new(3)
b.store(1)                    # [nil, nil, nil]
Cumo::RObject.new(3).seq + 1  # TypeError: nil can't be coerced into Integer

a[[0, 2, 4]] = Cumo::RObject[10, 20, 30]
a.to_a                        # [30, 1, 2, 3, 4, 5] -- all three writes landed on index 0
```

`CUDA_LAUNCH_BLOCKING=1` makes every one of these correct, which is what identifies the cause as ordering rather than a faulting kernel. Measured on an RTX A4000 with CUDA 13.0; the added tests fail on `master` with one failure and two errors.

## Note

`LOOP_UNARY_PTR` writes to `p1 + *idx2` where it means `p2 + *idx2` when only the destination carries an index. That is identical in numo-narray and numo-narray-alt, and `cumo_na_copy` always allocates a contiguous destination, so nothing here reaches it. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
