### PR TITLE
Fix segfaults from an unvalidated marshal payload

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1549,6 +1549,9 @@ cumo_na_marshal_load(VALUE self, VALUE a)
         rb_raise(rb_eArgError,"NArray marshal version %d is not supported "
                  "(only version 1)", NUM2INT(RARRAY_AREF(a,0)));
     }
+    if (TYPE(RARRAY_AREF(a,1)) != T_ARRAY) {
+        rb_raise(rb_eArgError,"marshal shape should be array");
+    }
     cumo_na_initialize(self,RARRAY_AREF(a,1));
     CUMO_NA_FL0_SET(self,FIX2INT(RARRAY_AREF(a,2)));
     v = RARRAY_AREF(a,3);
@@ -1565,6 +1568,7 @@ cumo_na_marshal_load(VALUE self, VALUE a)
         ptr = cumo_na_get_pointer_for_write(self);
         memcpy(ptr, RARRAY_PTR(v), CUMO_NA_SIZE(na)*sizeof(VALUE));
     } else {
+        Check_Type(v, T_STRING);
         rb_str_freeze(v);
         cumo_na_store_binary(1,&v,self);
         if (CUMO_TEST_BYTE_SWAPPED(self)) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,33 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  test "marshal_load rejects a non-array shape" do
+    [42, "AAAAAAAAAAAAAAAA", nil, {}, 1.5, :abc, true, Object.new].each do |bad|
+      assert_raise(ArgumentError) { Cumo::DFloat.allocate.marshal_load([1, bad, 0, +""]) }
+      assert_raise(ArgumentError) { Cumo::RObject.allocate.marshal_load([1, bad, 0, []]) }
+    end
+  end
+
+  test "marshal_load rejects non-string content" do
+    [[1, 2], {}, Object.new, 12_345, nil, :abc].each do |bad|
+      assert_raise(TypeError) { Cumo::DFloat.allocate.marshal_load([1, [2], 0, bad]) }
+    end
+  end
+
+  test "marshal_load rejects a malformed stream" do
+    # A user-class stream whose payload Marshal.load hands straight to marshal_load.
+    body = Marshal.dump([1, 42, 0, ""]).byteslice(2..)
+    name = "Cumo::DFloat"
+    stream = "\x04\x08U:#{(name.bytesize + 5).chr}#{name}#{body}".b
+    assert_raise(ArgumentError) { Marshal.load(stream) }
+
+    a = Cumo::DFloat[1.5, 2.5]
+    assert { Marshal.load(Marshal.dump(a)) == a }
+
+    b = Cumo::RObject[1, :x, nil]
+    assert { Marshal.load(Marshal.dump(b)) == b }
+  end
+
   test "indexing by an array does not leak host memory" do
     # The index list was staged in pinned host memory released from a CUDA
     # stream callback, but a callback may not call the CUDA API: cudaFreeHost


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#23](https://github.com/yoshoku/numo-narray-alt/pull/23) (merge `66d49f6`). `marshal_load` checked the array length and the version field, then handed the remaining two elements to code that assumes their types. Both reproduce on cumo master `b30166e`.

The shape went to `cumo_na_initialize`, which calls `RARRAY_LEN` and `RARRAY_AREF` on it without a check. The content went to `rb_str_freeze`, which calls `rb_str_resize`. `Marshal.load` feeds both straight from the stream, so a crafted stream reaches them.

`marshal_load` already gets a `Check_Type` on the content, but one call too late — it is inside `store_binary` (added in #182), and `rb_str_freeze` runs first. A *frozen* non-String returns early from `rb_str_freeze` and survives to that check, which is why only the unfrozen case crashes. Checking here covers both.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

```ruby
Cumo::DFloat.allocate.marshal_load([1, 42, 0, +""])       # SEGV at 0x55
Cumo::RObject.allocate.marshal_load([1, 42, 0, []])       # SEGV at 0x55
Cumo::DFloat.allocate.marshal_load([1, nil, 0, +""])      # SEGV at 0x04
Cumo::DFloat.allocate.marshal_load([1, [2], 0, [1, 2]])   # SEGV at 0x05
```

`0x55` is `INT2FIX(42)` — `RARRAY_LEN` reading the Fixnum as an object pointer. The same fault arrives through a plain `Marshal.load` of a crafted user-class stream:

```ruby
body = Marshal.dump([1, 42, 0, ""]).byteslice(2..)
name = "Cumo::DFloat"
Marshal.load("\x04\x08U:#{(name.bytesize + 5).chr}#{name}#{body}".b)
```

```
<internal:marshal>:34: [BUG] Segmentation fault at 0x0000000000000055
```

All four now raise `ArgumentError` or `TypeError`, and dump/load round-trips are unchanged for both the binary and the RObject paths. cumo had no `marshal` tests at all, so the round-trip goes in with them.

## Note

alt#22 is test-only — it corrects a `from_binary` size assert that never reached the guard it was aiming at — and belongs with the alt#21 backport rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
