### PR TITLE
Fix out-of-bounds writes in bincount from an overflowing length and a stale scan

### DIFF
--- a/ext/cumo/narray/gen/tmpl/bincount.c
+++ b/ext/cumo/narray/gen/tmpl/bincount.c
@@ -1,3 +1,14 @@
+// The items below index an output whose length an earlier scan of the same
+// array fixed. Ruby code can run in between, so the bound is rechecked.
+static inline void
+<%=c_func%>_check_item(size_t x, size_t n)
+{
+    if (x >= n) {
+        rb_raise(rb_eIndexError,
+                 "item %"SZF"u is out of range of the output(size:%"SZF"u)", x, n);
+    }
+}
+
 // ------- Integer count without weights -------
 <%
 [32,64].each do |bits|
@@ -27,11 +38,13 @@ static void
     if (idx1) {
         for (; i--;) {
             CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
+            <%=c_func%>_check_item(x, n);
             (*(<%=cnt_type%>*)(p2 + s2*x))++;
         }
     } else {
         for (; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
+            <%=c_func%>_check_item(x, n);
             (*(<%=cnt_type%>*)(p2 + s2*x))++;
         }
     }
@@ -88,6 +101,7 @@ static void
     for (; i--;) {
         CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
         CUMO_GET_DATA_STRIDE(p2,s2,<%=cnt_type%>,w);
+        <%=c_func%>_check_item(x, n);
         (*(<%=cnt_type%>*)(p3 + s3*x)) += w;
     }
 }
@@ -161,22 +175,35 @@ static VALUE
     rb_scan_args(argc, argv, "01:", &weight, &kw);
     rb_get_kwargs(kw, table, 0, 1, opts);
 
+    // Both conversions run Ruby code that can write to self, so they go before
+    // the scan that sizes the output rather than after it.
+    minlength = 0;
+    if (opts[0] != Qundef) {
+        minlength = NUM2SIZET(opts[0]);
+    }
+    if (!NIL_P(weight) && rb_obj_class(weight) != cumo_cSFloat) {
+        weight = rb_funcall(cumo_cDFloat, rb_intern("cast"), 1, weight);
+    }
+
   <% if is_unsigned %>
     v = <%=c_func%>_extract(<%=type_name%>_max(0,0,self));
+    length = NUM2SIZET(v);
+    if (length == SIZE_MAX) {
+        rb_raise(rb_eRangeError,
+                 "maximum item %"SZF"u is too large to size the output", length);
+    }
+    length += 1;
   <% else %>
     v = <%=type_name%>_minmax(0,0,self);
     if (m_num_to_data(<%=c_func%>_extract(RARRAY_AREF(v,0))) < 0) {
         rb_raise(rb_eArgError,"array items must be non-negative");
     }
     v = <%=c_func%>_extract(RARRAY_AREF(v,1));
-  <% end %>
     length = NUM2SIZET(v) + 1;
+  <% end %>
 
-    if (opts[0] != Qundef) {
-        minlength = NUM2SIZET(opts[0]);
-        if (minlength > length) {
-            length = minlength;
-        }
+    if (minlength > length) {
+        length = minlength;
     }
 
     if (NIL_P(weight)) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1496,6 +1496,43 @@ class NArrayTest < Test::Unit::TestCase
       assert_equal([[1, 1, 0, 0], [0, 1, 0, 1]], Cumo::Int32[[0, 1], [1, 3]].bincount.to_a)
     end
 
+    test "an item too large to size the output raises" do
+      assert_raise(RangeError) { Cumo::UInt64[(2**64) - 1].bincount }
+      assert_raise(RangeError) { Cumo::UInt64[(2**64) - 1, (2**62) + 1000].bincount(minlength: 8) }
+    end
+
+    test "the arguments are converted before the array is scanned" do
+      setter = Class.new do
+        def initialize(array, value)
+          @array = array
+          @value = value
+        end
+
+        def to_int
+          @array[0] = @value
+          3
+        end
+
+        def to_f
+          @array[0] = @value
+          1.0
+        end
+      end
+
+      a = Cumo::Int32[0, 1, 2]
+      r = a.bincount(minlength: setter.new(a, 100_000))
+      assert_equal(100_001, r.size)
+      assert_equal([1, 1, 1, 3], [r[100_000], r[1], r[2]].map { |x| x.to_a.first } << r.to_a.sum)
+
+      a = Cumo::Int32[0, 1, 2]
+      r = a.bincount([setter.new(a, 100_000), 2.0, 3.0])
+      assert_equal(100_001, r.size)
+      assert_equal([1.0, 2.0, 3.0], [r[100_000], r[1], r[2]].map { |x| x.to_a.first })
+
+      a = Cumo::Int32[0, 1, 2]
+      assert_raise(ArgumentError) { a.bincount(minlength: setter.new(a, -1)) }
+    end
+
     test "an array large enough that the filling kernel is still running" do
       r = (Cumo::Int32.new(1 << 20).seq % 997).bincount
       assert_equal(997, r.size)


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#20](https://github.com/yoshoku/numo-narray-alt/pull/20) (merge `3b6b6b3`). It was the one alt fix with nowhere to land: both of its findings sit below a line `bincount` never reached, until #203 made the method work. All of it reproduces on cumo master `d741e8f`.

**The output length wraps.** The unsigned branch sizes the output as `NUM2SIZET(max) + 1`, and an item of `2**64-1` turns that into zero. Nothing is allocated, so the base pointer is NULL and the increment lands wherever the item points. `RangeError` now rejects a maximum of `SIZE_MAX` before the addition. On a 64-bit build only `UInt64` can reach it.

**The scan goes stale.** The length is fixed by a `max` / `minmax` scan, and then Ruby code runs before the counting loop looks at the items again: `NUM2SIZET` calls `to_int` on the `minlength:` keyword, and a Ruby Array weight is cast to `Cumo::DFloat`, which calls `to_f` on its elements. Either callback can write to `self`. Both conversions now happen before the scan, so the scan sees the array it actually counts — the results come out correct rather than merely safe.

**The loops recheck the bound.** Allocating the output can still run a finalizer, and the invariant the counting loops rely on was established several calls earlier. This is no longer reachable from Ruby, so it has no test.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

```ruby
Cumo::UInt64[(2**64) - 1].bincount
# [BUG] Segmentation fault at 0x0000000000000000
#   c:0003 p:---- s:0013 e:000012 l:y b:0001 CFUNC  :bincount

Cumo::UInt64[(2**64) - 1, (2**62) + 1000].bincount(minlength: 8)
# => [0, 0, 0, 0, 0, 0, 0, 0]
```

The second one allocates eight `UInt32` elements and then evaluates `p2 + 4 * (2**62 + 1000)` modulo `2**64`, 4000 bytes past the output. Neither count reaches the array that comes back. It does not fault, because the memory pool rounds the allocation up — the same reason the out-of-bounds writes in #201 were silent.

The stale scan needs only an object with a `to_int`:

```ruby
setter = Class.new do
  def initialize(a, v) = (@a = a; @v = v)
  def to_int; @a[0] = @v; 3; end
  def to_f;   @a[0] = @v; 1.0; end
end

a = Cumo::Int32[0, 1, 2]
a.bincount(minlength: setter.new(a, 100_000))
# => size 3, [0, 1, 1] -- the count for 100_000 went 400_000 bytes past a 12-byte output
a.bincount([setter.new(a, 100_000), 2.0, 3.0])
# => size 3, [0.0, 2.0, 3.0] -- same, through the weight cast
a.bincount(minlength: setter.new(a, -1))
# => [0, 1, 1] -- -1 reaches the loop as 2**64-1 and writes 4 bytes *before* the output
```

After this change the first two return a 100001-element result with the counts in the right place, and the third raises `ArgumentError`, because the scan now runs after the callback.

Nine tests in the `bincount` sub-test-case, two of them new here. As a positive control, with `ext/` reverted to `d741e8f`, the suite **cannot finish** — it segfaults at the `2**64-1` line, exit 139 — and running the stale-scan test alone fails on the result size. Full suite 951 tests, 11168 assertions, 0 failures.

## Note

The bound-check helper goes in the template rather than `include/cumo/template.h`, where #198's helper lives: `narray.h` includes `template.h` at its line 13, before it defines `SZF` at line 61, so the message would not compile there.

This empties the backport queue again — every merged `numo-narray-alt` fix is now in cumo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
