### PR TITLE
Fix view offsets being added in the wrong unit

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1487,13 +1487,17 @@ cumo_na_to_binary(VALUE self)
     char *ptr;
     VALUE str;
     cumo_narray_t *na;
+    int offset_in_bits;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_to_binary", "any");
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     CumoGetNArray(self,na);
     if (na->type == CUMO_NARRAY_VIEW_T) {
-        if (cumo_na_check_contiguous(self)==Qtrue) {
+        // Cumo::Bit measures the offset in bits, so it cannot be added to a
+        // char pointer; kind_of because a subclass must not slip past either.
+        offset_in_bits = RTEST(rb_obj_is_kind_of(self, cumo_cBit)) && CUMO_NA_VIEW_OFFSET(na) != 0;
+        if (!offset_in_bits && cumo_na_check_contiguous(self)==Qtrue) {
             offset = CUMO_NA_VIEW_OFFSET(na);
         } else {
             self = rb_funcall(self,cumo_id_dup,0);
@@ -1530,7 +1534,7 @@ cumo_na_marshal_dump(VALUE self)
         CumoGetNArray(self,na);
         if (na->type == CUMO_NARRAY_VIEW_T) {
             if (cumo_na_check_contiguous(self)==Qtrue) {
-                offset = CUMO_NA_VIEW_OFFSET(na);
+                offset = CUMO_NA_VIEW_OFFSET(na) / sizeof(VALUE);
             } else {
                 self = rb_funcall(self,cumo_id_dup,0);
             }

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -797,4 +797,38 @@ class NArrayAltCoverageTest < CumoTestBase
     assert_equal([3.5], a.view.reshape!(1).to_a)
     assert_equal([[3.5]], a.view.reshape!(1, 1).to_a)
   end
+
+  class BitSubclass < Cumo::Bit; end
+
+  def test_marshal_dump_of_a_robject_view_with_an_offset
+    a = Cumo::RObject.cast(%i[a b c d e f g h])
+
+    (0..5).each do |i|
+      v = a[i..(i + 2)]
+      assert_equal([1, [3], 0, v.to_a], v.marshal_dump)
+      assert_equal(v.to_a, Marshal.load(Marshal.dump(v)).to_a)
+    end
+  end
+
+  def test_to_binary_of_a_bit_view_with_an_offset
+    bits = Array.new(200) { |i| (i * 7 % 5).zero? ? 1 : 0 }
+    a = Cumo::Bit.cast(bits)
+
+    [0, 1, 3, 8, 11, 16, 63, 64, 65, 100].each do |i|
+      v = a[i..(i + 20)]
+      assert_equal(bits[i, 21], v.to_a)
+      assert_equal(v.to_a, Marshal.load(Marshal.dump(v)).to_a)
+      assert_equal(v.to_a.join, v.to_binary.unpack1("b*")[0, 21])
+    end
+  end
+
+  def test_to_binary_of_a_bit_subclass_view_with_an_offset
+    bits = Array.new(32) { |i| (i % 3).zero? ? 1 : 0 }
+    a = BitSubclass.new(32).store(Cumo::Bit.cast(bits))
+
+    assert_equal(bits, a.to_a)
+    assert_equal(bits.join, a.to_binary.unpack1("b*"))
+    assert_equal(bits[8, 8], a[8..15].to_a)
+    assert_raise(Cumo::NArray::CastError) { a[8..15].to_binary }
+  end
 end


### PR DESCRIPTION
## Summary

Backport of [yoshoku/numo-narray-alt#25](https://github.com/yoshoku/numo-narray-alt/pull/25) (merge `e7812e1`). Both halves reproduce on cumo master `91e25d2`.

`cumo_na_to_binary` and `cumo_na_marshal_dump` avoid a copy for a contiguous view by adding `CUMO_NA_VIEW_OFFSET` to the data pointer. That assumes the offset is a byte count and the pointer a `char*`. Two dtypes break the assumption, both by a factor of eight:

- **`Cumo::Bit`** — its element stride is `1, // element_stride (in bits)`, so the offset is in **bits** while the other twelve dtypes use `sizeof(dtype)` and are in bytes.
- **`Cumo::RObject`** — the offset is in bytes, but `marshal_dump` adds it to a `VALUE*`.

## Problem

Measured on an RTX A4000 with CUDA 13.0.

```ruby
Marshal.load(Marshal.dump(Cumo::RObject.cast(%i[a b c d e])[1..3])).to_a
# => [false, false, false], want [:b, :c, :d]

b = Cumo::Bit.cast(Array.new(32) { |i| i % 3 == 0 ? 1 : 0 })
v = b[8..15]
v.to_a                              # => [0, 1, 0, 0, 1, 0, 0, 1]
Marshal.load(Marshal.dump(v)).to_a  # => [0, 0, 0, 0, 0, 0, 0, 0]
```

**The RObject case does not segfault here — it corrupts quietly.** alt reports a SIGSEGV for the same code; on this machine the word eight slots past the view happens to read back as `Qfalse`, so an array of `false` comes out instead. Same mechanism, and the silent version is the worse one to ship.

**Byte alignment is not the issue; the unit is.** `b[8..15]` is an offset of exactly 8 bits, a whole byte, and it is still wrong. So is every other offset tried — 0, 1, 3, 8, 11, 16, 63, 64, 65 and 100 all round-trip correctly after the change, and all but 0 were broken before it.

## Three notes on the port

**Not `offset / 8` for Bit, but the copy path.** `CUMO_BIT_DIGIT` is a word, so dividing would only hold on a little-endian machine, and an offset that is not a multiple of 8 cannot be expressed as a byte copy at all — it needs a shift. `dup` goes through the existing store loop, which already shifts.

**`rb_obj_is_kind_of`, not `rb_obj_class(self) == cumo_cBit`.** The codebase uses the latter everywhere else, and this guard is the exception on purpose: elsewhere a class mismatch falls through to a generic path, while here it would fall through to an out-of-bounds read. A `Cumo::Bit` subclass view has to be caught too.

**A Bit subclass view now raises instead of reading out of bounds.** `Cumo::NArray` subclasses cannot be `dup`ed at all — the `*_store` dispatch requires an exact class match, so `BitSubclass.new(4).store(...).dup` raises `CastError: unknown conversion from BitSubclass to BitSubclass`. A subclass view therefore takes the copy path and raises, which is the same exception a non-contiguous subclass view already raised on master. An out-of-bounds read is replaced by an existing limitation, not by new behaviour.

## Tests

alt's three tests, ported. As a positive control, with `ext/` reverted to `91e25d2` and rebuilt from a deleted `tmp/`, all three fail. Full suite 1114 tests, 15212 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
