### PR TITLE
Add a store_array regression test for a shrunk source Array

### DIFF
--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1194,6 +1194,32 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  # Shrinking the source keeps the buffer, so this reads past the end rather
+  # than through a freed pointer: wrong values, no crash.
+  test "store stops where a shrunk source array ends" do
+    shrink = Class.new do
+      def initialize(a) = @a = a
+      def to_int
+        4.times { @a.shift }
+        1
+      end
+      def to_f = to_int.to_f
+    end
+
+    {
+      Cumo::Int64 => [1, 105, 106, 107, 0, 0, 0, 0],
+      Cumo::DFloat => [1.0, 105.0, 106.0, 107.0, 0.0, 0.0, 0.0, 0.0],
+    }.each do |dtype, expected|
+      src = Array.new(8) { |i| i + 100 }
+      src[0] = shrink.new(src)
+      assert_equal(expected, dtype.cast(src).to_a)
+
+      src = Array.new(8) { |i| i + 100 }
+      src[0] = shrink.new(src)
+      assert_equal(expected, dtype.new(8).store(src).to_a)
+    end
+  end
+
   test "zero-sized multi-dimensional arrays" do
     # The free functions used to skip releasing base.shape when size == 0,
     # leaking the shape array allocated for ndim >= 2.


### PR DESCRIPTION
## Summary

Test-only follow-up to #198.

That PR fixed `store_array` reading a source Array its own elements rewrite, and the regression test it carries grows the Array from inside `to_f`. Growing forces a reallocation, so the loop reads through a freed pointer and the process dies — `assert_nothing_raised` catches it.

Shrinking is the other half and it behaves nothing like that. CRuby keeps the buffer when an Array shrinks, so the pointer stays valid and the loop simply walks past the new end, reading the last element over and over. Nothing faults; the values are just wrong. An `assert_nothing_raised` test passes on the broken code, which is why this case went in unverified.

`cumo_na_store_rary_fetch` bounds checks against the current `RARRAY_LEN` on every iteration, so it already covers this — the point of the test is that nothing was proving it.

## Problem

The source Array loses four entries while the loop is walking it:

```ruby
shrink = Class.new do
  def initialize(a) = @a = a
  def to_int
    4.times { @a.shift }
    1
  end
  def to_f = to_int.to_f
end

src = Array.new(8) { |i| i + 100 }
src[0] = shrink.new(src)
Cumo::Int64.cast(src)
```

With `ext/` reverted to `2cda577`, the commit before #198, that returns `[1, 105, 106, 107, 107, 107, 107, 107]` — the repeated 107 is the loop reading the same word past the end of the shortened Array. It matches numo-narray-alt's pre-fix value exactly. On `master` it is `[1, 105, 106, 107, 0, 0, 0, 0]`: the loop stops where the Array now ends and the rest gets the zero fill it would have had if the Array had been that short from the start.

Full suite 928 tests, 11084 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
