### PR TITLE
Fix store_array reading a source Array that its own elements rewrite

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -143,4 +143,22 @@ cumo_is_aligned_step(const ssize_t step, const size_t alignment)
     return ((step) & ((alignment)-1)) == 0;
 }
 
+// The store_array loops run Ruby code for every element -- m_num_to_data calls
+// to_f / to_int, cumo_na_step_sequence calls to_int on a Range's endpoints --
+// and that can reallocate or shrink the array being read, so neither its buffer
+// nor its length survives one iteration.
+static inline bool
+cumo_na_store_rary_fetch(VALUE ary, size_t i, VALUE *x)
+{
+    if (!RB_TYPE_P(ary, T_ARRAY)) {
+        *x = ary;
+        return true;
+    }
+    if (i >= (size_t)RARRAY_LEN(ary)) {
+        return false;
+    }
+    *x = RARRAY_AREF(ary, (long)i);
+    return true;
+}
+
 #endif /* ifndef CUMO_TEMPLATE_H */

--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -16,7 +16,7 @@ static void
 {
     size_t i, n;
     size_t i1, n1;
-    VALUE  v1, *ptr;
+    VALUE  v1;
     char   *p1;
     size_t s1, *idx1;
     VALUE  x;
@@ -51,12 +51,9 @@ static void
         goto loop_end;
     }
 
-    ptr = &v1;
-
     switch(TYPE(v1)) {
     case T_ARRAY:
         n1 = RARRAY_LEN(v1);
-        ptr = RARRAY_PTR(v1);
         break;
     case T_NIL:
         n1 = 0;
@@ -71,8 +68,8 @@ static void
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
         if (idx1) {
-            for (i=i1=0; i1<n1 && i<n; i++,i1++) {
-                x = ptr[i1];
+            for (i=i1=0; i1<n1 && i<n; i1++) {
+                if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
                 if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
@@ -88,11 +85,12 @@ static void
                 else if (TYPE(x) != T_ARRAY) {
                     z = m_num_to_data(x);
                     CUMO_SET_DATA_INDEX(p1, idx1, dtype, z);
+                    i++;
                 }
             }
         } else {
-            for (i=i1=0; i1<n1 && i<n; i++,i1++) {
-                x = ptr[i1];
+            for (i=i1=0; i1<n1 && i<n; i1++) {
+                if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
                 if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
@@ -108,6 +106,7 @@ static void
                 else if (TYPE(x) != T_ARRAY) {
                     z = m_num_to_data(x);
                     CUMO_SET_DATA_STRIDE(p1, s1, dtype, z);
+                    i++;
                 }
             }
         }
@@ -125,7 +124,7 @@ static void
         // https://devtalk.nvidia.com/default/topic/822942/why-does-cudastreamaddcallback-serialize-kernel-execution-and-break-concurrency-/
         dtype* host_z = ALLOC_N(dtype, n);
         for (i=i1=0; i1<n1 && i<n; i1++) {
-            x = ptr[i1];
+            if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else

--- a/ext/cumo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array.c
@@ -3,7 +3,7 @@ static void
 {
     size_t i, n;
     size_t i1, n1;
-    VALUE  v1, *ptr;
+    VALUE  v1;
     CUMO_BIT_DIGIT *a1;
     size_t p1;
     size_t s1, *idx1;
@@ -35,12 +35,9 @@ static void
         goto loop_end;
     }
 
-    ptr = &v1;
-
     switch(TYPE(v1)) {
     case T_ARRAY:
         n1 = RARRAY_LEN(v1);
-        ptr = RARRAY_PTR(v1);
         break;
     case T_NIL:
         n1 = 0;
@@ -50,8 +47,8 @@ static void
     }
 
     if (idx1) {
-        for (i=i1=0; i1<n1 && i<n; i++,i1++) {
-            x = ptr[i1];
+        for (i=i1=0; i1<n1 && i<n; i1++) {
+            if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
@@ -64,15 +61,16 @@ static void
                     CUMO_STORE_BIT(a1, p1+*idx1, z); idx1++;
                 }
             }
-            if (TYPE(x) != T_ARRAY) {
+            else if (TYPE(x) != T_ARRAY) {
                 if (x == Qnil) x = INT2FIX(0);
                 z = m_num_to_data(x);
                 CUMO_STORE_BIT(a1, p1+*idx1, z); idx1++;
+                i++;
             }
         }
     } else {
-        for (i=i1=0; i1<n1 && i<n; i++,i1++) {
-            x = ptr[i1];
+        for (i=i1=0; i1<n1 && i<n; i1++) {
+            if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
@@ -85,9 +83,10 @@ static void
                     CUMO_STORE_BIT(a1, p1, z); p1+=s1;
                 }
             }
-            if (TYPE(x) != T_ARRAY) {
+            else if (TYPE(x) != T_ARRAY) {
                 z = m_num_to_data(x);
                 CUMO_STORE_BIT(a1, p1, z); p1+=s1;
+                i++;
             }
         }
     }

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -191,4 +191,20 @@ class BitTest < Test::Unit::TestCase
     x[Cumo::Bit.cast([0, 1, 0])] = nil
     assert { x.to_a == [1, nil, 3] }
   end
+
+  test "store a Range element once" do
+    assert_equal([0] + [1] * 63, Cumo::Bit.cast([(0...64)]).to_a)
+  end
+
+  test "store fills every slot after a Range" do
+    assert_equal([1, 0, 1, 0], Cumo::Bit.cast([1, 0...2, 0]).to_a)
+    assert_equal([0, 1, 0, 0], Cumo::Bit.ones(4).store([(0...2), 0, 0]).to_a)
+  end
+
+  test "store a Range does not write past the destination" do
+    a = Cumo::Bit.new(128)
+    a.store(0)
+    a[0...64].store([(0...64)])
+    assert_equal(0, a[64].to_a.first)
+  end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1166,6 +1166,34 @@ class NArrayTest < Test::Unit::TestCase
     assert { c.min >= -2 && c.max < 3 }
   end
 
+  test "store fills every slot after a Range" do
+    assert_equal([9.0, 0.0, 1.0, 5.0], Cumo::DFloat.cast([9, 0...2, 5]).to_a)
+    assert_equal([0, 1, 2, 5], Cumo::Int64.cast([(0...3), 5]).to_a)
+    assert_equal([9, 0.0, 1.0, 5], Cumo::RObject.cast([9, 0...2, 5]).to_a)
+  end
+
+  test "store re-reads a source array the elements rewrite" do
+    grow = Class.new do
+      def initialize(a) = @a = a
+      # the append reallocates the element storage the loop was reading
+      def to_f
+        @a.concat(Array.new(4096, 7.7))
+        1.0
+      end
+      def to_int = 1
+    end
+
+    [Cumo::DFloat, Cumo::Int32, Cumo::RObject].each do |dtype|
+      src = Array.new(8) { |i| i + 100 }
+      src[0] = grow.new(src)
+      assert_nothing_raised { dtype.cast(src) }
+
+      src = Array.new(8) { |i| i + 100 }
+      src[0] = grow.new(src)
+      assert_nothing_raised { dtype.new(8).store(src) }
+    end
+  end
+
   test "zero-sized multi-dimensional arrays" do
     # The free functions used to skip releasing base.shape when size == 0,
     # leaking the shape array allocated for ndim >= 2.


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#19](https://github.com/yoshoku/numo-narray-alt/pull/19) (merge `6143085`), whose three commits map onto cumo's two `store_array` templates — `gen/tmpl/store_array.c` for the numeric and RObject paths, `gen/tmpl_bit/store_array.c` for Bit. All three defects reproduce on cumo master `18365c7`.

**The cached source pointer.** `ptr = RARRAY_PTR(v1)` was taken once before the loop, but the loop runs Ruby code for every element — `m_num_to_data` calls `to_f` / `to_int`, `cumo_na_step_sequence` calls `to_int` on a Range's endpoints — and that code can reallocate the Array being read. Elements are now fetched through `cumo_na_store_rary_fetch`, which bounds checks against the current `RARRAY_LEN` and reads with `RARRAY_AREF`. An Array that shrank past the current index ends the loop, leaving the rest to the zero fill it would have got had the Array been that short to begin with. The helper goes in `include/cumo/template.h`, cumo's equivalent of alt's `mh/store.h`.

**Counting inputs instead of slots.** A Range fills `len` slots through the inner loop, which already advances `i`, and then the outer `i++` added one more. `i` now advances where the write happens. cumo's numeric path was already correct — it was rewritten for the asynchronous host→device copy — so this half applies only to the RObject and Bit paths.

**The Bit template's missing `else`.** Its two branches are separate `if`s where every other template has `else if`, so a Range was expanded by the inner loop and then stored a second time, with no `i < n` guard, one element past what the Range wrote.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

An object whose `to_f` grows the source Array reallocates the storage the loop is walking:

```ruby
grow = Class.new do
  def initialize(a) = @a = a
  def to_f; @a.concat(Array.new(4096, 7.7)); 1.0; end
  def to_int = 1
end
src = Array.new(8) { |i| i + 100 }
src[0] = grow.new(src)
Cumo::DFloat.cast(src)
```

`Cumo::DFloat.cast` segfaults **5/5**, always at `0x38`; `DFloat#store` and `Cumo::Int32.cast` (through `to_int`) **3/3**. Shrinking the Array does not reproduce — `replace` keeps the buffer — so the repro has to force a reallocation.

The other two need no unusual object at all:

```ruby
Cumo::RObject.cast([9, 0...2, 5])   # => [9, 0.0, 1.0, nil], want [9, 0.0, 1.0, 5]
Cumo::Bit.cast([1, 0...2, 0])       # => [1, 0, 1, 1],        want [1, 0, 1, 0]
```

The Bit one is an out-of-bounds write, and it is visible without a sanitizer by aiming it at a view:

```ruby
a = Cumo::Bit.new(128); a.store(0)
a[0...64].store([(0...64)])
a[64]                               # => 1, was 0
```

It does not raise on the way out because Bit's `m_num_to_data` is `RTEST(num) && !rb_equal(num, 0)` — a Range is simply truthy, so it stores a 1. Note `[1, 0...2, 1]` looks correct by luck, the stray 1 matching the input that got dropped; a test has to end on a falsy element.

Full suite 927 tests, 11080 assertions, 0 failures, verified from a deleted `tmp/`. On `master` the added Bit tests fail 2 of 3 and the reentrancy test takes the process down with a core dump.

## Note

alt#20 (`bincount`) is not backported. cumo's `bincount` raises `TypeError: no implicit conversion of Cumo::Int32 into Integer` for every input: `gen/tmpl/bincount.c` does `NUM2SIZET(<type>_max(0, 0, self))`, and cumo's reductions return a 0-dim NArray rather than a Ruby numeric — returning a scalar would force a device synchronise. Both of alt#20's findings sit below a line that cannot be reached, so that one needs the dead method fixed first and is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
