### PR TITLE
Fix poly failing on every input from an uninitialized ndfunc dim

### DIFF
--- a/ext/cumo/narray/gen/tmpl/poly.c
+++ b/ext/cumo/narray/gen/tmpl/poly.c
@@ -1,21 +1,20 @@
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
+    size_t  i, n;
     dtype  x, y, a;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    x = *(dtype*)(lp->args[0].ptr + lp->args[0].iter[0].pos);
-    i = lp->narg - 2;
-    y = *(dtype*)(lp->args[i].ptr + lp->args[i].iter[0].pos);
-    for (; --i;) {
+    n = lp->narg - 2;
+    x = *(dtype*)CUMO_NDL_PTR(lp,0);
+    y = *(dtype*)CUMO_NDL_PTR(lp,n);
+    for (i=1; i<n; i++) {
         y = m_mul(x,y);
-        a = *(dtype*)(lp->args[i].ptr + lp->args[i].iter[0].pos);
+        a = *(dtype*)CUMO_NDL_PTR(lp,n-i);
         y = m_add(y,a);
     }
-    i = lp->narg - 1;
-    *(dtype*)(lp->args[i].ptr + lp->args[i].iter[0].pos) = y;
+    *(dtype*)CUMO_NDL_PTR(lp,lp->narg-1) = y;
 }
 
 /*
@@ -39,6 +38,7 @@ static VALUE
     ndf.ain = ALLOCA_N(cumo_ndfunc_arg_in_t,argc+1);
     for (i=0; i<argc+1; i++) {
         ndf.ain[i].type = cT;
+        ndf.ain[i].dim = 0;
     }
     argv = ALLOCA_N(VALUE,argc+1);
     argv[0] = self;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,30 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  sub_test_case "poly" do
+    test "evaluates the polynomial" do
+      x = Cumo::DFloat.new(4).seq(1)
+      assert_equal([3.0, 5.0, 7.0, 9.0], x.poly(1.0, 2.0).to_a)
+      assert_equal([6.0, 17.0, 34.0, 57.0], x.poly(1.0, 2.0, 3.0).to_a)
+      assert_equal([3.0, 3.0, 3.0, 3.0], x.poly(3.0).to_a)
+      assert_equal([1.0, 2.0, 3.0, 4.0], x.poly.to_a)
+      assert_equal([5.0], Cumo::DFloat[2.0].poly(1.0, 2.0).to_a)
+    end
+
+    test "narray coefficients" do
+      x = Cumo::DFloat.new(4).seq(1)
+      a0 = Cumo::DFloat[1, 1, 1, 1]
+      a1 = Cumo::DFloat[2, 2, 2, 2]
+      assert_equal([3.0, 5.0, 7.0, 9.0], x.poly(a0, a1).to_a)
+    end
+
+    test "every dtype" do
+      assert_equal([3.0, 5.0, 7.0, 9.0], Cumo::SFloat.new(4).seq(1).poly(1.0, 2.0).to_a)
+      assert_equal([3, 5, 7, 9], Cumo::Int32.new(4).seq(1).poly(1, 2).to_a)
+      assert_equal([3, 5, 7, 9], Cumo::RObject.new(4).seq(1).poly(1, 2).to_a)
+    end
+  end
+
   sub_test_case "bincount" do
     int_types = [
       Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64,


### PR DESCRIPTION
## Summary

`poly` failed on every input, of every dtype. The `cumo_ndfunc_arg_in_t` descriptors are `ALLOCA_N`'d and the loop that fills them sets only `.type`, leaving `.dim` as whatever was on the stack. `ndloop` sizes its buffers from that number.

A temporary `fprintf` on `ndf.ain[i].dim` for a three-argument call printed **1384259584, 801008184, 64817**. That is the whole bug; setting `.dim = 0` makes every case correct.

The iterator also counted its coefficients downward with `for (; --i;)`, starting from `lp->narg - 2`. With no coefficients that is zero, so `--i` wraps to `SIZE_MAX` and the loop walks off the argument list. Counting upward ends the loop immediately instead, which is what `x.poly` with no arguments should do.

numo leaves the same field uninitialized. It happens to work there; whether a stack slot holds a zero is not something cumo can rely on, and `numo-narray-alt` has since started setting it explicitly.

## Problem

Measured on an RTX A4000 with CUDA 13.0, cumo master `ce2c1be`.

```ruby
Cumo::DFloat.new(4).seq(1).poly(1.0, 2.0)  # NoMemoryError: failed to allocate memory
Cumo::Int32.new(4).seq(1).poly(1, 2)       # NoMemoryError: too large allocation size
Cumo::DFloat[2.0].poly(1.0, 2.0)           # [BUG] Segmentation fault
Cumo::DFloat.new(4).seq(1).poly            # SystemStackError
Cumo::RObject.new(4).seq(1).poly(1, 2)     # SystemStackError
```

Which allocator message comes out depends on how large the garbage happens to be; the scalar receiver skips the allocation and faults instead.

After this change all of them match `numo-narray-alt` 0.11.2 exactly:

```ruby
x = Cumo::DFloat.new(4).seq(1)
x.poly(1.0, 2.0)       # => [3.0, 5.0, 7.0, 9.0]
x.poly(1.0, 2.0, 3.0)  # => [6.0, 17.0, 34.0, 57.0]
x.poly(3.0)            # => [3.0, 3.0, 3.0, 3.0]
x.poly                 # => [1.0, 2.0, 3.0, 4.0]
```

including NArray coefficients, `SFloat`, `Int32` and `RObject`, and a one-element receiver.

Three tests added; `poly` had none, which is why a method that never worked went unnoticed. As a positive control, with `ext/` reverted to `ce2c1be`, the `NoMemoryError` escapes test-unit and the run stops at the first assertion. Full suite 954 tests, 11177 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
