### PR TITLE
Fix Cumo::RObject#logseq returning Infinity

### DIFF
--- a/ext/cumo/narray/gen/tmpl/logseq.c
+++ b/ext/cumo/narray/gen/tmpl/logseq.c
@@ -90,6 +90,7 @@ static VALUE
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 1,0, ain,0};
 
     g = ALLOCA_N(logseq_opt_t,1);
+    g->count = 0;
     rb_scan_args(argc, args, "21", &vbeg, &vstep, &vbase);
     g->beg = m_num_to_data(vbeg);
     g->step = m_num_to_data(vstep);

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -774,7 +774,6 @@ class NArrayAltCoverageTest < CumoTestBase
   end
 
   def test_robject_logseq
-    omit("Cumo::RObject#logseq returns Infinity")
     assert_equal(Cumo::RObject[1, 10, 100, 1000], Cumo::RObject.new(4).logseq(0, 1))
     assert_equal(Cumo::RObject[16, 8, 4, 2, 1], Cumo::RObject.new(5).logseq(4, -1, 2))
   end


### PR DESCRIPTION
## Summary

`logseq_opt_t` is `ALLOCA_N`'d, and `gen/tmpl/logseq.c` assigns `beg`, `step` and `base` right after — but never `count`. The iterator reads `count` as the sequence's starting index, so the first element comes out as `base ** garbage`.

```ruby
Cumo::RObject.new(4).logseq(0, 1)      # => [Infinity, Infinity, Infinity, Infinity]
Cumo::RObject.new(5).logseq(4, -1, 2)  # => ArgumentError
```

`gen/tmpl/seq.c` has always initialised its own `count`; only `logseq.c` was missing the line. Adding it makes every dtype match numo element for element:

```ruby
Cumo::RObject.new(4).logseq(0, 1)      # => [1.0, 10.0, 100.0, 1000.0]
Cumo::RObject.new(5).logseq(4, -1, 2)  # => [16, 8, 4, 2, 1]
```

`DFloat`, `SFloat`, `DComplex` and `SComplex` are unchanged: they were reading the same uninitialised field, but happened to see a zero. That is why the symptom looked specific to `Cumo::RObject` — it is undefined behaviour, so whether it bites depends on what the caller left on the stack.

## Provenance

Backport of `numo-narray-alt`'s `4788184`, which added the identical line when it unified `logseq` into a macro template — `src/mh/logseq.h:59`, between the `step` assignment and the `base` branch. Verified by reading the 0.11.2 gem, and alt returns the correct values for `Cumo::RObject`'s equivalent.

`ruby-numo/numo-narray` still has the omission: its `gen/tmpl/seq.c` sets `g->count = 0` at line 81, and its `logseq.c` only reads the field and writes it back. So this is shared lineage that alt has already fixed and numo master has not.

## Tests

`test_robject_logseq` was added in #209 as an `omit`ted case; this removes the `omit`. As a positive control, with `ext/` reverted to `1d66608` and rebuilt from a deleted `tmp/`, it fails. Full suite 1111 tests, 15166 assertions, 0 failures, likewise verified from a deleted `tmp/`.

## Note

This is the second partially-initialised `ALLOCA_N` struct found in cumo, after `poly`'s `ndf.ain[i].dim` in #205 — and alt is explicit in both places (`src/mh/poly.h:28` has `ain[i].dim = 0;`). Both of alt's initialisations arrived in commits filed as refactors rather than as fixes, so they do not appear in its merged-PR list. A sweep of cumo's own `ALLOCA_N` sites for structs that are only partly assigned is worth doing rather than waiting to trip over a third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
