### PR TITLE
Fix segfault in max_index and min_index with nan: true

### DIFF
--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -91,7 +91,10 @@ static VALUE
     {
         cumo_narray_t *na;
         VALUE reduce, ret;
-        cumo_ndfunc_arg_in_t ain[2] = {{Qnil,0},{cumo_sym_reduce,0}};
+        <% if is_float %>
+        cumo_na_iter_func_t iter_nan;
+        <% end %>
+        cumo_ndfunc_arg_in_t ain[3] = {{Qnil,0},{cumo_sym_reduce,0},{Qnil,0}};
         cumo_ndfunc_arg_out_t aout[1] = {{0,0,0}};
         cumo_ndfunc_t ndf = {0, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_EXTRACT|CUMO_NDF_INDEXER_LOOP, 2,1, ain,aout};
 
@@ -100,7 +103,8 @@ static VALUE
             aout[0].type = cumo_cInt64;
             ndf.func = <%=c_iter%>_index64;
             <% if is_float %>
-            reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, <%=c_iter%>_index64_nan);
+            iter_nan = <%=c_iter%>_index64_nan;
+            reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, iter_nan);
             <% else %>
             reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
             <% end %>
@@ -108,11 +112,33 @@ static VALUE
             aout[0].type = cumo_cInt32;
             ndf.func = <%=c_iter%>_index32;
             <% if is_float %>
-            reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, <%=c_iter%>_index32_nan);
+            iter_nan = <%=c_iter%>_index32_nan;
+            reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, iter_nan);
             <% else %>
             reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
             <% end %>
         }
+
+        <% if is_float %>
+        if (ndf.func == iter_nan) {
+            // The nan-aware path has no kernel and reads the index out of a seq
+            // array, the way robject does. Only that path takes a third argument.
+            VALUE idx = cumo_na_new(aout[0].type, na->ndim, na->shape);
+            rb_funcall(idx, rb_intern("seq"), 0);
+            ain[1].type = Qnil;
+            ain[2].type = cumo_sym_reduce;
+            ndf.nin = 3;
+            ndf.flag &= ~CUMO_NDF_INDEXER_LOOP;
+            if (cumo_na_has_idx_p(self)) {
+                self = cumo_na_copy(self);
+            }
+            ret = cumo_na_ndloop(&ndf, 3, self, idx, reduce);
+            if (cumo_compatible_mode_enabled_p()) {
+                return rb_funcall(ret, rb_intern("extract_cpu"), 0);
+            }
+            return ret;
+        }
+        <% end %>
 
         if (cumo_na_has_idx_p(self)) {
             VALUE copy = cumo_na_copy(self); // reduction does not support idx, make conttiguous

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1457,6 +1457,42 @@ class NArrayTest < Test::Unit::TestCase
     assert { v[true, :new].to_a == [[0], [1], [2], [3]] }
   end
 
+  sub_test_case "max_index/min_index with nan: true" do
+    nan = Float::NAN
+
+    test "one dimension" do
+      a = Cumo::DFloat[3, 4, nan, 2]
+      assert_equal([2], a.max_index(nan: true).to_a)
+      assert_equal([2], a.min_index(nan: true).to_a)
+
+      b = Cumo::DFloat[3, 4, 1, 2]
+      assert_equal([1], b.max_index(nan: true).to_a)
+      assert_equal([2], b.min_index(nan: true).to_a)
+    end
+
+    test "the index is into the whole array, not into the axis" do
+      b = Cumo::DFloat[[3, 4, 1], [nan, 2, 5]]
+      assert_equal([3], b.max_index(nan: true).to_a)
+      assert_equal([3], b.min_index(nan: true).to_a)
+      assert_equal([3, 1, 5], b.max_index(axis: 0, nan: true).to_a)
+      assert_equal([1, 3], b.max_index(axis: 1, nan: true).to_a)
+      assert_equal([3, 4, 2], b.min_index(axis: 0, nan: true).to_a)
+      assert_equal([2, 3], b.min_index(axis: 1, nan: true).to_a)
+    end
+
+    test "SFloat and a view" do
+      assert_equal([2], Cumo::SFloat[3, 4, nan, 2].max_index(nan: true).to_a)
+      assert_equal([2], Cumo::DFloat[3, 4, nan, 2, 9][0...4].max_index(nan: true).to_a)
+    end
+
+    test "the kernel path is unaffected" do
+      a = Cumo::DFloat[[3, 4, 1], [9, 2, 5]]
+      assert_equal([3], a.max_index.to_a)
+      assert_equal([1, 3], a.max_index(axis: 1).to_a)
+      assert_equal([2], a.min_index.to_a)
+    end
+  end
+
   sub_test_case "poly" do
     test "evaluates the polynomial" do
       x = Cumo::DFloat.new(4).seq(1)


### PR DESCRIPTION
## Summary

`max_index(nan: true)` and `min_index(nan: true)` segfaulted on every dtype except `Cumo::RObject`, which is the one dtype that worked.

`gen/tmpl/accum_index.c` has no kernel for the nan-aware case, so it falls back to the CPU iterator that numo uses. That iterator takes three arguments — the data, a seq array holding each element's flat index, and the output — and reads the answer as `*(idx_t*)(i_ptr + i_step * idx)`. Only the RObject branch of the method built that seq array; every other dtype set up two arguments for the kernel, so the iterator read its index array out of the output buffer and wrote the result one slot past the end of the argument list.

The fix builds the seq array on the nan path too, and clears `CUMO_NDF_INDEXER_LOOP` there, which only the kernel needs. The kernel path is untouched: it is selected exactly when `cumo_na_reduce_dimension` leaves `ndf.func` alone.

## Problem

Measured on an RTX A4000 with CUDA 13.0, cumo master `0c22e44`.

```ruby
Cumo::DFloat[3, 4, Float::NAN, 2].max_index(nan: true)
# [BUG] Segmentation fault at 0x0000000000000000
```

The seq array is what makes the result an index into the whole array rather than into the reduction axis, so a fix that only stopped the crash would have returned the wrong number. Every case below now matches `numo-narray-alt` 0.11.2:

```ruby
nan = Float::NAN
a = Cumo::DFloat[3, 4, nan, 2]
b = Cumo::DFloat[[3, 4, 1], [nan, 2, 5]]

a.max_index(nan: true)             # => 2
a.min_index(nan: true)             # => 2
b.max_index(nan: true)             # => 3
b.max_index(axis: 0, nan: true)    # => [3, 1, 5]
b.max_index(axis: 1, nan: true)    # => [1, 3]
b.min_index(axis: 0, nan: true)    # => [3, 4, 2]
```

Four tests added. As a positive control, with `ext/` reverted to `0c22e44` the suite does not finish — it segfaults at the first of them, exit 139. Full suite 958 tests, 11192 assertions, 0 failures.

## Note

An earlier version of this change also added the `na->ndim == 0` early return that the RObject branch has. It was dropped: the kernel path already handles a 0-dimensional array, and `INT2FIX(0)` would have turned a result that is a 0-dimensional NArray today into a Ruby Integer, which is not how the rest of cumo returns reductions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
