### PR TITLE
Fix integer division by zero returning garbage instead of raising

### DIFF
--- a/ext/cumo/cuda/runtime.c
+++ b/ext/cumo/cuda/runtime.c
@@ -19,6 +19,26 @@ cumo_cuda_runtime_check_kernel_launch(void)
     check_status(cudaGetLastError());
 }
 
+int*
+cumo_cuda_runtime_divzero_flag_new(void)
+{
+    static int *flag = NULL;
+
+    if (flag == NULL) {
+        check_status(cudaHostAlloc((void**)&flag, sizeof(int),
+                                   cudaHostAllocMapped | cudaHostAllocPortable));
+    }
+    *flag = 0;
+    return flag;
+}
+
+bool
+cumo_cuda_runtime_divzero_flag_get(int *flag)
+{
+    check_status(cudaDeviceSynchronize());
+    return (*flag != 0);
+}
+
 ///////////////////////////////////////////
 // Version Management
 ///////////////////////////////////////////

--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -51,6 +51,14 @@ cumo_cuda_runtime_is_device_memory(void* ptr)
     return (attrs.type != cudaMemoryTypeUnregistered);
 }
 
+// A kernel cannot raise, so an integer division reports a zero divisor through
+// this flag and the caller turns it into the exception ndloop expects. The
+// buffer is pinned host memory the device writes through, not pool memory: a
+// four-byte pool allocation lands in the same bin as a small output array, and
+// the managed page then migrates back and forth once per operation.
+int* cumo_cuda_runtime_divzero_flag_new(void);
+bool cumo_cuda_runtime_divzero_flag_get(int *flag);
+
 #if defined(__cplusplus)
 #if 0
 { /* satisfy cc-mode */

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -1,6 +1,3 @@
-// TODO(sonots): handle zero division error in CUDA kernel?
-// ref. https://devtalk.nvidia.com/default/topic/415951/divide-by-zero-handling/
-
 //<% if is_int and %w[div mod divmod].include? name %>
 #define check_intdivzero(y)              \
     if ((y)==0) {                        \
@@ -12,7 +9,7 @@
 //<% end %>
 
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
 <% end %>
 
 static void
@@ -117,7 +114,16 @@ static void
         cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
         cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+        //<% if is_int and %w[div mod].include? name %>
+        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer,divzero);
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+            lp->err_type = rb_eZeroDivError;
+        }
+        //<% else %>
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer,0);
+        //<% end %>
     }
     <% end %>
 }

--- a/ext/cumo/narray/gen/tmpl/binary2.c
+++ b/ext/cumo/narray/gen/tmpl/binary2.c
@@ -1,11 +1,11 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n);
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t   i, n;
+    size_t   n;
     char    *p1, *p2, *p3, *p4;
     ssize_t  s1, s2, s3, s4;
     CUMO_INIT_COUNTER(lp, n);
@@ -13,27 +13,39 @@ static void
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
     CUMO_INIT_PTR(lp, 3, p4, s4);
-    for (i=n; i--;) {
-        <% if type_name == 'robject' %>
-        {
+    <% if type_name == 'robject' %>
+    {
+        size_t i;
+        for (i=n; i--;) {
             dtype    x, y, a, b;
             CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             CUMO_GET_DATA_STRIDE(p2,s2,dtype,y);
 <% if is_int and %w[divmod].include? name %>
-                if (y==0) {
-                    lp->err_type = rb_eZeroDivError;
-                    return;
-                }
+            if (y==0) {
+                lp->err_type = rb_eZeroDivError;
+                return;
+            }
 <% end %>
             m_<%=name%>(x,y,a,b);
             CUMO_SET_DATA_STRIDE(p3,s3,dtype,a);
             CUMO_SET_DATA_STRIDE(p4,s4,dtype,b);
         }
-        <% else %>
-        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n);
-        <% end %>
     }
+    <% else %>
+    {
+        //<% if is_int and %w[divmod].include? name %>
+        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,divzero);
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+            lp->err_type = rb_eZeroDivError;
+        }
+        //<% else %>
+        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,0);
+        //<% end %>
+    }
+    <% end %>
 }
 
 static VALUE

--- a/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
@@ -1,16 +1,29 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n)
+
+//<% if is_int and %w[divmod].include? name %>
+#define cumo_check_intdivzero(y) \
+    if ((y)==0) {                \
+        *divzero = 1;            \
+        continue;                \
+    }
+//<% else %>
+#define cumo_check_intdivzero(y) {}
+//<% end %>
+
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(*(dtype*)(p2+(i*s2)));
         m_<%=name%>(*(dtype*)(p1+(i*s1)),*(dtype*)(p2+(i*s2)),*(dtype*)(p3+(i*s3)), *(dtype*)(p4+(i*s4)));
     }
 }
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n)
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
+#undef cumo_check_intdivzero
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -1,32 +1,44 @@
 <% unless type_name == 'robject' %>
 
+//<% if is_int and %w[div mod].include? name %>
+#define cumo_check_intdivzero(y) \
+    if ((y)==0) {                \
+        *divzero = 1;            \
+        continue;                \
+    }
+//<% else %>
+#define cumo_check_intdivzero(y) {}
+//<% end %>
+
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        cumo_check_intdivzero(*(dtype*)(p2));
         *(dtype*)(p3) = m_<%=name%>(*(dtype*)(p1),*(dtype*)(p2));
     }
 }
 <% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,divzero);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,divzero);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
 }
+#undef cumo_check_intdivzero
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/unary.c
+++ b/ext/cumo/narray/gen/tmpl/unary.c
@@ -1,10 +1,45 @@
 <% if type_name == 'robject' || name == 'map' %>
 <% else %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n);
+void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero);
+void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero);
+void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero);
+void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* divzero);
+
+static void
+<%=c_iter%>_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, size_t n, int* divzero)
+{
+    if (idx1) {
+        if (idx2) {
+            <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,n,divzero);
+        } else {
+            <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,n,divzero);
+        }
+    } else {
+        if (idx2) {
+            <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,n,divzero);
+        } else {
+            //<% if need_align %>
+            if (cumo_is_aligned(p1,sizeof(dtype)) &&
+                cumo_is_aligned(p2,sizeof(dtype)) ) {
+                if (s1 == sizeof(dtype) &&
+                    s2 == sizeof(dtype) ) {
+                    <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(p1,p2,n,divzero);
+                    return;
+                }
+                if (cumo_is_aligned_step(s1,sizeof(dtype)) &&
+                    cumo_is_aligned_step(s2,sizeof(dtype)) ) {
+                    //<% end %>
+                    <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,divzero);
+                    return;
+                    //<% if need_align %>
+                }
+            }
+            <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,divzero);
+            //<% end %>
+        }
+    }
+}
 <% end %>
 
 static void
@@ -79,36 +114,16 @@ static void
     }
     <% else %>
     {
-        if (idx1) {
-            if (idx2) {
-                <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,n);
-            } else {
-                <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,n);
-            }
-        } else {
-            if (idx2) {
-                <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,n);
-            } else {
-                //<% if need_align %>
-                if (cumo_is_aligned(p1,sizeof(dtype)) &&
-                    cumo_is_aligned(p2,sizeof(dtype)) ) {
-                    if (s1 == sizeof(dtype) &&
-                        s2 == sizeof(dtype) ) {
-                        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(p1,p2,n);
-                        return;
-                    }
-                    if (cumo_is_aligned_step(s1,sizeof(dtype)) &&
-                        cumo_is_aligned_step(s2,sizeof(dtype)) ) {
-                        //<% end %>
-                        <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n);
-                        return;
-                        //<% if need_align %>
-                    }
-                }
-                <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n);
-                //<% end %>
-            }
+        //<% if is_int and name == 'reciprocal' %>
+        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,divzero);
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+            lp->err_type = rb_eZeroDivError;
         }
+        //<% else %>
+        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,0);
+        //<% end %>
     }
     <% end %>
 }

--- a/ext/cumo/narray/gen/tmpl/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_kernel.cu
@@ -1,77 +1,94 @@
 <% if type_name == 'robject' || name == 'map' %>
 <% else %>
-__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
+
+//<% if is_int and name == 'reciprocal' %>
+#define cumo_check_intdivzero(x) \
+    if ((x)==0) {                \
+        *divzero = 1;            \
+        continue;                \
+    }
+//<% else %>
+#define cumo_check_intdivzero(x) {}
+//<% end %>
+
+__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(*(dtype*)(p1 + idx1[i]));
         *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
+__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(*(dtype*)(p1 + idx1[i]));
         *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
+__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(*(dtype*)(p1 + (i * s1)));
         *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
+__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(*(dtype*)(p1 + (i * s1)));
         *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(char *p1, char *p2, uint64_t n)
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(char *p1, char *p2, uint64_t n, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        cumo_check_intdivzero(((dtype*)p1)[i]);
         ((dtype*)p2)[i] = m_<%=name%>(((dtype*)p1)[i]);
     }
 }
 
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
+void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
+    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
+void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
+    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
+void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
+    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
+void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
+    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n)
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(p1,p2,n);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(p1,p2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
+#undef cumo_check_intdivzero
 <% end %>

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -768,10 +768,37 @@ class NArrayAltCoverageTest < CumoTestBase
     end
   end
   def test_integer_division_by_zero
-    omit("Cumo's integer division has no zero check: the guard in binary.c is in the robject branch, and the kernel has none")
-    INTEGER_TYPES.each do |dtype|
+    (INTEGER_TYPES + UNSIGNED_INTEGER_TYPES).each do |dtype|
       assert_raise(ZeroDivisionError) { dtype[1, 0].reciprocal }
       assert_raise(ZeroDivisionError) { dtype[1] / dtype[0] }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3] / dtype[1, 0, 3] }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3] / 0 }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3] % dtype[1, 0, 3] }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3].divmod(dtype[1, 0, 3]) }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3].inplace / dtype[1, 0, 3] }
+    end
+  end
+
+  def test_integer_division_by_zero_through_a_view
+    (INTEGER_TYPES + UNSIGNED_INTEGER_TYPES).each do |dtype|
+      divisor = dtype[1, 9, 0, 9, 3, 9][(0..5).step(2)]
+
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3] / divisor }
+      assert_raise(ZeroDivisionError) { dtype[1, 2, 3] % divisor }
+      assert_raise(ZeroDivisionError) { dtype[1, 0, 3][[0, 1, 2]].reciprocal }
+    end
+  end
+
+  def test_integer_division_without_a_zero_divisor
+    (INTEGER_TYPES + UNSIGNED_INTEGER_TYPES).each do |dtype|
+      a = dtype[10, 20, 30]
+      b = dtype[3, 4, 5]
+
+      assert_equal([3, 5, 6], (a / b).to_a)
+      assert_equal([1, 0, 0], (a % b).to_a)
+      assert_equal([[3, 5, 6], [1, 0, 0]], a.divmod(b).map(&:to_a))
+      assert_equal([1, 0, 0], dtype[1, 2, 3].reciprocal.to_a)
+      assert_equal([3, 6, 10], (a / dtype[3, 3, 3]).to_a)
     end
   end
 


### PR DESCRIPTION
`check_intdivzero` in `gen/tmpl/binary.c` only ever ran in the `robject` branch. Every other dtype divides on the GPU, where integer division by zero does not trap, so the hardware's answer was written to the result and returned. Numo raises `ZeroDivisionError` for all eight integer dtypes.

| | master | numo |
|---|---|---|
| `Cumo::Int32[1] / Cumo::Int32[0]` | `4294967295` | `ZeroDivisionError` |
| `Cumo::Int8[1] / Cumo::Int8[0]` | `-1` | `ZeroDivisionError` |
| `Cumo::UInt8[1] / Cumo::UInt8[0]` | `255` | `ZeroDivisionError` |
| `Cumo::Int32[1, 0].reciprocal` | `[1, 0]` | `ZeroDivisionError` |
| `Cumo::Int32[1, 2, 3] % Cumo::Int32[1, 0, 3]` | `[0, 4294967295, 0]` | `ZeroDivisionError` |
| `Cumo::Int32[1, 2, 3].divmod(Cumo::Int32[1, 0, 3])` | `[[1, 4294967295, 1], [0, 4294967295, 0]]` | `ZeroDivisionError` |

`Cumo::RObject` was already correct, because it is the one dtype that takes the host loop.

## Summary of Changes

- Check the divisor in the `div`, `mod`, `divmod` and `reciprocal` kernels and report it through a flag. The iterator turns the flag into `lp->err_type`, so the exception is the `ZeroDivisionError` `ndloop` already raises for `robject` — same class, same message.
- Keep the flag in pinned host memory allocated once, not in pool memory. A four-byte pool allocation shares a size bin with a small output array, and the managed page then migrates host-ward and back once per operation: dividing 100 `Int32` elements cost **851us** that way and **9us** this way.
- Launch the `divmod` kernel once instead of once per element. `binary2.c` had the launch inside `for (i=n; i--;)`, so every element launched a kernel over the whole array. 20000 elements took **34.66ms**, and now take **1.24ms**.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

`rake test` is 1271 tests / 16975 assertions / 0 failures, up from 1269 / 16855. `test_integer_division_by_zero` was omitted with "Cumo's integer division has no zero check"; it is now un-omitted and extended, and two more tests were added. The suite has one omission fewer.

Every one of the 9 integer-and-object dtypes was compared against `numo-narray-alt` across `a/b`, `a/0`, `a%b`, `divmod`, `reciprocal` and `inplace /` — 54 combinations, all identical after the change. A separate 61-line comparison of ordinary division, modulo, `divmod` and `reciprocal` values (including strided views and scalar divisors, for 11 dtypes) is also identical, so the guard changes nothing when no divisor is zero.

Positive control: revert `ext/` alone to `9077334` and the two zero-divisor tests fail with "exception was expected but none was thrown", while the value test still passes. `compute-sanitizer --tool memcheck` with the memory pool disabled reports 0 errors.

## Performance

Integer division now synchronizes once to read the flag. Measured on an RTX A4000:

| elements | `Int32 /` before | `Int32 /` after | `DFloat /` after |
|---|---|---|---|
| 100 | 5.4us | 9.3us | 3.9us |
| 10,000 | 5.4us | 11.9us | 7.9us |
| 1,000,000 | 339us | 224us | 540us |
| 20,000,000 | 6.0ms | 11.1ms | 31.0ms |

The cost is about 5us per operation and only shows on small arrays; at a million elements the kernel already dominates. Float dtypes, and every operation other than integer `div`, `mod`, `divmod` and `reciprocal`, are untouched — their kernels take the flag parameter but the check compiles away to `{}`.
