### PR TITLE
Fix minmax ignoring compatible mode and returning zero-dimensional NArrays

### DIFF
--- a/ext/cumo/narray/gen/tmpl/minmax.c
+++ b/ext/cumo/narray/gen/tmpl/minmax.c
@@ -34,7 +34,7 @@ static void
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
 {
-    VALUE reduce;
+    VALUE reduce, ret;
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cumo_sym_reduce,0}};
     cumo_ndfunc_arg_out_t aout[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_EXTRACT, 2,2, ain,aout};
@@ -44,5 +44,11 @@ static VALUE
   <% else %>
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
   <% end %>
-    return cumo_na_ndloop(&ndf, 2, self, reduce);
+    ret = cumo_na_ndloop(&ndf, 2, self, reduce);
+    // ndloop ignores CUMO_NDF_EXTRACT, so each method carrying it extracts for itself.
+    if (cumo_compatible_mode_enabled_p()) {
+        return rb_assoc_new(rb_funcall(RARRAY_AREF(ret,0), rb_intern("extract_cpu"), 0),
+                            rb_funcall(RARRAY_AREF(ret,1), rb_intern("extract_cpu"), 0));
+    }
+    return ret;
 }

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -21,6 +21,41 @@ class CumoTest < Test::Unit::TestCase
     assert { !Cumo.compatible_mode_enabled? }
   end
 
+  def test_compatible_mode_extracts_zero_dimensional_reduction_results
+    Cumo.enable_compatible_mode
+    a = Cumo::DFloat[3, 1, 7]
+    assert_equal([Float, Float], a.minmax.map(&:class))
+    assert_equal([1.0, 7.0], a.minmax)
+    assert_equal([true, true], Cumo::DFloat[3, Float::NAN, 1].minmax(nan: true).map(&:nan?))
+    assert_equal([Integer, Integer], Cumo::Int32[3, 1, 7].minmax.map(&:class))
+    assert_equal([1, 7], Cumo::Int32[3, 1, 7].minmax)
+    assert_equal([Integer, Integer], Cumo::RObject[3, 1, 7].minmax.map(&:class))
+    assert_equal(Float, a.max.class)
+    assert_equal(Integer, a.max_index.class)
+    assert_equal(Integer, a.argmax.class)
+  end
+
+  def test_minmax_returns_zero_dimensional_narrays_without_compatible_mode
+    Cumo.disable_compatible_mode
+    min, max = Cumo::DFloat[3, 1, 7].minmax
+    assert_instance_of(Cumo::DFloat, min)
+    assert_instance_of(Cumo::DFloat, max)
+    assert_equal(0, min.ndim)
+    assert_equal([1.0], min.to_a)
+    assert_equal([7.0], max.to_a)
+  end
+
+  def test_minmax_over_an_axis_is_unaffected_by_compatible_mode
+    a = Cumo::DFloat[[3, 1], [7, 2]]
+    [true, false].each do |compatible|
+      compatible ? Cumo.enable_compatible_mode : Cumo.disable_compatible_mode
+      min, max = a.minmax(axis: 1)
+      assert_instance_of(Cumo::DFloat, min)
+      assert_equal([1.0, 2.0], min.to_a)
+      assert_equal([3.0, 7.0], max.to_a)
+    end
+  end
+
   def test_version
     assert_nothing_raised { Cumo::VERSION }
   end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1810,9 +1810,9 @@ class NArrayTest < Test::Unit::TestCase
     total = n * (n + 1) / 2.0
 
     test "minmax" do
-      assert_equal([1.0, last], Cumo::DFloat.new(n).seq(1).minmax.map { |x| x.to_a.first })
-      assert_equal([1, n], Cumo::Int32.new(n).seq(1).minmax.map { |x| x.to_a.first })
-      assert_equal([1, 3], Cumo::Int32[1, 2, 3].minmax.map { |x| x.to_a.first })
+      assert_equal([1.0, last], Cumo::DFloat.new(n).seq(1).minmax)
+      assert_equal([1, n], Cumo::Int32.new(n).seq(1).minmax)
+      assert_equal([1, 3], Cumo::Int32[1, 2, 3].minmax)
     end
 
     test "nan-aware reductions" do


### PR DESCRIPTION
`minmax` carries `CUMO_NDF_EXTRACT`, but `ndloop_extract` has the whole `CUMO_NDF_EXTRACT` block commented out, so the flag does nothing. Every other method carrying it — `max_index`, `min_index`, `argmax`, `argmin` — calls `extract_cpu` itself when compatible mode is on, and `sum`/`min`/`max` go through the generated `extract`. `minmax` did neither, so it was the one reduction that ignored `Cumo.enable_compatible_mode`:

```ruby
Cumo.enable_compatible_mode
Cumo::DFloat[3, 1, 7].max     #=> 7.0
Cumo::DFloat[3, 1, 7].argmax  #=> 2
Cumo::DFloat[3, 1, 7].minmax  #=> [Cumo::DFloat(ndim=0), Cumo::DFloat(ndim=0)]   (numo: [1.0, 7.0])
```

It now extracts both results the same way, following the pattern already in `accum_index.c` and `accum_arg.c`.

The default mode is unchanged: `minmax` keeps returning zero-dimensional NArrays there, which is what `max`, `max_index` and `argmax` do. Reductions over an axis are unaffected in either mode, since `extract_cpu` returns self unless `ndim == 0`.

14 cases across `DFloat`, `SFloat`, `Int32`, `UInt8` and `RObject` — flat, over an axis, `keepdims`, `nan: true`, over a view — now match numo-narray-alt 0.11.2 exactly under `CUMO_COMPATIBLE_MODE=ON`, and still match the documented cumo behaviour with it off.

The one existing assertion that unwrapped the result by hand (`minmax.map { |x| x.to_a.first }` in the synchronization test) is now a plain comparison, which reads the same in both modes. Forcing the whole suite into compatible mode leaves the same 24 failures and 64 errors as before this change — the suite is written for the default mode.
