### PR TITLE
Fix reshape! and marshal_load mutating before they validate

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -405,6 +405,10 @@ cumo_na_check_reshape(int argc, VALUE *argv, VALUE self, size_t *shape)
     else if (total !=  CUMO_NA_SIZE(na)) {
         rb_raise(rb_eArgError, "Total size must be same");
     }
+
+    if (argc > CUMO_NA_MAX_DIMENSION) {
+        rb_raise(cumo_na_eDimensionError, "ndim=%d is too many", argc);
+    }
 }
 
 /*
@@ -425,11 +429,15 @@ cumo_na_reshape_bang(int argc, VALUE *argv, VALUE self)
     ssize_t stride;
     cumo_stridx_t *stridx;
     int i;
+    VALUE tmp;
 
+    if (OBJ_FROZEN(self)) {
+        rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+    }
     if (cumo_na_check_contiguous(self)==Qfalse) {
         rb_raise(rb_eStandardError, "cannot change shape of non-contiguous NArray");
     }
-    shape = ALLOCA_N(size_t, argc);
+    shape = RB_ALLOCV_N(size_t, tmp, argc);
     cumo_na_check_reshape(argc, argv, self, shape);
 
     CumoGetNArray(self, na);
@@ -455,6 +463,7 @@ cumo_na_reshape_bang(int argc, VALUE *argv, VALUE self)
         }
     }
     cumo_na_setup_shape(na, argc, shape);
+    RB_ALLOCV_END(tmp);
     return self;
 }
 
@@ -472,14 +481,15 @@ cumo_na_reshape(int argc, VALUE *argv, VALUE self)
 {
     size_t *shape;
     cumo_narray_t *na;
-    VALUE    copy;
+    VALUE    copy, tmp;
 
-    shape = ALLOCA_N(size_t, argc);
+    shape = RB_ALLOCV_N(size_t, tmp, argc);
     cumo_na_check_reshape(argc, argv, self, shape);
 
     copy = rb_funcall(self, rb_intern("dup"), 0);
     CumoGetNArray(copy, na);
     cumo_na_setup_shape(na, argc, shape);
+    RB_ALLOCV_END(tmp);
     return copy;
 }
 

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -253,9 +253,22 @@ cumo_na_array_to_internal_shape(VALUE self, VALUE ary, size_t *shape)
 
 
 
+static void
+cumo_na_check_ndim(int ndim)
+{
+    if (ndim < 0) {
+        rb_raise(cumo_na_eDimensionError,"ndim=%d is negative", ndim);
+    }
+    if (ndim > CUMO_NA_MAX_DIMENSION) {
+        rb_raise(cumo_na_eDimensionError,"ndim=%d is too many", ndim);
+    }
+}
+
 void
 cumo_na_alloc_shape(cumo_narray_t *na, int ndim)
 {
+    cumo_na_check_ndim(ndim);
+
     na->ndim = ndim;
     na->size = 0;
     if (na->shape != NULL && na->shape != &(na->size)) {
@@ -268,12 +281,6 @@ cumo_na_alloc_shape(cumo_narray_t *na, int ndim)
         na->shape = &(na->size);
         break;
     default:
-        if (ndim < 0) {
-            rb_raise(cumo_na_eDimensionError,"ndim=%d is negative", ndim);
-        }
-        if (ndim > CUMO_NA_MAX_DIMENSION) {
-            rb_raise(cumo_na_eDimensionError,"ndim=%d is too many", ndim);
-        }
         na->shape = ALLOC_N(size_t, ndim);
     }
 }
@@ -284,24 +291,23 @@ cumo_na_setup_shape(cumo_narray_t *na, int ndim, size_t *shape)
     int i;
     size_t size;
 
+    cumo_na_check_ndim(ndim);
+
+    for (i=0, size=1; i<ndim; i++) {
+        if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
+            rb_raise(rb_eRangeError, "total number of elements is too large");
+        }
+        size *= shape[i];
+    }
+
     cumo_na_alloc_shape(na, ndim);
 
-    if (ndim==0) {
-        na->size = 1;
-    }
-    else if (ndim==1) {
-        na->size = shape[0];
-    }
-    else {
-        for (i=0, size=1; i<ndim; i++) {
+    if (ndim > 1) {
+        for (i=0; i<ndim; i++) {
             na->shape[i] = shape[i];
-            if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
-                rb_raise(rb_eRangeError, "total number of elements is too large");
-            }
-            size *= shape[i];
         }
-        na->size = size;
     }
+    na->size = (ndim==0) ? 1 : size;
 }
 
 static void
@@ -1560,6 +1566,9 @@ cumo_na_marshal_load(VALUE self, VALUE a)
 {
     VALUE v;
 
+    if (OBJ_FROZEN(self)) {
+        rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+    }
     if (TYPE(a) != T_ARRAY) {
         rb_raise(rb_eArgError,"marshal argument should be array");
     }

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -26,6 +26,8 @@ class NArrayAltCoverageTest < CumoTestBase
     Cumo::UInt8,
   ]
 
+  CUMO_NA_MAX_DIMENSION = 12
+
   def test_each
     TYPES.each do |dtype|
       a = dtype[1, 2, 3, 5, 7, 11]
@@ -830,5 +832,56 @@ class NArrayAltCoverageTest < CumoTestBase
     assert_equal(bits.join, a.to_binary.unpack1("b*"))
     assert_equal(bits[8, 8], a[8..15].to_a)
     assert_raise(Cumo::NArray::CastError) { a[8..15].to_binary }
+  end
+
+  def test_reshape_bang_leaves_the_array_untouched_when_it_raises
+    ones = [1] * (CUMO_NA_MAX_DIMENSION + 1)
+    a = Cumo::DFloat.new(1).seq
+
+    assert_raise(Cumo::NArray::DimensionError) { a.reshape!(*ones) }
+    assert_equal([1], a.shape)
+    assert_equal([0.0], a.to_a)
+  end
+
+  def test_reshape_bang_leaves_a_view_untouched_when_it_raises
+    ones = [1] * (CUMO_NA_MAX_DIMENSION - 1)
+    v = Cumo::DFloat.new(6).seq[0..5]
+
+    assert_raise(Cumo::NArray::DimensionError) { v.reshape!(2, 3, *ones) }
+    assert_equal([6], v.shape)
+    assert_equal([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], v.to_a)
+  end
+
+  def test_marshal_load_leaves_the_array_untouched_on_an_overflowing_shape
+    a = Cumo::DFloat.new(2).seq
+
+    assert_raise(RangeError) { a.marshal_load([1, [2**40, 2**40, 8], 0, ""]) }
+    assert_equal([2], a.shape)
+    assert_equal([0.0, 1.0], a.to_a)
+  end
+
+  def test_marshal_load_rejects_a_frozen_narray
+    a = Cumo::DFloat.new(2).seq.freeze
+    payload = Cumo::DFloat.new(4, 5).seq.marshal_dump
+
+    assert_raise(RuntimeError) { a.marshal_load(payload) }
+    assert_equal([2], a.shape)
+    assert_equal([0.0, 1.0], a.to_a)
+  end
+
+  def test_reshape_bang_rejects_a_frozen_narray
+    a = Cumo::DFloat.new(2, 3).seq.freeze
+
+    assert_raise(RuntimeError) { a.reshape!(6) }
+    assert_equal([2, 3], a.shape)
+  end
+
+  def test_reshape_keeps_the_shape_buffer_off_the_machine_stack
+    ones = [1] * 1000
+    a = Cumo::DFloat.new(1).seq
+
+    assert_raise(Cumo::NArray::DimensionError) { a.reshape(*ones) }
+    assert_raise(Cumo::NArray::DimensionError) { a.reshape!(*ones) }
+    assert_equal([1], a.shape)
   end
 end


### PR DESCRIPTION
Backport of [numo-narray-alt#26](https://github.com/yoshoku/numo-narray-alt/pull/26) (`5948c8e`).

Five places changed the receiver before deciding the change was legal, so a raise left a live object whose `ndim`, `shape` or `stridx` disagreed with its allocation. Reading it afterwards is an out-of-bounds read, not just a wrong value. All five reproduce on master (`5ecf78c`); `CUMO_NA_MAX_DIMENSION` is 12, so 13 dimensions is enough.

| | master |
|---|---|
| `a = Cumo::DFloat.new(1).seq; a.reshape!(*([1]*13)) rescue nil; a.shape` | `[0, 94486375023464, 1, 139964931112960, ...]` — 13 heap words |
| `v = Cumo::DFloat.new(6).seq[0..5]; v.reshape!(2,3,*([1]*11)) rescue nil; v.to_a` | `[[[[[[[[[[[[[]]]]]]]]]]]]]` |
| `b = Cumo::DFloat.new(2).seq; b.marshal_load([1,[2**40,2**40,8],0,'']) rescue nil; b.shape` | `[1099511627776, 1099511627776, 0]` |
| `Cumo::DFloat.new(2).seq.freeze.marshal_load(Cumo::DFloat.new(4,5).seq.marshal_dump)` | leaves `shape` `[4, 5]` over 16 bytes |
| `Cumo::DFloat.new(2,3).seq.freeze.reshape!(6)` | succeeds |

## Summary of Changes

- Validate `ndim` in a new `cumo_na_check_ndim` before `cumo_na_alloc_shape` assigns it. A 1-D array keeps `shape` pointing at `&na->size`, so `#shape` then read `ndim` words past the `cumo_narray_t`.
- Compute the element count in `cumo_na_setup_shape` before it commits anything, so the `RangeError` leaves the array alone.
- Reject too many `reshape!` dimensions at the **end** of `cumo_na_check_reshape`, before the strides are rewritten. Placing it earlier would change which exception several existing inputs raise.
- Raise on a frozen receiver in `cumo_na_reshape_bang` and `cumo_na_marshal_load`, the same class and message every other writer in `narray.c` uses.
- Swap `ALLOCA_N` for `RB_ALLOCV_N` in both reshape entry points, keeping the alloca for ordinary calls and moving large ones to the heap. `argc` is caller-controlled through a splat.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

`rake test` is 1269 tests / 16855 assertions / 0 failures, up from 1263 / 16838. Six tests added to `test/narray_alt_coverage_test.rb`, one per defect plus the heap-buffer path.

Positive control: revert `ext/` alone to `5ecf78c` with the new tests in place and all six fail — the first one printing the 13 heap words above.

Error classes, messages and precedence are unchanged. Sixteen `reshape`/`reshape!` paths (no args, wrong total, negative size, unfixed-with-zero-total, non-divisor, multiple unfixed, illegal type, overflowing product, empty array, non-contiguous, and the successful forms) were diffed before and after and against `numo-narray-alt`; the only differences are the two frozen cases, which are the point of the change.

Two notes for anyone comparing against upstream:

- Upstream derives `NA_MAX_DIMENSION` in its tests as `[0].pack('J').bytesize * 8 - 2`, because `Integer#size` is `sizeof(long)` and breaks under Windows LLP64. `CUMO_NA_MAX_DIMENSION` is a hardcoded 12 and does not depend on `sizeof(VALUE)`, so the test uses that value directly.
- Upstream's PR body demonstrates the `ALLOCA_N` case with a 200,000-argument splat. That does not reach `reshape!` on either project — the splat exhausts the VM stack first (`SystemStackError`). The test uses 1,000 arguments, which still exceeds `RUBY_ALLOCV_LIMIT / sizeof(size_t)` = 128 and so exercises the heap path.
