### PR TITLE
Fix dot handing gemm operands of a different dtype

### DIFF
--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -307,6 +307,12 @@ static VALUE
     beta = cumo_cuda_cublas_option_value(opts[1],Qnil);
     g.beta = RTEST(beta) ? m_num_to_data(beta) : m_zero;
 
+    // b is handed to cuBLAS as a raw <%=cutype%>*, so another dtype would be
+    // reinterpreted, and a narrower one read past its end.
+    if (rb_obj_class(b) != cT) {
+        b = rb_funcall(cT, rb_intern("cast"), 1, b);
+    }
+
     CumoGetNArray(a, na);
     CumoGetNArray(b, nb);
     CHECK_DIM_GE(na, 2);

--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -1148,21 +1148,22 @@ module Cumo
         return self * b
       end
       if [SFloat, DFloat, SComplex, DComplex].include?(t)
-        b = self.class.asarray(b)
-        case self.ndim
+        a = t.cast(self)
+        b = t.asarray(t.cast(b))
+        case a.ndim
         when 1
           case b.ndim
           when 1
-            self.mulsum(b, axis:-1)
+            a.mulsum(b, axis:-1)
           else
-            self[:new, false].gemm(b).flatten
+            a[:new, false].gemm(b).flatten
           end
         else
           case b.ndim
           when 1
-            self.gemm(b[false, :new]).flatten
+            a.gemm(b[false, :new]).flatten
           else
-            self.gemm(b)
+            a.gemm(b)
           end
         end
       else

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -582,10 +582,13 @@ class NArrayExtraTest < CumoTestBase
   end
 
   def test_dot_between_types
-    omit("Cumo's dot raises NoMethodError for Int32.dot(DFloat) and returns a wrong value for DFloat.dot(Int32)")
     a = Cumo::Int32[1, 2, 3]
     b = Cumo::DFloat[[4], [5], [6]]
     assert_equal(Cumo::DFloat[32], a.dot(b))
+  end
+
+  def test_dot_between_types_without_upcast
+    omit("Cumo's mulsum reduces the wrong axis when the reduced axis is not the last one and the last dimension is 1")
     assert_equal(Cumo::DFloat[32], Cumo::DFloat[1, 2, 3].dot(Cumo::Int32[[4], [5], [6]]))
   end
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -674,6 +674,24 @@ class NArrayTest < Test::Unit::TestCase
           alpha = [Cumo::DComplex, Cumo::SComplex].include?(dtype) ? Complex(3) : 3
           assert { a.gemm(b.transpose) * alpha == a.gemm(b.transpose, alpha: alpha) }
         end
+        test "matrix.gemm(matrix) of another dtype" do
+          a = dtype[1..6].reshape(2, 3)
+          real = [Cumo::SFloat, Cumo::DFloat].include?(dtype)
+          [Cumo::Int32, Cumo::SFloat, Cumo::DFloat, Cumo::SComplex, Cumo::DComplex].each do |btype|
+            b = btype[1..6].reshape(3, 2)
+            if real && [Cumo::SComplex, Cumo::DComplex].include?(btype)
+              assert_raise(Cumo::NArray::CastError) { a.gemm(b) }
+              next
+            end
+            c = a.gemm(b)
+            assert { c.instance_of?(dtype) }
+            assert { c == [[22, 28], [49, 64]] }
+          end
+        end
+        test "matrix.gemm(array)" do
+          a = dtype[1..6].reshape(2, 3)
+          assert { a.gemm([[1, 2], [3, 4], [5, 6]]) == [[22, 28], [49, 64]] }
+        end
       end
     end
 
@@ -851,6 +869,33 @@ class NArrayTest < Test::Unit::TestCase
   test "cast any object that responds to to_a" do
     object = Struct.new(:to_a).new([1, 2, 3])
     assert { Cumo::NArray.cast(object) == [1, 2, 3] }
+  end
+
+  sub_test_case "#dot between types" do
+    dot_types = [
+      Cumo::Int32,
+      Cumo::Int64,
+      Cumo::UInt8,
+      Cumo::SFloat,
+      Cumo::DFloat,
+      Cumo::SComplex,
+      Cumo::DComplex,
+    ]
+
+    dot_types.each do |atype|
+      dot_types.each do |btype|
+        test "#{atype}.dot(#{btype})" do
+          upcast = atype::UPCAST[btype] || btype::UPCAST[atype]
+          a = atype[1..6].reshape(2, 3)
+          b = btype[1..6].reshape(3, 2)
+          assert { a.dot(b).instance_of?(upcast) }
+          assert { a.dot(b) == [[22, 28], [49, 64]] }
+          assert { a.dot(btype[1..3]) == [14, 32] }
+          assert { atype[1..3].dot(b) == [22, 28] }
+          assert { atype[1..3].dot(btype[1..3]) == 14 }
+        end
+      end
+    end
   end
 
   sub_test_case "reshape argument validation" do


### PR DESCRIPTION

`gemm` never checked the dtype of `b`. It passed `b`'s device pointer straight to `cublas<T>gemmStridedBatched` as its own `dtype`, so a wider `b` was reinterpreted and a narrower one was read past its end.

`dot` picks the cuBLAS path from `self.class::UPCAST[b.class]` but cast neither operand to it, so it fed `gemm` exactly those mismatched pairs.

* `Cumo::Int32#dot(Cumo::DFloat)` raised `NoMethodError: undefined method 'gemm'` — 36 of the 147 combinations of 49 dtype pairs and 3 shapes
* `Cumo::SFloat#dot(Cumo::DFloat)` returned `[[0.0, 12.25], [0.0, 30.25]]` instead of `[[22, 28], [49, 64]]`, with no error
* `Cumo::DFloat#gemm(Cumo::SFloat)` read 8 and 17 bytes past a 24-byte allocation (`compute-sanitizer`, memory pool disabled)

Fix:

* Cast both operands to the upcast type in `dot`
* Cast `b` to the receiver's type in `gemm`, mirroring how `c` is already handled

Verified on an RTX A4000 with CUDA 13.0. All 147 dot combinations now match numo-narray 0.11.2, `compute-sanitizer` reports 0 errors where it previously reported 5, and `rake test` is 1174 tests / 15507 assertions / 0 failures.

`Cumo::DFloat#dot(Cumo::Int32)` still returns `[18]` where numo returns `[32]`. That is the separate `mulsum` defect — it reduces the wrong axis when the reduced axis is not the last one and the last dimension is 1 — and reproduces with same-dtype operands, so it is left for its own fix and marked as an omission.