### PR TITLE
Fix host loops reading device memory without synchronizing

### DIFF
--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -23,6 +23,7 @@ static void
         p2 = lp->args[1].ptr + lp->args[1].iter[0].pos;
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         *(<%=dtype%>*)p2 = f_<%=name%><%=nan%>(n,p1,s1);
     }
     //<% elsif !indexer_ops.include?(name) %>

--- a/ext/cumo/narray/gen/tmpl/accum_arg.c
+++ b/ext/cumo/narray/gen/tmpl/accum_arg.c
@@ -21,6 +21,7 @@ static void
         o_ptr = CUMO_NDL_PTR(lp,1);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         idx = f_<%=name[3..5]%>_index<%=nan%>(n,d_ptr,d_step);
         *(idx_t*)o_ptr = (idx_t)idx;
     }

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -22,6 +22,7 @@ static void
         o_ptr = CUMO_NDL_PTR(lp,2);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         idx = f_<%=name%><%=nan%>(n,d_ptr,d_step);
         *(idx_t*)o_ptr = *(idx_t*)(i_ptr + i_step * idx);
     }

--- a/ext/cumo/narray/gen/tmpl/frexp.c
+++ b/ext/cumo/narray/gen/tmpl/frexp.c
@@ -11,6 +11,7 @@ static void
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     for (; i--;) {
         CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
         x = m_<%=name%>(x,&y);

--- a/ext/cumo/narray/gen/tmpl/median.c
+++ b/ext/cumo/narray/gen/tmpl/median.c
@@ -12,6 +12,7 @@ static void
     buf = (dtype*)p1;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     <%=type_name%>_qsort<%=j%>(buf, n, sizeof(dtype));
 
     <% if is_float %>

--- a/ext/cumo/narray/gen/tmpl/minmax.c
+++ b/ext/cumo/narray/gen/tmpl/minmax.c
@@ -11,6 +11,7 @@ static void
     CUMO_INIT_PTR(lp, 0, p1, s1);
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     f_<%=name%><%=j%>(n,p1,s1,&xmin,&xmax);
 
     *(dtype*)(lp->args[1].ptr + lp->args[1].iter[0].pos) = xmin;

--- a/ext/cumo/narray/gen/tmpl/poly.c
+++ b/ext/cumo/narray/gen/tmpl/poly.c
@@ -5,6 +5,7 @@ static void
     dtype  x, y, a;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     x = *(dtype*)(lp->args[0].ptr + lp->args[0].iter[0].pos);
     i = lp->narg - 2;
     y = *(dtype*)(lp->args[i].ptr + lp->args[i].iter[0].pos);

--- a/ext/cumo/narray/gen/tmpl/set2.c
+++ b/ext/cumo/narray/gen/tmpl/set2.c
@@ -11,6 +11,7 @@ static void
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     if (idx1) {
         if (idx2) {
             for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl/unary_ret2.c
+++ b/ext/cumo/narray/gen/tmpl/unary_ret2.c
@@ -10,6 +10,7 @@ static void
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     for (; i--;) {
         CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
         m_<%=name%>(x,y,z);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,59 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  # These all run a host loop over managed memory, so they read whatever the
+  # last kernel has written so far unless they synchronize first. The arrays
+  # are large enough that the kernel filling them is still in flight.
+  sub_test_case "host loops synchronize before reading device memory" do
+    n = 1 << 20
+    last = n.to_f
+    total = n * (n + 1) / 2.0
+
+    test "minmax" do
+      assert_equal([1.0, last], Cumo::DFloat.new(n).seq(1).minmax.map { |x| x.to_a.first })
+      assert_equal([1, n], Cumo::Int32.new(n).seq(1).minmax.map { |x| x.to_a.first })
+      assert_equal([1, 3], Cumo::Int32[1, 2, 3].minmax.map { |x| x.to_a.first })
+    end
+
+    test "nan-aware reductions" do
+      a = Cumo::DFloat.new(n).seq(1)
+      assert_equal([total], a.sum(nan: true).to_a)
+      assert_equal([last], a.max(nan: true).to_a)
+      assert_equal([1.0], a.min(nan: true).to_a)
+      assert_equal([(1.0 + last) / 2], a.mean(nan: true).to_a)
+    end
+
+    test "kahan_sum" do
+      assert_equal([total], Cumo::DFloat.new(n).seq(1).kahan_sum.to_a)
+    end
+
+    test "median" do
+      assert_equal([(last + 1) / 2], Cumo::DFloat.new(n).seq(1).median.to_a)
+    end
+
+    test "modf" do
+      frac, int = (Cumo::DFloat.new(n).seq(1) / 4).modf
+      assert_equal([0.25, 0.5], frac.to_a.first(2))
+      assert_equal([0.0, 0.0], int.to_a.first(2))
+    end
+
+    test "frexp" do
+      frac, exp = Cumo::NMath.frexp(Cumo::DFloat.new(n).seq(1))
+      assert_equal([0.5, 0.5], frac.to_a.first(2))
+      assert_equal([1, 2], exp.to_a.first(2))
+    end
+
+    test "set_real and set_imag" do
+      a = Cumo::DComplex.new(n).seq(1)
+      a.imag = Cumo::DFloat.new(n).seq(100)
+      assert_equal([Complex(1, 100), Complex(2, 101)], a.to_a.first(2))
+
+      b = Cumo::DComplex.new(n).seq(1)
+      b.real = Cumo::DFloat.new(n).seq(100)
+      assert_equal([Complex(100, 0), Complex(101, 0)], b.to_a.first(2))
+    end
+  end
+
   test "a shape whose element count overflows raises" do
     assert_raise(RangeError) { Cumo::Int8.new((2**62) + 1, 4) }
     assert_raise(RangeError) { Cumo::Bit.new((2**62) + 1, 4) }


### PR DESCRIPTION
## Summary

Nine iterators emit `CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE` — whose message reads *"Method X for dtype Y synchronizes with CPU"* — and then walk managed memory on the host without ever calling `cudaDeviceSynchronize`. They announce a synchronization they do not perform, so they read whatever the kernel filling the array had written by the time the host loop got there.

`sort.c`, `cum.c`, `unary.c`, `clip.c` and the `tmpl_bit` templates already call it on the line after the warning. This adds the same line to the nine that do not.

Only iterators that read device memory are touched. The same warning appears in about a dozen other templates, but there it sits inside a `type_name == 'robject'` branch, where the buffer is host memory and no synchronization is owed. `binary.c`'s host path is robject-only too, which is why integer `div`/`mod`/`divmod` are unaffected.

## Problem

Measured on an RTX A4000 with CUDA 13.0, cumo master `c5b8ee9`. The left column is what the method returns today; the right is the same call under `CUDA_LAUNCH_BLOCKING=1`.

| call | now | correct |
|---|---|---|
| `Cumo::Int32[1, 2, 3].minmax` | `[0, 0]` | `[1, 3]` |
| `a.sum(nan: true)` | `0.0` | `549756338176.0` |
| `a.max(nan: true)` | `970848.0` | `1048576.0` |
| `a.min(nan: true)` | `0.0` | `1.0` |
| `a.mean(nan: true)` | `523366.16659832` | `524288.5` |
| `a.kahan_sum` | `549754365085.0` | `549756338176.0` |
| `(a / 3).modf` | `[[0.0, 0.0], …]` | `[[0.333…, 0.666…], …]` |
| `Cumo::NMath.frexp(a)` | `[[0.0, 0.0], [0, 0]]` | `[[0.5, 0.5], [1, 2]]` |
| `c.imag = …` | `(1.0+0.0i)` | `(1.0+100.0i)` |

`a` is `Cumo::DFloat.new(1 << 20).seq(1)`, `c` is `Cumo::DComplex.new(1 << 20).seq(1)`.

`minmax` is the clearest one: `min` and `max` called separately are correct, because they run a GPU reduction kernel; only `minmax` has no kernel and drops to a host loop. It is also the one method here with **no test at all** in the suite, which is why the suite stayed green.

The results are non-deterministic — the same call occasionally comes out right — so the check that settles it is that `CUDA_LAUNCH_BLOCKING=1` makes every case correct, and after this change the async and blocking runs agree on all of them.

`median` and the `nan: true` forms of `argmax`/`argmin`/`max_index`/`min_index` did not drift in any run I took, and `poly` crashes for an unrelated reason (below). They are structurally identical host loops, so they get the same line rather than being left as the next thing to notice.

## Tests

Seven tests in a `host loops synchronize before reading device memory` sub-test-case, sized at `1 << 20` so the filling kernel is still in flight. As a positive control, with `ext/` reverted to `c5b8ee9`: `minmax`, `kahan_sum`, `modf` and `set_real and set_imag` fail on every run, `nan-aware reductions` fails on 2 of 3, and `median` and `frexp` did not fail inside the suite. Full suite 942 tests, 11140 assertions, 0 failures.

## Note

`poly` is still broken after this change and needs its own investigation: `Cumo::DFloat.new(4).seq(1).poly(1.0, 2.0)` raises `NoMemoryError`, and under `CUDA_LAUNCH_BLOCKING=1` it took the process down with a segfault before this change and raises `SystemStackError` after it. The missing synchronization was not its cause; the line is added there for the same structural reason as the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
