### PR TITLE
Fix nan poisoning max and an all-nan min answering DBL_MAX

### DIFF
--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -20,16 +20,31 @@ struct cumo_<%=type_name%>_prod_impl {
 };
 
 struct cumo_<%=type_name%>_min_impl {
+<% if is_float %>
+    // A NaN loses the comparison, so it is skipped unless the accumulator is
+    // still the identity: the reduction then answers NaN only when every
+    // element was NaN, and equal elements keep the earlier one as numo does.
+    __device__ dtype Identity(int64_t /*index*/) { return (dtype)nan(""); }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { if (next < accum || !not_nan(accum)) { accum = next; } }
+<% else %>
     __device__ dtype Identity(int64_t /*index*/) { return DATA_MAX; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { accum = next < accum ? next : accum; }
+<% end %>
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_max_impl {
+<% if is_float %>
+    __device__ dtype Identity(int64_t /*index*/) { return (dtype)nan(""); }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { if (accum < next || !not_nan(accum)) { accum = next; } }
+<% else %>
     __device__ dtype Identity(int64_t /*index*/) { return DATA_MIN; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { accum = next < accum ? accum : next; }
+<% end %>
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -597,6 +597,68 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
 
+    if [Cumo::DFloat, Cumo::SFloat].include?(dtype)
+      sub_test_case "#{dtype}, #max/#min corner cases" do
+        nan = Float::NAN
+
+        test "max and min ignore nan wherever it sits" do
+          assert { dtype[nan, 3, 1, 7].max == 7 }
+          assert { dtype[3, nan, 1, 7].max == 7 }
+          assert { dtype[3, 1, 7, nan].max == 7 }
+          assert { dtype[nan, 3, 1, 7].min == 1 }
+          assert { dtype[3, nan, 1, 7].min == 1 }
+          assert { dtype[3, 1, 7, nan].min == 1 }
+          assert { dtype[-Float::INFINITY, nan].max == -Float::INFINITY }
+          assert { dtype[Float::INFINITY, nan].min == Float::INFINITY }
+        end
+
+        test "max and min answer nan only when every element is nan" do
+          assert { dtype[nan].max.to_f.nan? }
+          assert { dtype[nan].min.to_f.nan? }
+          assert { dtype[nan, nan].max.to_f.nan? }
+          assert { dtype[nan, nan].min.to_f.nan? }
+
+          a = dtype[[1, nan], [nan, nan]]
+          assert { a.max(axis: 1).to_a[0] == 1 }
+          assert { a.max(axis: 1).to_a[1].nan? }
+          assert { a.min(axis: 1).to_a[0] == 1 }
+          assert { a.min(axis: 1).to_a[1].nan? }
+        end
+
+        # More than one block, so the shared-memory tree reduction runs.
+        test "max and min over a large reduction" do
+          a = dtype.cast(Array.new(5000) { |i| (i * 37) % 97 })
+          a[2500] = nan
+          assert { a.max == 96 }
+          assert { a.min == 0 }
+          assert { dtype.new(5000).fill(nan).max.to_f.nan? }
+          assert { dtype.new(5000).fill(nan).min.to_f.nan? }
+        end
+
+        test "max and min over views" do
+          a = dtype[9, 3, 1, 7, nan]
+          assert { a[1..4].max == 7 }
+          assert { a[1..4].min == 1 }
+          assert { dtype[9, nan, nan][1..2].max.to_f.nan? }
+          assert { dtype[9, nan, nan][1..2].min.to_f.nan? }
+        end
+
+        test "max(nan: true) and min(nan: true) propagate nan" do
+          assert { dtype[3, nan, 1, 7].max(nan: true).to_f.nan? }
+          assert { dtype[3, nan, 1, 7].min(nan: true).to_f.nan? }
+          assert { dtype[3, 10, 1, 7].max(nan: true) == 10 }
+          assert { dtype[3, 10, 1, 7].min(nan: true) == 1 }
+        end
+
+        test "max and min keep the earlier of two equal elements" do
+          assert { 1.0 / dtype[0.0, -0.0].min.to_f == Float::INFINITY }
+          assert { 1.0 / dtype[0.0, -0.0].max.to_f == Float::INFINITY }
+          assert { 1.0 / dtype[-0.0, 0.0].min.to_f == -Float::INFINITY }
+          assert { 1.0 / dtype[-0.0, 0.0].max.to_f == -Float::INFINITY }
+        end
+      end
+    end
+
     sub_test_case "#{dtype}, #mulsum" do
       test "vector.mulsum(vector)" do
         a = dtype[1..3]


### PR DESCRIPTION
`min` and `max` reduce on the GPU through `cumo_reduce`, and their reduction impls handled NaN differently from the host loop numo runs.

`max` combined with `accum = next < accum ? accum : next`. A NaN loses that comparison, so it was taken over the accumulator and poisoned the result:

```ruby
Cumo::DFloat[3, 1, 7, Float::NAN].max  #=> NaN   (numo: 7.0)
Cumo::DFloat[-Float::INFINITY, Float::NAN].max  #=> NaN   (numo: -Infinity)
```

Whether it poisoned depended on the order threads happened to visit the elements — a NaN in the middle of a large array was overwritten by a later element, so `Cumo::DFloat[Float::NAN, 3, 1, 7].max` already answered 7.0.

`min` combined with `accum = next < accum ? next : accum`, which skips NaN correctly, but the identity `DATA_MAX` then survived when every element was NaN:

```ruby
Cumo::DFloat[Float::NAN, Float::NAN].min  #=> 1.7976931348623157e+308   (numo: NaN)
Cumo::SFloat[Float::NAN, Float::NAN].min  #=> 3.4028234663852886e+38    (numo: NaN)
```

Both now take NaN as the reduction identity and replace it on the first element that is not NaN, which is what numo's `f_min`/`f_max` do. `min(nan: true)`/`max(nan: true)` were already correct because they run on the host. Integer types keep `DATA_MIN`/`DATA_MAX` and are untouched.

51 min/max combinations over `DFloat`, `SFloat` and the integer types — NaN first, in the middle, last, all-NaN, `±Infinity`, axis reductions, views, `keepdims`, and reductions large enough to run the shared-memory tree — now answer exactly what numo-narray-alt 0.11.2 answers. `compute-sanitizer --tool memcheck` reports 0 errors.

## Cost

The reduce step gains one comparison per element on float `min`/`max`, measured on an RTX A4000 (best of 5, `DFloat.new(1_000_000).seq`):

| | before | after |
|---|---|---|
| `DFloat` 1e6 `max` | 775 us | 923 us |
| `DFloat` 1e6 `min` | 785 us | 929 us |
| `SFloat` 1e6 `min`/`max` | 727 us | 726 us |
| `Int32` 1e6 `min`/`max` | 744 us | 737 us |
| `DFloat` 1000x1000 `max(axis: 1)` | 787 us | 787 us |

The cost lands only on `DFloat`, where the added compare runs on the FP64 pipe at 1/64 rate on this card. `fmin`/`fmax` would have halved it, but IEEE `fmin(0.0, -0.0)` answers `-0.0` while numo answers the element it met first, so keeping the explicit comparison keeps the sign of a zero result matching numo too.
