### PR TITLE
Fix kernel launch errors being discarded

### DIFF
--- a/ext/cumo/cuda/runtime.c
+++ b/ext/cumo/cuda/runtime.c
@@ -10,6 +10,15 @@ VALUE cumo_cuda_mRuntime;
 
 #define check_status(status) (cumo_cuda_runtime_check_status((status)))
 
+// Called right after a <<<>>> launch. cudaGetLastError() reports errors the
+// launch itself was rejected for; a fault while the kernel runs is asynchronous
+// and still surfaces at a later call.
+void
+cumo_cuda_runtime_check_kernel_launch(void)
+{
+    check_status(cudaGetLastError());
+}
+
 ///////////////////////////////////////////
 // Version Management
 ///////////////////////////////////////////

--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -169,6 +169,7 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
     cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 // Variant of cumo_reduce for arg-reductions (argmax/argmin), which returns
@@ -192,6 +193,7 @@ void cumo_reduce_arg(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
     cumo_detail::reduction_arg_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 #endif // CUMO_REDUCE_KERNEL_H

--- a/ext/cumo/include/cumo/template_kernel.h
+++ b/ext/cumo/include/cumo/template_kernel.h
@@ -69,9 +69,16 @@ cumo_get_grid_dim(size_t n)
 static inline size_t
 cumo_get_block_dim(size_t n)
 {
+    // A launch of zero threads is rejected as an invalid configuration, and an
+    // empty array reaches here with n == 0. Every kernel is bounded by n, so a
+    // single thread does no work.
     size_t block_dim = (n > CUMO_MAX_BLOCK_DIM) ? CUMO_MAX_BLOCK_DIM : n;
-    return block_dim;
+    return (block_dim == 0) ? 1 : block_dim;
 }
+
+// Raises the error a kernel launch reported, if any. Defined in cuda/runtime.c
+// because raising needs ruby.h, which the .cu translation units do not include.
+void cumo_cuda_runtime_check_kernel_launch(void);
 
 
 #endif /* ifndef CUMO_TEMPLATE_KERNEL_H */

--- a/ext/cumo/narray/data_kernel.cu
+++ b/ext/cumo/narray/data_kernel.cu
@@ -44,6 +44,7 @@ void cumo_iter_copy_bytes_kernel_launch(char *p1, char *p2, ssize_t s1, ssize_t 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_iter_copy_bytes_kernel<<<grid_dim, block_dim>>>(p1, p2, s1, s2, idx1, idx2, n, elmsz);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_diagonal_index_index_kernel_launch(size_t *idx, size_t *idx0, size_t *idx1, size_t k0, size_t k1, uint64_t n)
@@ -51,6 +52,7 @@ void cumo_na_diagonal_index_index_kernel_launch(size_t *idx, size_t *idx0, size_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_diagonal_index_index_kernel<<<grid_dim, block_dim>>>(idx, idx0, idx1, k0, k1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_diagonal_index_stride_kernel_launch(size_t *idx, size_t *idx0, ssize_t s1, size_t k0, size_t k1, uint64_t n)
@@ -58,6 +60,7 @@ void cumo_na_diagonal_index_stride_kernel_launch(size_t *idx, size_t *idx0, ssiz
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_diagonal_index_stride_kernel<<<grid_dim, block_dim>>>(idx, idx0, s1, k0, k1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_diagonal_stride_index_kernel_launch(size_t *idx, ssize_t s0, size_t *idx1, size_t k0, size_t k1, uint64_t n)
@@ -65,6 +68,7 @@ void cumo_na_diagonal_stride_index_kernel_launch(size_t *idx, ssize_t s0, size_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_diagonal_stride_index_kernel<<<grid_dim, block_dim>>>(idx, s0, idx1, k0, k1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 #if defined(__cplusplus)

--- a/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
@@ -48,9 +48,11 @@ void <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel_launch"%>(char *p1, char *
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> r1(p1_begin, p1_end, s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> r2(p2_begin, p2_end, s2_idx);
         <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(r1.begin(), r1.end(), r2.begin(), (dtype*)p3);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         // ref. https://github.com/thrust/thrust/blob/master/examples/cuda/async_reduce.cu
         <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(p1_begin, p1_end, p2_begin, (dtype*)p3);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -59,6 +61,7 @@ void <%="cumo_#{type_name}_mulsum#{nan}_kernel_launch"%>(char *p1, char *p2, cha
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{type_name}_mulsum#{nan}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 //<% end %>
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
@@ -11,5 +11,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ch
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -27,5 +27,6 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
         <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
         break;
     }
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
@@ -11,5 +11,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ss
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -81,10 +81,12 @@ void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, ch
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (dtype*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (dtype*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -94,10 +96,12 @@ void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
     thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -107,10 +111,12 @@ void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, 
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -120,10 +126,12 @@ void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 

--- a/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
@@ -14,5 +14,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, CUMO_BIT_DIG
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a3,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/ewcomp_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/ewcomp_kernel.cu
@@ -13,6 +13,7 @@ void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(char *p1, char *p2, cha
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{type_name}_#{name}#{nan}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/eye_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/eye_kernel.cu
@@ -14,6 +14,7 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *ptr, ssize_t s0, ssize_t s
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(ptr,s0,s1,kofs,data,n0,n1,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>
 

--- a/ext/cumo/narray/gen/tmpl/fill_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/fill_kernel.cu
@@ -18,6 +18,7 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *ptr, size_t *idx, dtype val
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(ptr,idx,val,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *ptr, ssize_t step, dtype val, uint64_t n)
@@ -25,5 +26,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *ptr, ssize_t step, dtype v
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(ptr,step,val,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -59,10 +59,12 @@ void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, ch
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -72,10 +74,12 @@ void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -85,10 +89,12 @@ void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, 
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }
 
@@ -98,9 +104,11 @@ void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, cha
     thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
     if (s1_idx == 1 || n == 1) {
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     } else {
         thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
         cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
         cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
+        cumo_cuda_runtime_check_kernel_launch();
     }
 }

--- a/ext/cumo/narray/gen/tmpl/logseq_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/logseq_kernel.cu
@@ -20,6 +20,7 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t* idx1, seq_data_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,beg,step,base,c,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t beg, seq_data_t step, seq_data_t base, seq_count_t c, uint64_t n)
@@ -27,5 +28,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,beg,step,base,c,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/new_dim0_kernel.cu
@@ -6,5 +6,6 @@ __global__ void <%="cumo_#{c_func(:nodef)}_kernel"%>(dtype *ptr, dtype x)
 void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x)
 {
     <%="cumo_#{c_func(:nodef)}_kernel"%><<<1,1>>>(ptr,x);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/pow_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/pow_kernel.cu
@@ -18,6 +18,7 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_int32_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
@@ -25,5 +26,6 @@ void <%="cumo_#{c_iter}_int32_kernel_launch"%>(char *p1, char *p2, char *p3, ssi
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_int32_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -72,4 +72,5 @@ void cumo_<%=type_name%>_max_kernel_launch(cumo_na_reduction_arg_t* arg)
 void cumo_<%=type_name%>_ptp_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     cumo_<%=type_name%>_ptp_kernel<<<1,1>>>(*arg);
+    cumo_cuda_runtime_check_kernel_launch();
 }

--- a/ext/cumo/narray/gen/tmpl/seq_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/seq_kernel.cu
@@ -32,6 +32,7 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t* idx1, seq_data_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,beg,step,c,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n)
@@ -39,5 +40,6 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,beg,step,c,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/store_array_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/store_array_kernel.cu
@@ -32,6 +32,7 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, dtype* z,
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, dtype* z, uint64_t n)
@@ -39,6 +40,7 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, dtype* z, 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(char *p1, size_t *idx1, dtype z, uint64_t n)
@@ -46,6 +48,7 @@ void <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(char *p1, size_t *idx1, dt
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_scalar_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(char *p1, ssize_t s1, dtype z, uint64_t n)
@@ -53,6 +56,7 @@ void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(char *p1, ssize_t s1, dty
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_scalar_kernel"%><<<grid_dim, block_dim>>>(p1,s1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/store_bit_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/store_bit_kernel.cu
@@ -40,6 +40,7 @@ void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, size_t p2, CUMO_B
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a2,idx1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, ssize_t s1, size_t *idx2, uint64_t n)
@@ -47,6 +48,7 @@ void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, size_t p2, CUMO_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a2,s1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, size_t *idx1, ssize_t s2, uint64_t n)
@@ -54,6 +56,7 @@ void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, size_t p2, CUMO_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a2,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, ssize_t s1, ssize_t s2, uint64_t n)
@@ -61,6 +64,7 @@ void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, size_t p2, CUMO
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a2,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
@@ -32,6 +32,7 @@ void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
@@ -39,6 +40,7 @@ void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
@@ -46,6 +48,7 @@ void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
@@ -53,6 +56,7 @@ void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_kernel.cu
@@ -40,6 +40,7 @@ void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
@@ -47,6 +48,7 @@ void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
@@ -54,6 +56,7 @@ void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
@@ -61,6 +64,7 @@ void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n)
@@ -68,5 +72,6 @@ void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(p1,p2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
@@ -32,6 +32,7 @@ void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
@@ -39,6 +40,7 @@ void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
@@ -46,6 +48,7 @@ void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
@@ -53,6 +56,7 @@ void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 <% end %>

--- a/ext/cumo/narray/gen/tmpl_bit/bit_count_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_count_kernel.cu
@@ -50,6 +50,7 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIG
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,idx1,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, ssize_t s1, uint64_t n)
@@ -57,6 +58,7 @@ void <%="cumo_#{c_iter}_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DI
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,s1,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, size_t *idx1, ssize_t s2, uint64_t n)
@@ -64,6 +66,7 @@ void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, ssize_t s1, ssize_t s2, uint64_t n)
@@ -71,6 +74,7 @@ void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(size_t p1, char *p2, CUMO
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 #undef int_t

--- a/ext/cumo/narray/index_kernel.cu
+++ b/ext/cumo/narray/index_kernel.cu
@@ -89,6 +89,7 @@ void cumo_na_index_aref_nadata_index_stride_kernel_launch(size_t *idx, ssize_t s
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_aref_nadata_index_stride_kernel<<<grid_dim, block_dim>>>(idx, s1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_aref_naview_index_index_kernel_launch(size_t *idx, size_t *idx1, uint64_t n)
@@ -96,6 +97,7 @@ void cumo_na_index_aref_naview_index_index_kernel_launch(size_t *idx, size_t *id
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_aref_naview_index_index_kernel<<<grid_dim, block_dim>>>(idx, idx1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_aref_naview_index_stride_last_kernel_launch(size_t *idx, ssize_t s1, size_t last, uint64_t n)
@@ -103,6 +105,7 @@ void cumo_na_index_aref_naview_index_stride_last_kernel_launch(size_t *idx, ssiz
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_aref_naview_index_stride_last_kernel<<<grid_dim, block_dim>>>(idx, s1, last, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_aref_naview_index_stride_kernel_launch(size_t *idx, ssize_t s1, uint64_t n)
@@ -110,6 +113,7 @@ void cumo_na_index_aref_naview_index_stride_kernel_launch(size_t *idx, ssize_t s
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_aref_naview_index_stride_kernel<<<grid_dim, block_dim>>>(idx, s1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_aref_naview_index_index_beg_step_kernel_launch(size_t *idx, size_t *idx1, size_t beg, ssize_t step, uint64_t n)
@@ -117,6 +121,7 @@ void cumo_na_index_aref_naview_index_index_beg_step_kernel_launch(size_t *idx, s
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_aref_naview_index_index_beg_step_kernel<<<grid_dim, block_dim>>>(idx, idx1, beg, step, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_nadata_index_stride_add_kernel_launch(size_t *idx, size_t *idx1, ssize_t s1, uint64_t n)
@@ -124,6 +129,7 @@ void cumo_na_index_at_nadata_index_stride_add_kernel_launch(size_t *idx, size_t 
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_nadata_index_stride_add_kernel<<<grid_dim, block_dim>>>(idx, idx1, s1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_nadata_index_beg_step_stride_kernel_launch(size_t *idx, size_t beg, ssize_t step, ssize_t s1, uint64_t n)
@@ -131,6 +137,7 @@ void cumo_na_index_at_nadata_index_beg_step_stride_kernel_launch(size_t *idx, si
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_nadata_index_beg_step_stride_kernel<<<grid_dim, block_dim>>>(idx, beg, step, s1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_nadata_index_beg_step_stride_add_kernel_launch(size_t *idx, size_t beg, ssize_t step, ssize_t s1, uint64_t n)
@@ -138,6 +145,7 @@ void cumo_na_index_at_nadata_index_beg_step_stride_add_kernel_launch(size_t *idx
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_nadata_index_beg_step_stride_add_kernel<<<grid_dim, block_dim>>>(idx, beg, step, s1, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_naview_index_index_index_add_kernel_launch(size_t *idx, size_t *idx1, size_t *idx2, uint64_t n)
@@ -145,6 +153,7 @@ void cumo_na_index_at_naview_index_index_index_add_kernel_launch(size_t *idx, si
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_naview_index_index_index_add_kernel<<<grid_dim, block_dim>>>(idx, idx1, idx2, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_naview_index_index_beg_step_add_kernel_launch(size_t *idx, size_t *idx1, size_t beg, ssize_t step, uint64_t n)
@@ -152,6 +161,7 @@ void cumo_na_index_at_naview_index_index_beg_step_add_kernel_launch(size_t *idx,
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_naview_index_index_beg_step_add_kernel<<<grid_dim, block_dim>>>(idx, idx1, beg, step, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, ssize_t s1, size_t last, uint64_t n)
@@ -159,6 +169,7 @@ void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, ss
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
     cumo_na_index_at_naview_index_stride_last_add_kernel<<<grid_dim, block_dim>>>(idx, s1, last, n);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 #if defined(__cplusplus)

--- a/ext/cumo/narray/ndloop_kernel.cu
+++ b/ext/cumo/narray/ndloop_kernel.cu
@@ -64,6 +64,7 @@ void cumo_ndloop_copy_from_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo
             cumo_ndloop_copy_from_buffer_kernel_dim<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
             break;
     }
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_ndloop_copy_to_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo_na_indexer_t* indexer, char *buf, size_t elmsz)
@@ -87,6 +88,7 @@ void cumo_ndloop_copy_to_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo_n
             cumo_ndloop_copy_to_buffer_kernel_dim<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
             break;
     }
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 #if defined(__cplusplus)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -981,6 +981,24 @@ class NArrayTest < Test::Unit::TestCase
     assert { empty.concatenate(empty) == [] }
   end
 
+  test "empty array leaves no CUDA error behind" do
+    {
+      Cumo::DFloat => [1.0, 2.0, 3.0, 4.0],
+      Cumo::Int32 => [1, 2, 3, 4],
+      Cumo::SComplex => [Complex(1), Complex(2), Complex(3), Complex(4)],
+    }.each do |dtype, expected|
+      empty = dtype.new(0)
+      assert_equal([], empty.seq.to_a)
+      assert_equal([], (empty + 1).to_a)
+      assert_equal([], empty.copy.to_a)
+      assert_equal([], (empty * empty).to_a)
+      assert_equal([], dtype.new(4).seq[[]].to_a)
+
+      # an error left behind by the launches above surfaces on the next one
+      assert_equal(expected, (dtype.new(4).seq + 1).to_a)
+    end
+  end
+
   test "parse" do
     assert { Cumo::DFloat.parse("2 -3 5\n4 9 7\n2 -1 6") == Cumo::DFloat[[2, -3, 5], [4, 9, 7], [2, -1, 6]] }
     assert { Cumo::DFloat.parse("1 2; 3 4") == Cumo::DFloat[[1, 2], [3, 4]] }


### PR DESCRIPTION
## Summary

No `<<<>>>` launch in the extension was followed by `cudaGetLastError()`, so a launch the driver rejected produced no error anywhere. The operation returned normally with its output buffer untouched, and the recorded error sat in the runtime's per-thread slot until something discarded it — `cumo_cuda_runtime_is_device_memory()` calls `cudaGetLastError()` purely to clear it.

This adds the check to all 79 launch sites in the real sources. Functions that select a kernel with a `switch` check once after the switch, so the audit unit is the launch function: of the 1805 launch functions in the generated tree, none is now without a check.

The second half is `cumo_get_block_dim()`, which returns 0 when the array is empty. A launch of zero threads is itself rejected, so every operation on an empty array was already producing a discarded error — adding the check alone would have turned `Cumo::DFloat.new(0).seq` into a `Cumo::CUDA::RuntimeError`. It now never derives a block dimension below 1; every kernel is bounded by `n`, so the single thread does no work.

`cudaGetLastError()` after a launch reports what the launch was rejected for — configuration, resources. A fault while the kernel runs is asynchronous and still surfaces at a later call, as before.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

With `CUMO_MAX_BLOCK_DIM` temporarily set past the hardware limit so that every launch is rejected:

```ruby
a = Cumo::DFloat.new(5000).seq
b = a + 1.0
b[0..3].to_a   # => [0.0, 0.0, 0.0, 0.0], and nothing raised
```

On this branch the same build raises `Cumo::CUDA::RuntimeError: invalid argument (error=1)` from `Cumo::DFloat#seq`, at the operation that failed.

The zero-thread launch needs no fault injection. Instrumenting `cumo_get_block_dim()` shows `n == 0` reaching it from `Cumo::DFloat.new(0).seq` and `Cumo::DFloat.new(0) + 1`, and building this branch with the check but without the block-dimension fix makes both of them raise.

The added test does not fail on `master`: with nothing checking `cudaGetLastError()`, `master` has no way to observe the error it leaves behind. It guards the pair — it fails if the block dimension can reach 0 again while the check is in place.

Full suite 921 tests, 11066 assertions, 0 failures, verified from a deleted `tmp/`. Elementwise, fancy-index, copy and scalar microbenchmarks over a 1e6-element `DFloat` are unchanged within noise.

## Note

The check adds a raise point to each launch function. Where a caller has already allocated a scratch buffer it does not own through `rb_ensure` — `store_array.c`'s `host_z`, and the index arrays in `index.c` — a rejected launch now leaks that buffer instead of continuing with a wrong result. `host_z` leaking on a raise is already tracked separately; this does not widen it beyond the case where a launch was rejected, which previously produced silent garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
