### PR TITLE
Fix bincount raising TypeError for every input

### DIFF
--- a/ext/cumo/narray/gen/tmpl/bincount.c
+++ b/ext/cumo/narray/gen/tmpl/bincount.c
@@ -23,6 +23,7 @@ static void
     }
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_<%=bits%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     if (idx1) {
         for (; i--;) {
             CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
@@ -77,6 +78,9 @@ static void
                  "size mismatch along last axis between self and weight");
     }
 
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_<%=fn%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
     // initialize
     for (x=0; x < n; x++) {
         *(<%=cnt_type%>*)(p3 + s3*x) = 0;
@@ -101,6 +105,17 @@ static VALUE
 }
 <% end %>
 // ------- end of Float count with weights -------
+
+// Reductions hand back the 0-dimensional NArray rather than a Ruby numeric, to
+// avoid a device synchronization. The length below has to be a host value.
+static VALUE
+<%=c_func%>_extract(VALUE v)
+{
+    if (rb_obj_is_kind_of(v, cT)) {
+        return <%=type_name%>_extract_cpu(v);
+    }
+    return v;
+}
 
 /*
   Count the number of occurrences of each non-negative integer value.
@@ -147,13 +162,13 @@ static VALUE
     rb_get_kwargs(kw, table, 0, 1, opts);
 
   <% if is_unsigned %>
-    v = <%=type_name%>_max(0,0,self);
+    v = <%=c_func%>_extract(<%=type_name%>_max(0,0,self));
   <% else %>
     v = <%=type_name%>_minmax(0,0,self);
-    if (m_num_to_data(RARRAY_AREF(v,0)) < 0) {
-        rb_raise(rb_eArgError,"array items must be non-netagive");
+    if (m_num_to_data(<%=c_func%>_extract(RARRAY_AREF(v,0))) < 0) {
+        rb_raise(rb_eArgError,"array items must be non-negative");
     }
-    v = RARRAY_AREF(v,1);
+    v = <%=c_func%>_extract(RARRAY_AREF(v,1));
   <% end %>
     length = NUM2SIZET(v) + 1;
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,52 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  sub_test_case "bincount" do
+    int_types = [
+      Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64,
+      Cumo::UInt8, Cumo::UInt16, Cumo::UInt32, Cumo::UInt64,
+    ]
+
+    test "counts every value" do
+      int_types.each do |dtype|
+        assert_equal([1, 3, 1, 1, 0, 0, 0, 1], dtype[0, 1, 1, 3, 2, 1, 7].bincount.to_a)
+      end
+    end
+
+    test "the result is as long as the largest value plus one" do
+      x = Cumo::Int32[0, 1, 1, 3, 2, 1, 7, 23]
+      assert_equal(x.max.to_a.first + 1, x.bincount.size)
+    end
+
+    test "minlength extends but does not truncate" do
+      assert_equal([1, 2, 0, 0, 0, 0], Cumo::Int32[0, 1, 1].bincount(minlength: 6).to_a)
+      assert_equal([1, 1, 0, 0, 0, 1], Cumo::Int32[0, 1, 5].bincount(minlength: 2).to_a)
+    end
+
+    test "weights" do
+      x = Cumo::Int32[0, 1, 1, 2, 2, 2]
+      w = Cumo::DFloat[0.3, 0.5, 0.2, 0.7, 1.0, -0.6]
+      [0.3, 0.7, 1.1].zip(x.bincount(w).to_a) { |want, got| assert_in_delta(want, got, 1e-12) }
+      assert_equal([1.0, 2.0, 3.0], x.bincount(Cumo::SFloat[1, 1, 1, 1, 1, 1]).to_a)
+      assert_raise(Cumo::NArray::ShapeError) { Cumo::Int32[0, 1].bincount(Cumo::DFloat[1, 2, 3]) }
+    end
+
+    test "a negative element raises" do
+      assert_raise(ArgumentError) { Cumo::Int32[0, -1, 2].bincount }
+    end
+
+    test "views and multi-dimensional input" do
+      assert_equal([1, 2, 0, 1], Cumo::Int32[0, 1, 1, 3, 9][0...4].bincount.to_a)
+      assert_equal([[1, 1, 0, 0], [0, 1, 0, 1]], Cumo::Int32[[0, 1], [1, 3]].bincount.to_a)
+    end
+
+    test "an array large enough that the filling kernel is still running" do
+      r = (Cumo::Int32.new(1 << 20).seq % 997).bincount
+      assert_equal(997, r.size)
+      assert_equal(1 << 20, r.to_a.sum)
+    end
+  end
+
   # These all run a host loop over managed memory, so they read whatever the
   # last kernel has written so far unless they synchronize first. The arrays
   # are large enough that the kernel filling them is still in flight.


### PR DESCRIPTION
## Summary

`bincount` raised `TypeError: no implicit conversion of Cumo::Int32 into Integer` for **every** input, of every integer dtype, since the method was inherited from numo. It sizes its result from `NUM2SIZET(<type>_max(0, 0, self))`, and cumo's reductions return the 0-dimensional NArray rather than a Ruby numeric — `extract` does that deliberately, to avoid a device synchronization. The length is computed before anything else happens, so nothing ever reached the counting loop.

The extraction now goes through `extract_cpu`, which is where the value has to be anyway: the length is a host-side `size_t`. The guard keeps `Cumo.enable_compatible_mode` working, where the reduction already hands back a numeric.

Both counting loops also gained the `cudaDeviceSynchronize` that #202 added to the other host loops. In compatible mode the sync arrived for free through `extract_cpu`, but relying on that would have left the weighted loop — which never calls a reduction at all — reading the array while the kernel filling it is still running.

## Problem

Measured on an RTX A4000 with CUDA 13.0, cumo master `32039e7`.

```ruby
Cumo::Int32[0, 1, 1, 3, 2, 1, 7].bincount
# => TypeError: no implicit conversion of Cumo::Int32 into Integer
```

Every one of the eight integer dtypes, with or without weights, with or without `minlength`. Enabling compatible mode fixed only the unsigned half: the signed branch reads `minmax`, which bypasses `extract` and returns a Ruby Array holding two 0-dimensional NArrays, so `m_num_to_data` and `NUM2SIZET` both still refused it.

After this change every result matches `Numo::NArray` exactly, checked against `numo-narray-alt` 0.11.2 side by side:

```ruby
Cumo::Int32[0, 1, 1, 3, 2, 1, 7].bincount        # => [1, 3, 1, 1, 0, 0, 0, 1]
Cumo::Int32[0, 1, 5].bincount(minlength: 2)      # => [1, 1, 0, 0, 0, 1]
Cumo::Int32[0, 1, 1, 2, 2, 2].bincount(w)        # => [0.3, 0.7, 1.1]
Cumo::Int32[[0, 1], [1, 3]].bincount             # => [[1, 1, 0, 0], [0, 1, 0, 1]]
Cumo::Int32[0, 1, 1, 3, 9][0...4].bincount       # => [1, 2, 0, 1]
```

including the result class (`Cumo::UInt32`) and the three examples in the method's own documentation, which had never been executable.

Seven tests added; `bincount` had none. As a positive control, with `ext/` reverted to `32039e7`, all seven fail. Full suite 949 tests, 11161 assertions, 0 failures.

## Note

One user-visible message changes: `array items must be non-netagive` becomes `non-negative`. numo has the same typo, but a message no input could reach until now seemed worth spelling correctly rather than preserving.

This also gives [yoshoku/numo-narray-alt#20](https://github.com/yoshoku/numo-narray-alt/pull/20) somewhere to land — its two findings, the `NUM2SIZET(max) + 1` wrap and the convert-after-scan TOCTOU, both sit below the line that used to be unreachable. That backport is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
