### PR TITLE
Report device memory to the GC so temporaries are collected

### DIFF
--- a/ext/cumo/narray/gen/tmpl/alloc_func.c
+++ b/ext/cumo/narray/gen/tmpl/alloc_func.c
@@ -1,4 +1,17 @@
 static size_t
+<%=type_name%>_data_bytes(const cumo_narray_data_t *na)
+{
+    if (na->base.size == 0) {
+        return 0;
+    }
+  <% if is_bit %>
+    return ((na->base.size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT);
+  <% else %>
+    return na->base.size * sizeof(dtype);
+  <% end %>
+}
+
+static size_t
 <%=type_name%>_memsize(const void* ptr)
 {
     size_t size = sizeof(cumo_narray_data_t);
@@ -7,11 +20,7 @@ static size_t
     assert(na->base.type == CUMO_NARRAY_DATA_T);
 
     if (na->ptr != NULL) {
-  <% if is_bit %>
-        size += ((na->base.size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT);
-  <% else %>
-        size += na->base.size * sizeof(dtype);
-  <% end %>
+        size += <%=type_name%>_data_bytes(na);
     }
     if (na->base.size > 0) {
         if (na->base.shape != NULL && na->base.shape != &(na->base.size)) {
@@ -34,6 +43,7 @@ static void
             xfree(na->ptr);
   <% else %>
             cumo_cuda_runtime_free(na->ptr);
+            rb_gc_adjust_memory_usage(-(ssize_t)<%=type_name%>_data_bytes(na));
   <% end %>
         }
         na->ptr = NULL;

--- a/ext/cumo/narray/gen/tmpl/allocate.c
+++ b/ext/cumo/narray/gen/tmpl/allocate.c
@@ -26,6 +26,12 @@ static VALUE
             <% end %>
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = TRUE;
+            <% unless is_object %>
+            // Device memory never passes through ruby_xmalloc, so the GC sees a
+            // few-byte object holding an arbitrarily large buffer and does not
+            // run until the host itself runs out.
+            rb_gc_adjust_memory_usage(sizeof(dtype) * na->size);
+            <% end %>
         }
         break;
     case CUMO_NARRAY_VIEW_T:

--- a/ext/cumo/narray/gen/tmpl_bit/allocate.c
+++ b/ext/cumo/narray/gen/tmpl_bit/allocate.c
@@ -13,6 +13,7 @@ static VALUE
             ptr = cumo_cuda_runtime_malloc(((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT));
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = TRUE;
+            rb_gc_adjust_memory_usage(((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT));
         }
         break;
     case CUMO_NARRAY_VIEW_T:

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -589,6 +589,25 @@ cumo_na_s_eye(int argc, VALUE *argv, VALUE klass)
 #define READ 1
 #define WRITE 2
 
+// Byte size of the data buffer self owns, the same expression allocate() sized
+// it with.
+size_t
+cumo_na_data_byte_size(VALUE self)
+{
+    const cumo_narray_type_info_t *info;
+    cumo_narray_t *na;
+
+    CumoGetNArray(self,na);
+    if (na->size == 0) {
+        return 0;
+    }
+    info = (const cumo_narray_type_info_t *)(RTYPEDDATA_TYPE(self)->data);
+    if (info->element_bits > 0) {
+        return ((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT);
+    }
+    return na->size * info->element_bytes;
+}
+
 // allocate() takes xmalloc for RObject and the CUDA allocator for every other
 // type, so the deallocator has to be picked the same way. cudaFree() on host
 // memory raises, and xfree() on device memory reads a malloc header that is not
@@ -600,6 +619,7 @@ cumo_na_free_owned_ptr(VALUE self, void *ptr)
         xfree(ptr);
     } else {
         cumo_cuda_runtime_free(ptr);
+        rb_gc_adjust_memory_usage(-(ssize_t)cumo_na_data_byte_size(self));
     }
 }
 

--- a/test/cuda/memory_pool_test.rb
+++ b/test/cuda/memory_pool_test.rb
@@ -42,6 +42,30 @@ module Cumo::CUDA
       assert_nothing_raised { MemoryPool.total_bytes }
     end
 
+    # Device memory does not pass through ruby_xmalloc, so unless the GC is told
+    # about it these tiny Ruby objects never trigger one and the pool grows to
+    # the total churn instead of the live set.
+    def test_dropped_arrays_do_not_grow_the_pool_by_their_total_size
+      MemoryPool.enable
+      GC.start
+      MemoryPool.free_all_blocks
+      base = MemoryPool.total_bytes
+      # 1 MiB each, 1 GiB of churn against a live set of one array
+      1024.times { Cumo::SFloat.new(1 << 18).allocate }
+      GC.start
+      assert { MemoryPool.total_bytes - base < 256 << 20 }
+    end
+
+    def test_dropped_bit_arrays_do_not_grow_the_pool_by_their_total_size
+      MemoryPool.enable
+      GC.start
+      MemoryPool.free_all_blocks
+      base = MemoryPool.total_bytes
+      1024.times { Cumo::Bit.new(1 << 23).allocate }
+      GC.start
+      assert { MemoryPool.total_bytes - base < 256 << 20 }
+    end
+
     def test_malloc_with_size_whose_rounding_overflows
       MemoryPool.enable
       # 8 * (2**61 - 1) is SIZE_MAX - 7. Rounding it up to a multiple of the


### PR DESCRIPTION
NArray data is allocated with `cudaMallocManaged` through the memory pool, which never passes through `ruby_xmalloc`. Ruby's GC decides when to run from its own heap slots and from `malloc_increase`, so a `Cumo::SFloat` holding a 16 MiB device buffer looks like a few-byte object and never creates any pressure. `<type>_memsize` reports the buffer correctly, but that is only read by `ObjectSpace.memsize_of` and has no effect on when a GC happens.

The result is that a loop producing temporaries grows the pool to the total churn rather than the live set. `bench/bench.rb` with `GPU=1 SIZE=1024 STEPS=200 ITER=1`:

| | before | after |
|---|---|---|
| `MemoryPool.total_bytes` | 11194 MB | 575 MB |
| peak RSS | 2397 MB | 475 MB |
| GC runs | 10 | 597 |
| mandelbrot | 2.584 s | 9.935 s |
| diffusion | 0.564 s | 0.373 s |
| nbody | 0.134 s | 0.058 s |
| monte_carlo | 0.145 s | 0.113 s |

The live set in that mandelbrot loop is 20 MB; the rest was garbage waiting for a GC that had no reason to run. `SIZE=2048` used to exhaust the host and take the session down with it — managed memory oversubscribes, so it never fails as a clean GPU out-of-memory — and now completes with a 560 MB peak RSS.

`rb_gc_adjust_memory_usage` is reported on allocation and release. Only two sites take ownership of a buffer (`allocate` for the general types and for `Cumo::Bit`), and it is released in `<type>_free` and in `cumo_na_free_owned_ptr`, which covers the GC path, `NArray#free`, and `store_binary` replacing an owned buffer. `Cumo::RObject` allocates with `xmalloc` and is left alone, since Ruby already counts it.

## Why mandelbrot got slower

Not the GC: it accounts for 3-7 ms of the 2.4 s, and the extra time is spread evenly over every step rather than landing on the steps where a GC ran (14.1 ms with a GC vs 13.9 ms without).

It is `clip`, which still runs a host loop for every dtype — `cudaDeviceSynchronize` and then a CPU pass over managed memory, three times per step. Once the host has touched those pages, recycling them costs a migration back to the device on the next kernel. Running the same loop with `clip` removed reverses the ordering:

| N=512, 100 steps | pool 73 MB (recycled) | pool 907 MB (fresh) |
|---|---|---|
| with `clip` | 1.40 s | 0.35 s |
| without `clip` | 0.010 s | 0.077 s |

With no host loop in the way, recycling is 7.7x faster than growing the pool, because growing it pays `cudaMallocManaged` and a first-touch page fault every time. Three of the four benchmarks above are faster for exactly that reason. Making `clip` a kernel is a separate fix.

## Verified

- Both new tests fail on master: the pool grows by the full 1 GiB of churn.
- `GC.stress = true` over the allocate/free/`#free`/`store_binary`/`Bit`/`RObject` paths, since the release runs inside the GC's free callback.
- `MemoryPool.used_bytes` returns to 0 after 500 cycles through each of those four paths, so the increments and decrements balance.
- Full suite: 1288 tests, 17061 assertions, 0 failures.
