### PR TITLE
Fix ptp answering 1 whatever the input

### DIFF
--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -33,14 +33,26 @@ struct cumo_<%=type_name%>_max_impl {
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 
-// TODO(sonots): Implement minmax
-__global__ void cumo_<%=type_name%>_ptp_kernel(cumo_na_reduction_arg_t arg)
-{
-    dtype min=0,max=1;
-    //<%=type_name%>_minmax_kernel<<<1,1>>>(n,p1,s1,&min,&max);
-    char* p2 = arg.out.ptr;
-    *(dtype*)p2 = m_sub(max,min);
-}
+struct cumo_<%=type_name%>_ptp_impl {
+    struct MinAndMax {
+        dtype min;
+        dtype max;
+    };
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
+    __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
+    __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
+        if (next.min < accum.min) { accum.min = next.min; }
+        if (accum.max < next.max) { accum.max = next.max; }
+    }
+    __device__ dtype MapOut(MinAndMax accum) {
+    <% if is_float %>
+        // A NaN loses both comparisons above, so every element being NaN leaves
+        // the identity untouched. An empty reduction raises before it gets here.
+        if (accum.max < accum.min) { return (dtype)nan(""); }
+    <% end %>
+        return m_sub(accum.max, accum.min);
+    }
+};
 
 #if defined(__cplusplus)
 extern "C" {
@@ -71,6 +83,5 @@ void cumo_<%=type_name%>_max_kernel_launch(cumo_na_reduction_arg_t* arg)
 
 void cumo_<%=type_name%>_ptp_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_<%=type_name%>_ptp_kernel<<<1,1>>>(*arg);
-    cumo_cuda_runtime_check_kernel_launch();
+    cumo_reduce<dtype, dtype, cumo_<%=type_name%>_ptp_impl>(*arg, cumo_<%=type_name%>_ptp_impl{});
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -544,6 +544,59 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
 
+    unless [Cumo::DComplex, Cumo::SComplex].include?(dtype)
+      sub_test_case "#{dtype}, #ptp" do
+        test "ptp" do
+          assert { dtype[3, 10, 1, 7].ptp == 9 }
+          assert { dtype[5].ptp == 0 }
+          a = dtype[1..6].reshape(2, 3)
+          assert { a.ptp == 5 }
+          assert { a.ptp(axis: 0) == [3, 3, 3] }
+          assert { a.ptp(axis: 1) == [2, 2] }
+          assert { a.ptp(axis: 0, keepdims: true) == [[3, 3, 3]] }
+        end
+
+        test "ptp over every axis" do
+          [[5], [3, 1], [1, 3], [3, 2], [2, 3], [2, 3, 1], [2, 1, 3], [2, 3, 4]].each do |shape|
+            a = dtype.cast(Array.new(shape.reduce(:*)) { |i| (i * 7 + 3) % 11 }).reshape(*shape)
+            (-shape.size...shape.size).each do |axis|
+              assert { a.ptp(axis: axis) == a.max(axis: axis) - a.min(axis: axis) }
+            end
+            assert { a.ptp == a.max - a.min }
+          end
+        end
+
+        # More than one block, so the shared-memory tree reduction runs.
+        test "ptp over a large reduction" do
+          a = dtype.cast(Array.new(5000) { |i| (i * 37) % 97 })
+          assert { a.ptp == a.max - a.min }
+          b = a.reshape(50, 100)
+          assert { b.ptp(axis: 0) == b.max(axis: 0) - b.min(axis: 0) }
+          assert { b.ptp(axis: 1) == b.max(axis: 1) - b.min(axis: 1) }
+        end
+
+        test "ptp over views" do
+          v = dtype.cast(Array.new(12) { |i| (i * 5 + 1) % 13 }).reshape(4, 3)
+          [v[1..2, 0..1], v.transpose, v.reverse(0), v[(0..3).step(2), true]].each do |w|
+            assert { w.ptp == w.max - w.min }
+            assert { w.ptp(axis: 0) == w.max(axis: 0) - w.min(axis: 0) }
+          end
+        end
+
+        if [Cumo::DFloat, Cumo::SFloat].include?(dtype)
+          test "ptp ignores nan, and ptp(nan: true) propagates it" do
+            nan = Float::NAN
+            assert { dtype[3, nan, 1, 7].ptp == 6 }
+            assert { dtype[nan, 3, 1, 7].ptp == 6 }
+            assert { dtype[3, 1, 7, nan].ptp == 6 }
+            assert { dtype[nan, nan].ptp.to_f.nan? }
+            assert { dtype[3, nan, 1, 7].ptp(nan: true).to_f.nan? }
+            assert { dtype[3, 10, 1, 7].ptp(nan: true) == 9 }
+          end
+        end
+      end
+    end
+
     sub_test_case "#{dtype}, #mulsum" do
       test "vector.mulsum(vector)" do
         a = dtype[1..3]


### PR DESCRIPTION

`cumo_<type>_ptp_kernel` never computed anything. It set `dtype min=0,max=1;` with the real `minmax` call commented out under a `// TODO(sonots): Implement minmax`, then wrote `m_sub(max,min)` — so it answered `1` for any input. It also launched `<<<1,1>>>`, so a single thread wrote only the first output element and the rest kept the initial value:

```
Cumo::DFloat[3, 10, 1, 7].ptp             # [1.0],           want 9.0
Cumo::DFloat.new(2, 3).seq(1).ptp(axis: 0) # [1.0, 0.0, 0.0], want [3.0, 3.0, 3.0]
```

`Cumo::RObject#ptp` is correct, because it is the one dtype that takes the host loop; and `ptp(nan: true)` was correct too, because the nan-aware form has no kernel and falls back to `f_ptp_nan`. `ptp` has no tests, which is how a method that never worked went unnoticed.

Fix:

* Compute `ptp` with `cumo_reduce` over a min/max pair accumulator. `reduction_kernel` takes the accumulator type from `decltype(impl.Identity(0))`, so a struct works — `accum_index` already uses the same shape for its value/index pairs.
* A NaN loses both comparisons, so it is skipped, matching what `f_minmax` does on the host and what numo answers: `DFloat[3, NaN, 1, 7].ptp` is `6.0`. When every element is NaN nothing merges into the identity, which would otherwise surface as `DATA_MIN - DATA_MAX`; that case answers NaN, as numo does. An empty reduction raises `ShapeError` before reaching the kernel, so it cannot reach that branch.

Verified on an RTX A4000 with CUDA 13.0. 621 `ptp` results over 10 dtypes, 9 shapes, every axis, `keepdims`, reductions larger than one block, sliced/transposed/reversed/strided views, NaN and infinity now match numo-narray 0.11.2 exactly — 619 of them differed before. `compute-sanitizer` reports 0 errors, and `rake test` is 1263 tests / 16838 assertions / 0 failures. The 42 new tests all fail on master.

Unrelated and left alone: the `min` and `max` kernels disagree with numo on two NaN corners — `DFloat[3, 1, 7, NaN].max` is `NaN` where numo gives `7.0`, and `DFloat[NaN, NaN].min` returns `DBL_MAX` where numo gives `NaN`.