### PR TITLE
Fix spelling in messages, docs and comments

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -40,7 +40,7 @@ extern VALUE cumo_na_eShapeError;
 #define CUMO_CUDA_CUDNN_CHECK_DIM_EQ(nd1,nd2)        \
     if ((nd1) != (nd2)) {                            \
         rb_raise(cumo_na_eShapeError,                \
-                 "dimention mismatch: %d != %d",     \
+                 "dimension mismatch: %d != %d",     \
                  (int)(nd1), (int)(nd2));            \
     }
 

--- a/ext/cumo/include/cumo/ndloop.h
+++ b/ext/cumo/include/cumo/ndloop.h
@@ -21,7 +21,7 @@ typedef struct {
 // pass this structure to user iterator
 typedef struct {
     int  narg;
-    int  ndim;             // n of user dimention used at user function.
+    int  ndim;             // n of user dimension used at user function.
     size_t *n;             // n of elements for each dim (=shape)
     cumo_na_loop_args_t *args;  // for each arg
     VALUE  option;

--- a/ext/cumo/narray/array.c
+++ b/ext/cumo/narray/array.c
@@ -554,7 +554,7 @@ cumo_na_mdai_for_struct(cumo_na_mdai_t *mdai, int ndim)
             //fputs("compati\n",stderr);
             return 1;
         }
-        // otherwise, multi-dimention
+        // otherwise, multi-dimension
         if (ndim >= mdai->capa) {
             //fprintf(stderr,"exeed capa\n");            abort();
             cumo_na_mdai_realloc(mdai,4);

--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -73,7 +73,7 @@ if is_int && !is_object
   def_id "minlength" # for bincount
 end
 
-# Constatnts
+# Constants
 
 if is_bit
   def_const "ELEMENT_BIT_SIZE",  "INT2FIX(1)"

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -141,7 +141,7 @@ static VALUE
         <% end %>
 
         if (cumo_na_has_idx_p(self)) {
-            VALUE copy = cumo_na_copy(self); // reduction does not support idx, make conttiguous
+            VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
             ret = cumo_na_ndloop(&ndf, 2, copy, reduce);
         } else {
             ret = cumo_na_ndloop(&ndf, 2, self, reduce);

--- a/ext/cumo/narray/gen/tmpl/aset.c
+++ b/ext/cumo/narray/gen/tmpl/aset.c
@@ -6,7 +6,7 @@
   @return [Numeric] returns val (last argument).
 
   --- Replace element(s) at +dim0+, +dim1+, ... (index/range/array/true
-  for each dimention). Broadcasting mechanism is applied.
+  for each dimension). Broadcasting mechanism is applied.
 
   @example
       a = Cumo::DFloat.new(3,4).seq

--- a/ext/cumo/narray/gen/tmpl/format.c
+++ b/ext/cumo/narray/gen/tmpl/format.c
@@ -53,7 +53,7 @@ static void
   Format elements into strings.
   @overload <%=name%> format
   @param [String] format
-  @return [Cumo::RObject] array of formated strings.
+  @return [Cumo::RObject] array of formatted strings.
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)

--- a/ext/cumo/narray/gen/tmpl/format_to_a.c
+++ b/ext/cumo/narray/gen/tmpl/format_to_a.c
@@ -33,7 +33,7 @@ static void
   Format elements into strings.
   @overload <%=name%> format
   @param [String] format
-  @return [Array] array of formated strings.
+  @return [Array] array of formatted strings.
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)

--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -42,7 +42,7 @@
 #define CHECK_DIM_EQ(na1,nd)                                    \
     if ((na1)->ndim != (nd)) {                                  \
         rb_raise(cumo_na_eShapeError,                           \
-                 "dimention mismatch: %d != %d",                \
+                 "dimension mismatch: %d != %d",                \
                  (na1)->ndim, (nd));                            \
     }
 
@@ -258,7 +258,7 @@ static void
   def mat(v,*a,**h)
     tp = h[:type] || class_name
     a.map!{|x| x==:inplace ? "inplace allowed" : x}
-    a.unshift ">=2-dimentional NArray"
+    a.unshift ">=2-dimensional NArray"
     "@param #{v} [#{tp}]  matrix (#{a.join(', ')})."
   end
 

--- a/ext/cumo/narray/gen/tmpl/logseq.c
+++ b/ext/cumo/narray/gen/tmpl/logseq.c
@@ -67,7 +67,7 @@ static void
   Applicable classes: DFloat, SFloat, DComplex, SCopmplex.
 
   @overload logseq(beg,step,[base])
-  @param [Numeric] beg  The begining of sequence.
+  @param [Numeric] beg  The beginning of sequence.
   @param [Numeric] step  The step of sequence.
   @param [Numeric] base  The base of log space. (default=10)
   @return [Cumo::<%=class_name%>] self.

--- a/ext/cumo/narray/gen/tmpl/seq.c
+++ b/ext/cumo/narray/gen/tmpl/seq.c
@@ -75,7 +75,7 @@ static void
      beg+i*step
   where i is 1-dimensional index.
   @overload seq([beg,[step]])
-  @param [Numeric] beg  begining of sequence. (default=0)
+  @param [Numeric] beg  beginning of sequence. (default=0)
   @param [Numeric] step  step of sequence. (default=1)
   @return [Cumo::<%=class_name%>] self.
   @example

--- a/ext/cumo/narray/gen/tmpl_bit/format.c
+++ b/ext/cumo/narray/gen/tmpl_bit/format.c
@@ -48,7 +48,7 @@ static void
   Format elements into strings.
   @overload <%=name%> format
   @param [String] format
-  @return [Cumo::RObject] array of formated strings.
+  @return [Cumo::RObject] array of formatted strings.
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)

--- a/ext/cumo/narray/gen/tmpl_bit/format_to_a.c
+++ b/ext/cumo/narray/gen/tmpl_bit/format_to_a.c
@@ -33,7 +33,7 @@ static void
   Format elements into strings.
   @overload <%=name%> format
   @param [String] format
-  @return [Array] array of formated strings.
+  @return [Array] array of formatted strings.
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -13,7 +13,7 @@
 #endif
 
 
-// note: the memory refed by this pointer is not freed and causes memroy leak.
+// note: the memory refed by this pointer is not freed and causes memory leak.
 //
 // @example
 //     a[1..3,1] generates two cumo_na_index_arg_t(s). First is for 1..3, and second is for 1.
@@ -427,7 +427,7 @@ cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, 
             cumo_na_index_parse_each(v, 1, k, &q[j]);
             j++;
         }
-        // other dimention
+        // other dimension
         else {
             cumo_na_index_parse_each(v, na->shape[k], k, &q[j]);
             if (q[j].n > 1) {
@@ -1058,7 +1058,7 @@ check_index_count(int argc, int cumo_na_ndim, int count_new, int count_rest)
                  argc,cumo_na_ndim);
         break;
     default:
-        rb_raise(rb_eIndexError,"multiple rest-dimension is not allowd");
+        rb_raise(rb_eIndexError,"multiple rest-dimension is not allowed");
     }
     return -1;
 }

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -40,7 +40,7 @@ typedef struct CUMO_NA_LOOP_XARGS {
 typedef struct CUMO_NA_MD_LOOP {
     int  narg;
     int  nin;
-    int  ndim;                // n of total dimention looped at loop_narray. NOTE: lp->ndim + lp-.user.ndim is the total dimension.
+    int  ndim;                // n of total dimension looped at loop_narray. NOTE: lp->ndim + lp-.user.ndim is the total dimension.
     unsigned int copy_flag;   // set i-th bit if i-th arg is cast
     void    *ptr;             // memory for n
     cumo_na_loop_iter_t *iter_ptr; // memory for iter

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -949,7 +949,7 @@ module Cumo
       else
         arg = arg.to_a
         if arg.size != c.shape[axis]
-          raise ArgumentError, "repeat size shoud be equal to size along axis"
+          raise ArgumentError, "repeat size should be equal to size along axis"
         end
         arg.each do |i|
           if !i.kind_of?(Integer) || i < 0
@@ -1041,7 +1041,7 @@ module Cumo
       end
     end
 
-    # Return the indices for the uppler-triangle on and above the k-th diagonal.
+    # Return the indices for the upper-triangle on and above the k-th diagonal.
     def triu_indices(k=0)
       if ndim < 2
         raise NArray::ShapeError, "must be >= 2-dimensional array"
@@ -1050,7 +1050,7 @@ module Cumo
       NArray.triu_indices(m, n, k)
     end
 
-    # Return the indices for the uppler-triangle on and above the k-th diagonal.
+    # Return the indices for the upper-triangle on and above the k-th diagonal.
     def self.triu_indices(m, n, k=0)
       x = Cumo::Int64.new(m, 1).seq + k
       y = Cumo::Int64.new(1, n).seq


### PR DESCRIPTION
## Summary

numo has a batch of spelling commits from 2025-05 that were never backported, and `numo-narray-alt` fixed one more (`allowd`) that cumo still carries. Rather than port those commits one at a time — cumo's comments have drifted from numo's, so several would not apply and others would miss cumo-only text — this is a sweep of cumo's own tree.

21 replacements across 16 files. No behaviour change beyond the wording of four messages.

## What changed

**User-visible messages** — four:

| where | before | after |
|---|---|---|
| `narray/index.c:1061` | `multiple rest-dimension is not allowd` | `... not allowed` |
| `gen/tmpl/gemm.c:45` | `dimention mismatch: %d != %d` | `dimension mismatch: ...` |
| `include/cumo/cuda/cudnn.h:43` | `dimention mismatch: %d != %d` | `dimension mismatch: ...` |
| `lib/cumo/narray/extra.rb:952` | `repeat size shoud be equal to size along axis` | `... should be ...` |

Anything matching on those strings would need updating, which is why they are listed rather than buried in the count.

**Yard docs**, which reach the generated documentation — `formated` → `formatted` in the four `format` / `format_to_a` templates, `begining` → `beginning` in `seq` and `logseq`, `uppler` → `upper` in `triu_indices`, and `>=2-dimentional NArray` in `gemm`.

**Comments** — `memroy`, `conttiguous`, `Constatnts`, and the remaining `dimention`.

## How the list was built

Grepped for the words numo's commits fix, then swept a list of about eighty common misspellings over `ext/cumo`, `lib` and the markdown. `numer` and `strid` matched only as substrings of `numerical` and `strides`; `successfull` matched `successfully`. The generated `narray/types/*.c` were excluded — they are rebuilt from the templates.

Full suite 1111 tests, 15166 assertions, 0 failures, verified from a deleted `tmp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
