### PR TITLE
Fix CUDA initialisation statuses being ignored

### DIFF
--- a/ext/cumo/cuda/cublas.c
+++ b/ext/cumo/cuda/cublas.c
@@ -51,14 +51,16 @@ cumo_cuda_cublas_handle()
     if (handles == 0) {
         int i;
         int device_count = cumo_cuda_runtime_get_device_count();
-        handles = malloc(sizeof(cublasHandle_t) * device_count);
+        handles = ALLOC_N(cublasHandle_t, device_count);
         for (i = 0; i < device_count; ++i) {
             handles[i] = 0;
         }
     }
     device = cumo_cuda_runtime_get_device();
     if (handles[device] == 0) {
-        cublasCreate(&handles[device]);
+        // A discarded status leaves the handle NULL, and cuBLAS reports that as
+        // CUBLAS_STATUS_NOT_INITIALIZED at the next call instead of the reason.
+        cumo_cuda_cublas_check_status(cublasCreate(&handles[device]));
     }
     return handles[device];
 }

--- a/ext/cumo/cuda/cudnn.c
+++ b/ext/cumo/cuda/cudnn.c
@@ -30,14 +30,16 @@ cumo_cuda_cudnn_handle()
     if (handles == 0) {
         int i;
         int device_count = cumo_cuda_runtime_get_device_count();
-        handles = malloc(sizeof(cudnnHandle_t) * device_count);
+        handles = ALLOC_N(cudnnHandle_t, device_count);
         for (i = 0; i < device_count; ++i) {
             handles[i] = 0;
         }
     }
     device = cumo_cuda_runtime_get_device();
     if (handles[device] == 0) {
-        cudnnCreate(&handles[device]);
+        // A discarded status leaves the handle NULL, and cuDNN reports that as
+        // CUDNN_STATUS_NOT_INITIALIZED at the next call instead of the reason.
+        cumo_cuda_cudnn_check_status(cudnnCreate(&handles[device]));
     }
     return handles[device];
 }

--- a/ext/cumo/cuda/driver.c
+++ b/ext/cumo/cuda/driver.c
@@ -445,11 +445,19 @@ Init_cumo_cuda_driver()
     rb_define_const(mDriver, "CU_JIT_INPUT_OBJECT", INT2NUM(CU_JIT_INPUT_OBJECT));
     rb_define_const(mDriver, "CU_JIT_INPUT_PTX", INT2NUM(CU_JIT_INPUT_PTX));
 
-    cuInit(0);
-    cuDeviceGet(&cuDevice, 0);
+    check_status(cuInit(0));
+
+    // A driver API call needs a current context, and the runtime API only
+    // creates its primary one once an array operation happens, so this covers
+    // the gap in between. Losing it is not fatal -- everything but a driver
+    // call made before any array operation still works -- so a device that
+    // refuses a context is left for that call to report. cuDeviceGet leaves
+    // cuDevice untouched when it fails, hence the guard.
+    if (cuDeviceGet(&cuDevice, 0) == CUDA_SUCCESS) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 13000
-    cuCtxCreate(&context, NULL, 0, cuDevice);
+        cuCtxCreate(&context, NULL, 0, cuDevice);
 #else
-    cuCtxCreate(&context, 0, cuDevice);
+        cuCtxCreate(&context, 0, cuDevice);
 #endif
+    }
 }

--- a/test/cuda/driver_test.rb
+++ b/test/cuda/driver_test.rb
@@ -78,6 +78,22 @@ module Cumo::CUDA
       assert_raise(ArgumentError) { Driver.cuModuleGetGlobal(hmod, "cumo_test_global") }
     end
 
+    # The context Init_cumo_cuda_driver creates is what lets this work: the
+    # runtime API only makes its primary context once an array operation
+    # happens. In-process the suite has always run one by now, so this needs a
+    # fresh interpreter to mean anything.
+    def test_driver_call_works_before_any_array_operation
+      lib = File.expand_path("../../../lib", __FILE__)
+      script = <<~RUBY
+        require "cumo"
+        state = Cumo::CUDA::Driver.cuLinkCreate
+        Cumo::CUDA::Driver.cuLinkDestroy(state)
+        print "ok"
+      RUBY
+      out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], err: %i[child out], &:read)
+      assert_equal("ok", out)
+    end
+
     def test_link_state_arguments_are_type_checked
       NON_STRINGS.each do |bad|
         LinkState.new do |link|


### PR DESCRIPTION
## Summary

Two initialisation paths threw their status away.

`Init_cumo_cuda_driver` called `cuInit()`, `cuDeviceGet()` and `cuCtxCreate()` and looked at none of them. `cuDeviceGet()` leaves its output parameter untouched when it fails, so `cuCtxCreate()` was then handed an uninitialised `cuDevice`.

`cumo_cuda_cublas_handle()` and `cumo_cuda_cudnn_handle()` discarded the status of `cublasCreate()` / `cudnnCreate()`. A failure leaves the handle NULL, `handles[device] == 0` still reads as "not created yet", and the NULL reaches cuBLAS/cuDNN, which report `NOT_INITIALIZED` — the real cause is lost. Their `malloc()` was unchecked as well.

The three driver calls are not equally load-bearing, and the difference is measured rather than assumed:

- **`cuInit()` failing means nothing works.** `cuDeviceGet()` then returns `CUDA_ERROR_NOT_INITIALIZED` and every array operation raises. It now raises, so `require` reports the actual reason at the point it is known.
- **`cuCtxCreate()` failing is survivable.** With `cuDeviceGet()` forced to fail, the whole suite still passes — 921 tests — and NVRTC compilation works, because the runtime API creates its own primary context once an array operation happens. The one thing that breaks is a driver API call made *before* any array operation. So that context is a convenience, its failure is left for the call that needs it to report, and only the uninitialised read is fixed.

`ALLOC_N` replaces `malloc` for the handle tables: it raises `NoMemoryError` on failure and keeps the allocation inside Ruby's accounting.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

With `CUDA_VISIBLE_DEVICES=""`, the three statuses are `CUDA_ERROR_NO_DEVICE` (100), `CUDA_ERROR_NOT_INITIALIZED` (3) and `CUDA_ERROR_NOT_INITIALIZED` (3); a poisoned `cuDevice` survives `cuDeviceGet` unchanged, which is what `cuCtxCreate` was reading. `require "cumo/narray"` returned normally and the failure appeared later:

```
require OK
Cumo::CUDA::Runtime.cudaGetDeviceCount  # Cumo::CUDA::RuntimeError: no CUDA-capable device is detected (error=100)
Cumo::DFloat.new(3).seq                 # Cumo::CUDA::RuntimeError: no CUDA-capable device is detected (error=100)
```

On this branch the same command raises at `require`:

```
Cumo::CUDA::DriverError: CUDA_ERROR_NO_DEVICE no CUDA-capable device is detected (error=100)
```

For the handle path, injecting a `cublasCreate()` failure of `CUBLAS_STATUS_ALLOC_FAILED` and running `Cumo::DFloat[[1, 2], [3, 4]].dot(...)`:

| | result |
|---|---|
| `master` | `Cumo::CUDA::CublasError: CUBLAS_STATUS_NOT_INITIALIZED (error=1)` |
| this branch | `Cumo::CUDA::CublasError: CUBLAS_STATUS_ALLOC_FAILED (error=3)` |

The added test does not fail on `master`, which has the same context — it guards the property the measurement turned up: the suite passes with the `Init_` context gone, so nothing in it would notice its removal. The test spawns a fresh interpreter and makes a driver call before touching an array, and it fails with `CUDA_ERROR_INVALID_CONTEXT` when the context is removed.

Full suite 922 tests, 11067 assertions, 0 failures, verified from a deleted `tmp/`.

## Note

`require` now raising where it used to succeed is a user-visible change, for machines where CUDA is unusable at all. Worth a line in the changelog at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
