### PR TITLE
Fix mulsum's reduce kernel ignoring the accumulator and the operand strides

### DIFF
--- a/ext/cumo/include/cumo/cuda/cumo_thrust.hpp
+++ b/ext/cumo/include/cumo/cuda/cumo_thrust.hpp
@@ -53,7 +53,12 @@ class cumo_thrust_strided_range
 
     // construct strided_range for the range [first,last)
     cumo_thrust_strided_range(Iterator first, Iterator last, difference_type stride)
-        : first(first), last(last), stride(stride) {}
+        : first(first), stride(stride), count(((last - first) + (stride - 1)) / stride) {}
+
+    // A stride of 0 repeats one element and a negative stride walks backwards, so
+    // neither can be counted from (last - first); those callers pass the count.
+    cumo_thrust_strided_range(Iterator first, difference_type stride, difference_type count)
+        : first(first), stride(stride), count(count) {}
 
     iterator begin(void) const
     {
@@ -62,13 +67,13 @@ class cumo_thrust_strided_range
 
     iterator end(void) const
     {
-        return begin() + ((last - first) + (stride - 1)) / stride;
+        return begin() + count;
     }
 
     protected:
     Iterator first;
-    Iterator last;
     difference_type stride;
+    difference_type count;
 };
 
 

--- a/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
@@ -14,7 +14,7 @@
 template<typename Iterator1, typename Iterator2>
 __global__ void <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%>(Iterator1 p1_begin, Iterator1 p1_end, Iterator2 p2_begin, dtype* p3)
 {
-    dtype init = m_zero;
+    dtype init = *p3;
     *p3 = thrust::inner_product(thrust::cuda::par, p1_begin, p1_end, p2_begin, init, cumo_thrust_plus(), cumo_thrust_multiplies<%= "_mulsum#{nan}" unless nan.empty? %>());
 }
 
@@ -36,22 +36,19 @@ void <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel_launch"%>(char *p1, char *
 {
     ssize_t s1_idx = s1 / sizeof(dtype);
     ssize_t s2_idx = s2 / sizeof(dtype);
-    if (n == 1) { // when n == 1, s1 and s3 could be 0
-        s1_idx = 1;
-        s2_idx = 1;
-    }
     thrust::device_ptr<dtype> p1_begin = thrust::device_pointer_cast((dtype*)p1);
-    thrust::device_ptr<dtype> p1_end   = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
     thrust::device_ptr<dtype> p2_begin = thrust::device_pointer_cast((dtype*)p2);
-    thrust::device_ptr<dtype> p2_end   = thrust::device_pointer_cast(((dtype*)p2) + n * s2_idx);
-    if (s1_idx > 1 || s2_idx > 1) {
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> r1(p1_begin, p1_end, s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> r2(p2_begin, p2_end, s2_idx);
-        <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(r1.begin(), r1.end(), r2.begin(), (dtype*)p3);
+    // A broadcast operand has stride 0 and a reversed view a negative one, so
+    // anything but 1 has to go through the strided range.
+    if (s1_idx == 1 && s2_idx == 1) {
+        // ref. https://github.com/thrust/thrust/blob/master/examples/cuda/async_reduce.cu
+        <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(p1_begin, p1_begin + n, p2_begin, (dtype*)p3);
         cumo_cuda_runtime_check_kernel_launch();
     } else {
-        // ref. https://github.com/thrust/thrust/blob/master/examples/cuda/async_reduce.cu
-        <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(p1_begin, p1_end, p2_begin, (dtype*)p3);
+        typedef cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range_t;
+        range_t r1(p1_begin, (range_t::difference_type)s1_idx, (range_t::difference_type)n);
+        range_t r2(p2_begin, (range_t::difference_type)s2_idx, (range_t::difference_type)n);
+        <%="cumo_#{type_name}_mulsum#{nan}_reduce_kernel"%><<<1,1>>>(r1.begin(), r1.end(), r2.begin(), (dtype*)p3);
         cumo_cuda_runtime_check_kernel_launch();
     }
 }

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -585,10 +585,6 @@ class NArrayExtraTest < CumoTestBase
     a = Cumo::Int32[1, 2, 3]
     b = Cumo::DFloat[[4], [5], [6]]
     assert_equal(Cumo::DFloat[32], a.dot(b))
-  end
-
-  def test_dot_between_types_without_upcast
-    omit("Cumo's mulsum reduces the wrong axis when the reduced axis is not the last one and the last dimension is 1")
     assert_equal(Cumo::DFloat[32], Cumo::DFloat[1, 2, 3].dot(Cumo::Int32[[4], [5], [6]]))
   end
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -559,6 +559,42 @@ class NArrayTest < Test::Unit::TestCase
           assert { a.mulsum(b, nan: true) == (0 + 2 * 3 + 3 * 4) }
         end
       end
+
+      # The elementwise reference squares before it sums, so keep the values
+      # small enough that the 8-bit dtypes do not wrap.
+      small = ->(shape) { dtype.cast(Array.new(shape.reduce(:*)) { |i| i % 4 + 1 }).reshape(*shape) }
+
+      test "mulsum over every axis" do
+        [[3], [3, 1], [1, 3], [3, 2], [2, 3], [3, 1, 1], [2, 3, 1], [2, 1, 3], [2, 3, 4]].each do |shape|
+          a = small.call(shape)
+          (-shape.size...shape.size).each do |axis|
+            assert { a.mulsum(a, axis: axis) == (a * a).sum(axis: axis) }
+          end
+        end
+        # mulsum accumulates in its own dtype while sum widens, so compare the
+        # two only where the total still fits the narrowest dtype.
+        a = small.call([3, 1])
+        assert { a.mulsum(a) == (a * a).sum }
+      end
+
+      test "mulsum with a broadcast operand" do
+        [[3, 1], [3, 2], [2, 3], [2, 3, 1], [2, 3, 4]].each do |shape|
+          a = small.call(shape)
+          b = dtype.cast([2]).reshape(*shape.map { 1 })
+          (0...shape.size).each do |axis|
+            assert { a.mulsum(b, axis: axis) == (a * b).sum(axis: axis) }
+          end
+        end
+      end
+
+      test "mulsum over a reversed view" do
+        a = small.call([6])
+        assert { a.reverse(0).mulsum(a.reverse(0), axis: 0) == (a * a).sum(axis: 0) }
+        b = small.call([3, 2])
+        assert { b.reverse(0).mulsum(b.reverse(0), axis: 0) == (b * b).sum(axis: 0) }
+        c = a[(0..5).step(2)].reverse(0)
+        assert { c.mulsum(c, axis: 0) == (c * c).sum(axis: 0) }
+      end
     end
 
     sub_test_case "#{dtype}, #dot" do
@@ -586,6 +622,11 @@ class NArrayTest < Test::Unit::TestCase
         a = dtype[1..2]
         b = dtype[1..6].reshape(2, 3)
         assert { a.dot(b) == [9, 12, 15] }
+      end
+      test "vector.dot(matrix) of a single column" do
+        a = dtype[1..3]
+        b = dtype[4..6].reshape(3, 1)
+        assert { a.dot(b) == [32] }
       end
       test "matrix.dot(matrix)" do
         a = dtype[1..6].reshape(3, 2)


### PR DESCRIPTION

`mulsum` is the only reduction still on the chunked `CUMO_STRIDE_LOOP_NIP` path — `sum`, `prod`, `min` and `max` fold into a single `cumo_reduce` launch — and its reduce kernel and launcher both break the contract that the host loop next to them honours. `Cumo::RObject`, the one dtype that takes the host loop, is correct in every case below.

**The kernel discarded the accumulator.** It started from `m_zero` and assigned to `*p3`, where the host loop reads `*p3` and adds to it. When `ndloop` splits one output element across several calls, every chunk but the last is thrown away:

```
Cumo::DFloat.new(3, 1).seq(1).mulsum(self, axis: 0)   # [9.0], want [14.0]
Cumo::Int32[1, 2, 3].dot(Cumo::Int32[[4], [5], [6]])  # [18],  want [32]
```

A trace of the iterator shows why it needs the last dimension to be 1: the call arrives three times with `n=1`, `s3=0` and the same `p3`, so the reduce path runs three times over one output slot. With a last dimension of 2 the loop gets `s3=8` and takes the elementwise kernel, which accumulates in place and is correct.

**The launcher mis-read two strides.** It sent a stride to the strided range only when it was above 1, so:

* a broadcast operand (stride 0) was walked forward as if contiguous — `Cumo::DFloat.new(3,2).seq(1).mulsum(Cumo::DFloat[[2.0]], axis: 1)` gave `[2.0, 6.0, 10.0]` for `[6.0, 14.0, 22.0]`, reading 1 byte past an 8-byte allocation
* a reversed view (negative stride) produced an inverted range — `Cumo::DFloat.new(4).seq(1).reverse(0).mulsum(self, axis: 0)` gave `[0.0]`, the untouched init, for `[30.0]`

On the 8-bit dtypes the reversed case is not a wrong value but an illegal memory access, 3 runs out of 3: with the memory pool on it raises `Cumo::CUDA::RuntimeError: an illegal memory access was encountered (error=700)`, which is sticky and takes the rest of the process with it, and with the pool off the interpreter dumps core.

Fix:

* Seed the reduction from the current accumulator, matching the host loop
* Send every stride but 1 through the strided range
* Give `cumo_thrust_strided_range` a constructor taking the element count, because `(last - first)` carries no length when the stride is 0 or negative

Verified on an RTX A4000 with CUDA 13.0. 551 `mulsum` results over 5 dtypes, 15 shapes, every axis, broadcasts, views and the nan-aware form now match numo-narray 0.11.2 exactly; `compute-sanitizer` reports 0 errors where it reported 4; `rake test` is 1221 tests / 16216 assertions / 0 failures. The new tests fail on master with 15 failures and 30 errors.

This also removes the last `dot` divergence from numo, so the omission added in #208 is folded back into `test_dot_between_types`.

`Cumo::NArray#ptp` is broken in an unrelated way and is left alone: its kernel hardcodes `min=0, max=1` with the `minmax` call commented out behind a `TODO`, so it answers 1 for the first output element and 0 for the rest whatever the input.