### PR TITLE
Fix interpreter abort on a zero-dimensional view

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -440,7 +440,11 @@ cumo_na_reshape_bang(int argc, VALUE *argv, VALUE self)
         } else {
             stridx = na2->stridx;
         }
-        stride = CUMO_SDX_GET_STRIDE(na2->stridx[na->ndim-1]);
+        if (na->ndim == 0) {
+            stride = cumo_na_element_stride(self);
+        } else {
+            stride = CUMO_SDX_GET_STRIDE(na2->stridx[na->ndim-1]);
+        }
         for (i=argc; i--;) {
             CUMO_SDX_SET_STRIDE(stridx[i],stride);
             stride *= shape[i];

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -941,6 +941,9 @@ cumo_na_check_ladder(VALUE self, int start_dim)
     cumo_narray_t *na;
     CumoGetNArray(self,na);
 
+    if (na->ndim == 0) {
+        return Qtrue;
+    }
     if (start_dim < -na->ndim || start_dim >= na->ndim) {
         rb_bug("start_dim (%d) out of range",start_dim);
     }
@@ -985,6 +988,9 @@ cumo_na_check_contiguous(VALUE self)
         return Qtrue;
     case CUMO_NARRAY_VIEW_T:
         if (CUMO_NA_VIEW_STRIDX(na)==0) {
+            return Qtrue;
+        }
+        if (CUMO_NA_NDIM(na)==0) {
             return Qtrue;
         }
         if (cumo_na_check_ladder(self,0)==Qtrue) {

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -777,4 +777,24 @@ class NArrayAltCoverageTest < CumoTestBase
     assert_equal(Cumo::RObject[1, 10, 100, 1000], Cumo::RObject.new(4).logseq(0, 1))
     assert_equal(Cumo::RObject[16, 8, 4, 2, 1], Cumo::RObject.new(5).logseq(4, -1, 2))
   end
+  def test_zero_dimensional_view_is_contiguous
+    a = Cumo::DFloat.cast(3.5)
+    bin = [3.5].pack("d")
+
+    assert_predicate(a.view, :contiguous?)
+    assert_equal(bin, a.view.to_binary)
+    assert_equal(bin, a.transpose.to_binary)
+    assert_equal(bin, a.flatten.to_binary)
+    assert_equal([1, [], 0, bin], a.view.marshal_dump)
+    assert_equal(a, Marshal.load(Marshal.dump(a.view)))
+
+    assert_equal([1, [], 0, [:sym]], Cumo::RObject.cast(:sym).view.marshal_dump)
+  end
+
+  def test_reshape_bang_on_a_zero_dimensional_view
+    a = Cumo::DFloat.cast(3.5)
+
+    assert_equal([3.5], a.view.reshape!(1).to_a)
+    assert_equal([[3.5]], a.view.reshape!(1, 1).to_a)
+  end
 end


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#24](https://github.com/yoshoku/numo-narray-alt/pull/24) (merge `c886904`). Every route reproduces on cumo master `91e25d2`.

`cumo_na_check_contiguous` calls `cumo_na_check_ladder(self, 0)` for a view, and that function's argument check

```c
if (start_dim < -na->ndim || start_dim >= na->ndim) {
    rb_bug("start_dim (%d) out of range", start_dim);
}
```

is true for **every** `start_dim` once `ndim` is 0, because both halves collapse to `0` on each side. A zero-dimensional NArray comes straight out of `cast` or `zeros`, and `view`, `transpose` and `flatten` all return views of one, so the abort is a few characters away from ordinary code.

## Problem

Measured on an RTX A4000 with CUDA 13.0. Each of these takes the interpreter down with SIGABRT:

```ruby
a = Cumo::DFloat.cast(3.5)
a.view.to_binary
a.view.contiguous?
a.view.to_string
a.view.marshal_dump
Marshal.dump(a.view)
a.view.reshape!(1)
Cumo::DFloat.zeros.transpose.to_binary
a.flatten.to_binary
```

```
[BUG] start_dim (0) out of range
```

The zero-dimensional array itself is fine — `a.to_binary` returns the eight bytes — so it is specifically the view.

## The order matters

The three changes are not independent, which is worth stating because applying a subset is worse than applying none:

- `cumo_na_check_ladder` returns `Qtrue` for `ndim == 0` **at the top of the function**. Relaxing the range check to `na->ndim > 0 && (...)` instead would only move the problem: a zero-dimensional `VIEW_T` would then fall into the switch below and read `stridx[0]`, replacing `rb_bug` with an out-of-bounds read.
- `cumo_na_check_contiguous` returns `Qtrue` for `ndim == 0` as well, otherwise the stride comparison right after it indexes `CUMO_NA_STRIDE_AT(na, -1)`.
- `cumo_na_reshape_bang` takes the element size when `ndim == 0`, otherwise it reads `na2->stridx[-1]` for the same reason. alt measured that one as an eight-byte heap over-read under ASan.

## Tests

alt's two tests, ported. As a positive control, with `ext/` reverted to `91e25d2` and rebuilt from a deleted `tmp/`, the suite aborts at the first of them with exit 134. Full suite 1113 tests, 15175 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
