### PR TITLE
Fix out-of-bounds access from three unchecked size_t multiplications

### DIFF
--- a/ext/cumo/narray/gen/tmpl/allocate.c
+++ b/ext/cumo/narray/gen/tmpl/allocate.c
@@ -10,6 +10,9 @@ static VALUE
     case CUMO_NARRAY_DATA_T:
         ptr = CUMO_NA_DATA_PTR(na);
         if (na->size > 0 && ptr == NULL) {
+            if (na->size > SIZE_MAX / sizeof(dtype)) {
+                rb_raise(rb_eRangeError, "total byte size of data is too large");
+            }
             <% if is_object %>
             ptr = xmalloc(sizeof(dtype) * na->size);
             {   size_t i;

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -295,6 +295,9 @@ cumo_na_setup_shape(cumo_narray_t *na, int ndim, size_t *shape)
     else {
         for (i=0, size=1; i<ndim; i++) {
             na->shape[i] = shape[i];
+            if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
+                rb_raise(rb_eRangeError, "total number of elements is too large");
+            }
             size *= shape[i];
         }
         na->size = size;
@@ -1375,7 +1378,11 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
             rb_raise(rb_eArgError,"second argument must be size or shape");
         }
         if (FIXNUM_P(velmsz)) {
-            byte_size = len * NUM2SIZET(velmsz);
+            size_t elmsz = NUM2SIZET(velmsz);
+            if (elmsz != 0 && len > SIZE_MAX / elmsz) {
+                rb_raise(rb_eArgError, "specified size is too large");
+            }
+            byte_size = len * elmsz;
         } else {
             byte_size = ceil(len * NUM2DBL(velmsz));
         }
@@ -1439,7 +1446,11 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
     size = CUMO_NA_SIZE(na);
     velmsz = rb_const_get(rb_obj_class(self), cumo_id_element_byte_size);
     if (FIXNUM_P(velmsz)) {
-        byte_size = size * NUM2SIZET(velmsz);
+        size_t elmsz = NUM2SIZET(velmsz);
+        if (elmsz != 0 && size > SIZE_MAX / elmsz) {
+            rb_raise(rb_eArgError, "string is too short to store");
+        }
+        byte_size = size * elmsz;
     } else {
         byte_size = ceil(size * NUM2DBL(velmsz));
     }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,40 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  test "a shape whose element count overflows raises" do
+    assert_raise(RangeError) { Cumo::Int8.new((2**62) + 1, 4) }
+    assert_raise(RangeError) { Cumo::Bit.new((2**62) + 1, 4) }
+    assert_raise(RangeError) { Cumo::DFloat.new(2**32, 2**32) }
+    assert_raise(RangeError) { Cumo::DFloat.zeros(2**40, 2**40, 2**40) }
+
+    assert_equal(0, Cumo::DFloat.new(0, 2**62).size)
+    assert_equal([3, 4], Cumo::DFloat.zeros(3, 4).shape)
+  end
+
+  test "a one-dimensional size whose byte count overflows raises" do
+    # A one-dimensional shape is not a product, so it reaches the allocator
+    # untouched by the check above.
+    assert_raise(RangeError) { Cumo::DFloat.new((2**61) + 4).allocate }
+    assert_raise(RangeError) { Cumo::DComplex.new((2**60) + 1).allocate }
+    assert_raise(RangeError) { Cumo::RObject.new((2**61) + 4).allocate }
+
+    assert_equal(4, Cumo::DFloat.new(4).allocate.size)
+  end
+
+  test "from_binary rejects a size whose byte count overflows" do
+    assert_raise(ArgumentError) { Cumo::DFloat.from_binary(+"12345678", 2**61) }
+    assert_raise(ArgumentError) { Cumo::DFloat.from_binary("12345678", [2**61]) }
+    assert_raise(ArgumentError) { Cumo::DFloat.from_binary("12345678", [2**60, 4]) }
+    assert_raise(ArgumentError) { Cumo::Int16.from_binary("12345678", [(2**63) + 1]) }
+  end
+
+  test "store_binary rejects a size whose byte count overflows" do
+    # A frozen String takes cumo_na_set_pointer, which never allocates, so the
+    # allocator check does not cover this path.
+    assert_raise(ArgumentError) { Cumo::DFloat.new(2**61).store_binary(("A" * 4096).freeze) }
+    assert_raise(ArgumentError) { Cumo::DComplex.new(2**60).store_binary(("A" * 4096).freeze) }
+  end
+
   test "marshal_load rejects a non-array shape" do
     [42, "AAAAAAAAAAAAAAAA", nil, {}, 1.5, :abc, true, Object.new].each do |bad|
       assert_raise(ArgumentError) { Cumo::DFloat.allocate.marshal_load([1, bad, 0, +""]) }


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#21](https://github.com/yoshoku/numo-narray-alt/pull/21) (merge `670e785`) with the test correction from [#22](https://github.com/yoshoku/numo-narray-alt/pull/22). Three `size_t` multiplications wrapped without a check, and all three reproduce on cumo master `06946e3`. None needs an unusual object — a large enough literal is the whole input.

**The shape's element count.** `cumo_na_setup_shape` multiplied the per-dimension sizes into `na->size`, but `na->shape` kept the original values, and it is the shape that `cumo_na_range_check` uses as the index bound. The check divides before it multiplies and raises `RangeError`.

**The one-dimensional byte count.** `gen/tmpl/allocate.c` sized its buffer as `sizeof(dtype) * na->size`. A one-dimensional shape is not a product, so it never passes through the check above — this is an independent second entrance, and fixing either one alone leaves the other. alt swapped its 13 copied allocators to `xmalloc2`; cumo has one template but allocates with `cumo_cuda_runtime_malloc`, so the divide-first check goes in ahead of both branches and covers `Cumo::RObject`'s `xmalloc` too. `tmpl_bit/allocate.c` needs nothing: it divides before it multiplies.

**The binary byte count.** `from_binary` and `store_binary` computed `len * element_byte_size`. When the product wraps, the "specified size is too large" and "string is too short to store" guards that follow compare against a small number and pass, so the array keeps the huge element count while its data pointer is the short String's buffer. A frozen String takes `cumo_na_set_pointer`, which never allocates, so the allocator check does not cover this path.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

```ruby
a = Cumo::Int8.new(2**62 + 1, 4)   # size 4, shape [4611686018427387905, 4]
a.allocate                          # 4 bytes
a[2, 0] = 65                        # accepted, reads back 65 -- byte 8 of a 4-byte buffer

b = Cumo::Bit.new(2**62 + 1, 4)     # 4 bytes
b.allocate
b[1000, 0] = 1                      # accepted -- bit 4000, 496 bytes past the end

c = Cumo::DFloat.new(2**61 + 4)     # allocates 32 bytes
c.allocate
c[1000] = 1.234                     # accepted, reads back 1.234

d = Cumo::DFloat.from_binary("\x00" * 32, [2**61 + 4])
d.size                              # => 2305843009213693956
d[1000]                             # reads past the 32-byte String

e = Cumo::DFloat.new(2**61)
e.store_binary(("A" * 4096).freeze) # => 0 bytes stored, e.size still 2**61
e[1000]                             # reads past the String
```

The out-of-bounds writes do not crash — the memory pool rounds allocations up — so the evidence is that the value is accepted and reads back, not a fault. alt reports the same for its own unsanitised build; its `heap-buffer-overflow` traces come from an ASan build.

The wraps that land on zero rather than a small number were already harmless (`ShapeError` on the first access); they now raise `RangeError` at construction.

Full suite 935 tests, 11125 assertions, 0 failures. On master all four added tests fail.

## Note

Two `size_t` products are deliberately left alone.

`cumo_na_pointer_copy_on_write` computes the same byte size, as does alt at its own equivalent. Its only callers are `from_binary` and `store_binary`, both of which now reject the wrap, and the allocator runs the same product again before the copy. It becomes reachable again if a new `cumo_na_set_pointer` caller appears.

`nst_allocate` (`struct.c:24`) has the identical unchecked product, and alt has not filed it either. It is unreachable in cumo for a different reason: **`Cumo::Struct` cannot be instantiated at all.** Every construction route — `new`, `cast`, `zeros`, `[]`, `from_binary` — raises `TypeError: allocator undefined`, because the generated struct class gets `rb_define_method(st, "allocate", ...)` but no `rb_define_alloc_func`, and `rb_class_new_instance` needs the latter. That is a separate defect worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
