### PR TITLE
CI: Stop the ccache cache growing past the 10 GB limit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write # to replace the ccache entry
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +46,7 @@ jobs:
         run: |
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+            curl \
             git \
             build-essential \
             ruby-full \
@@ -56,13 +60,14 @@ jobs:
       - name: Fix Git directory ownership
         run: git config --global --add safe.directory '*'
 
-      - name: Cache ccache
-        uses: actions/cache@v6
+      # One entry per CUDA version, replaced on every push to master. A key
+      # carrying the SHA never repeats, so every run saved a new entry rather
+      # than refreshing one.
+      - name: Restore ccache
+        uses: actions/cache/restore@v6
         with:
           path: ~/.cache/ccache
-          key: ccache-${{ matrix.cuda_version }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ matrix.cuda_version }}-
+          key: ccache-${{ matrix.cuda_version }}
 
       - name: Install Ruby dependencies
         run: bundle install
@@ -80,7 +85,7 @@ jobs:
           export PATH=/opt/ccache-bin:$PATH
 
           export CCACHE_DIR=~/.cache/ccache
-          export CCACHE_MAXSIZE=1G
+          export CCACHE_MAXSIZE=500M
           export CCACHE_CPP2=1
           ccache -z
 
@@ -88,3 +93,23 @@ jobs:
           bundle exec rake build_ctest
 
           ccache -s
+
+      - name: Drop the ccache entry being replaced
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 204 replaced, 404 none yet; anything else and the save below is
+          # refused, leaving the entry stale
+          status=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/caches?key=ccache-${{ matrix.cuda_version }}" || echo 000)
+          echo "delete ccache-${{ matrix.cuda_version }} -> HTTP ${status}"
+
+      - name: Save ccache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ matrix.cuda_version }}


### PR DESCRIPTION
## Summary

The ccache key was `ccache-<cuda_version>-<github.sha>`. A SHA never repeats, so the key never matched and every run saved a brand new entry — four of them, one per matrix leg — while `restore-keys` did the actual restoring by prefix. Nothing ever replaced anything.

Keying on the CUDA version alone and deleting the entry before saving it leaves exactly four caches. Saving now happens only on a push to master: a cache written from `refs/pull/N/merge` is readable only by re-runs of that same pull request, never by master or by another branch, so those entries were paid for and never used again. Pull requests still restore master's cache, which is where their speedup came from already.

`CCACHE_MAXSIZE` drops from 1G to 500M. A full build's objects come to about 120 MB, so the old ceiling only mattered as room for years of superseded ones.

## Problem

`GET /repos/sonots/cumo/actions/caches` on 2026-08-15:

| ref | entries | size |
|---|---|---|
| `refs/pull/*/merge` | 113 | 5.4 GB |
| `refs/heads/master` | 104 | 5.1 GB |
| **total** | **217** | **11.1 GB** |

The repository limit is 10 GB, so entries were already being evicted least-recently-used.

The cache is worth keeping — the timings say so. On master, the build step takes **27 s** when the cache is warm and **13–14 min** when a template change invalidates the generated sources. `ccache -s` reports 17 of 35 calls cacheable at a 100% hit rate.

## Note

`actions: write` is needed to delete a cache entry, so the job now declares its permissions explicitly; that also drops everything else the default token would have carried. If an organisation policy withholds `actions: write`, the delete returns 403, the save is refused as a duplicate, and the entry goes stale rather than the build failing — the step prints the HTTP status so that shows up in the log.

The 217 existing entries are not removed by this change. They will age out, or they can be cleared with `gh cache delete --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
