### PR TITLE
Run clip on the GPU instead of a host loop

### DIFF
--- a/ext/cumo/cuda/runtime.c
+++ b/ext/cumo/cuda/runtime.c
@@ -20,7 +20,7 @@ cumo_cuda_runtime_check_kernel_launch(void)
 }
 
 int*
-cumo_cuda_runtime_divzero_flag_new(void)
+cumo_cuda_runtime_error_flag_new(void)
 {
     static int *flag = NULL;
 
@@ -33,7 +33,7 @@ cumo_cuda_runtime_divzero_flag_new(void)
 }
 
 bool
-cumo_cuda_runtime_divzero_flag_get(int *flag)
+cumo_cuda_runtime_error_flag_get(int *flag)
 {
     check_status(cudaDeviceSynchronize());
     return (*flag != 0);

--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -51,13 +51,13 @@ cumo_cuda_runtime_is_device_memory(void* ptr)
     return (attrs.type != cudaMemoryTypeUnregistered);
 }
 
-// A kernel cannot raise, so an integer division reports a zero divisor through
-// this flag and the caller turns it into the exception ndloop expects. The
-// buffer is pinned host memory the device writes through, not pool memory: a
-// four-byte pool allocation lands in the same bin as a small output array, and
-// the managed page then migrates back and forth once per operation.
-int* cumo_cuda_runtime_divzero_flag_new(void);
-bool cumo_cuda_runtime_divzero_flag_get(int *flag);
+// A kernel cannot raise, so it reports a bad argument through this flag and the
+// caller turns it into an exception. The buffer is pinned host memory the device
+// writes through, not pool memory: a four-byte pool allocation lands in the same
+// bin as a small output array, and the managed page then migrates back and forth
+// once per operation.
+int* cumo_cuda_runtime_error_flag_new(void);
+bool cumo_cuda_runtime_error_flag_get(int *flag);
 
 #if defined(__cplusplus)
 #if 0

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -115,10 +115,10 @@ static void
         cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
         //<% if is_int and %w[div mod].include? name %>
-        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        int *divzero = cumo_cuda_runtime_error_flag_new();
         <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer,divzero);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+        if (cumo_cuda_runtime_error_flag_get(divzero)) {
             lp->err_type = rb_eZeroDivError;
         }
         //<% else %>

--- a/ext/cumo/narray/gen/tmpl/binary2.c
+++ b/ext/cumo/narray/gen/tmpl/binary2.c
@@ -35,10 +35,10 @@ static void
     <% else %>
     {
         //<% if is_int and %w[divmod].include? name %>
-        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        int *divzero = cumo_cuda_runtime_error_flag_new();
         <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,divzero);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+        if (cumo_cuda_runtime_error_flag_get(divzero)) {
             lp->err_type = rb_eZeroDivError;
         }
         //<% else %>

--- a/ext/cumo/narray/gen/tmpl/clip.c
+++ b/ext/cumo/narray/gen/tmpl/clip.c
@@ -1,68 +1,105 @@
+<% unless type_name == 'robject' %>
+void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid);
+void <%="cumo_#{c_iter}_min_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_max_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+<% end %>
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
+    size_t  n;
     char   *p1, *p2, *p3, *p4;
     ssize_t s1, s2, s3, s4;
-    dtype   x, min, max;
-    CUMO_INIT_COUNTER(lp, i);
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
     CUMO_INIT_PTR(lp, 3, p4, s4);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
-        CUMO_GET_DATA_STRIDE(p3,s3,dtype,max);
-        if (m_gt(min,max)) {rb_raise(cumo_na_eOperationError,"min is greater than max");}
-        if (m_lt(x,min)) {x=min;}
-        if (m_gt(x,max)) {x=max;}
-        CUMO_SET_DATA_STRIDE(p4,s4,dtype,x);
+    <% if type_name == 'robject' %>
+    {
+        size_t i;
+        dtype  x, min, max;
+
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        for (i=n; i--;) {
+            CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
+            CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
+            CUMO_GET_DATA_STRIDE(p3,s3,dtype,max);
+            if (m_gt(min,max)) {rb_raise(cumo_na_eOperationError,"min is greater than max");}
+            if (m_lt(x,min)) {x=min;}
+            if (m_gt(x,max)) {x=max;}
+            CUMO_SET_DATA_STRIDE(p4,s4,dtype,x);
+        }
     }
+    <% else %>
+    {
+        int *invalid = cumo_cuda_runtime_error_flag_new();
+        <%="cumo_#{c_iter}_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,invalid);
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        if (cumo_cuda_runtime_error_flag_get(invalid)) {
+            rb_raise(cumo_na_eOperationError,"min is greater than max");
+        }
+    }
+    <% end %>
 }
 
 static void
 <%=c_iter%>_min(cumo_na_loop_t *const lp)
 {
-    size_t  i;
+    size_t  n;
     char   *p1, *p2, *p3;
     ssize_t s1, s2, s3;
-    dtype   x, min;
-    CUMO_INIT_COUNTER(lp, i);
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_min", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
-        if (m_lt(x,min)) {x=min;}
-        CUMO_SET_DATA_STRIDE(p3,s3,dtype,x);
+    <% if type_name == 'robject' %>
+    {
+        size_t i;
+        dtype  x, min;
+
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_min", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        for (i=n; i--;) {
+            CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
+            CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
+            if (m_lt(x,min)) {x=min;}
+            CUMO_SET_DATA_STRIDE(p3,s3,dtype,x);
+        }
     }
+    <% else %>
+    <%="cumo_#{c_iter}_min_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    <% end %>
 }
 
 static void
 <%=c_iter%>_max(cumo_na_loop_t *const lp)
 {
-    size_t  i;
+    size_t  n;
     char   *p1, *p2, *p3;
     ssize_t s1, s2, s3;
-    dtype   x, max;
-    CUMO_INIT_COUNTER(lp, i);
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_max", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        CUMO_GET_DATA_STRIDE(p2,s2,dtype,max);
-        if (m_gt(x,max)) {x=max;}
-        CUMO_SET_DATA_STRIDE(p3,s3,dtype,x);
+    <% if type_name == 'robject' %>
+    {
+        size_t i;
+        dtype  x, max;
+
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_max", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        for (i=n; i--;) {
+            CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
+            CUMO_GET_DATA_STRIDE(p2,s2,dtype,max);
+            if (m_gt(x,max)) {x=max;}
+            CUMO_SET_DATA_STRIDE(p3,s3,dtype,x);
+        }
     }
+    <% else %>
+    <%="cumo_#{c_iter}_max_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    <% end %>
 }
 
 /*

--- a/ext/cumo/narray/gen/tmpl/clip_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/clip_kernel.cu
@@ -1,0 +1,58 @@
+<% unless type_name == 'robject' %>
+__global__ void <%="cumo_#{c_iter}_kernel"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        dtype min = *(dtype*)(p2+(i*s2));
+        dtype max = *(dtype*)(p3+(i*s3));
+        // Leaving the element unwritten keeps a scalar min > max, where every
+        // element takes this branch, from touching the output before it raises.
+        if (m_gt(min,max)) { *invalid = 1; continue; }
+        if (m_lt(x,min)) { x = min; }
+        if (m_gt(x,max)) { x = max; }
+        *(dtype*)(p4+(i*s4)) = x;
+    }
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n,invalid);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+__global__ void <%="cumo_#{c_iter}_min_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        dtype min = *(dtype*)(p2+(i*s2));
+        *(dtype*)(p3+(i*s3)) = m_lt(x,min) ? min : x;
+    }
+}
+
+void <%="cumo_#{c_iter}_min_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_min_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+__global__ void <%="cumo_#{c_iter}_max_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        dtype max = *(dtype*)(p2+(i*s2));
+        *(dtype*)(p3+(i*s3)) = m_gt(x,max) ? max : x;
+    }
+}
+
+void <%="cumo_#{c_iter}_max_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_max_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>

--- a/ext/cumo/narray/gen/tmpl/unary.c
+++ b/ext/cumo/narray/gen/tmpl/unary.c
@@ -115,10 +115,10 @@ static void
     <% else %>
     {
         //<% if is_int and name == 'reciprocal' %>
-        int *divzero = cumo_cuda_runtime_divzero_flag_new();
+        int *divzero = cumo_cuda_runtime_error_flag_new();
         <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,divzero);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        if (cumo_cuda_runtime_divzero_flag_get(divzero)) {
+        if (cumo_cuda_runtime_error_flag_get(divzero)) {
             lp->err_type = rb_eZeroDivError;
         }
         //<% else %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -659,6 +659,58 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
 
+    unless [Cumo::DComplex, Cumo::SComplex].include?(dtype)
+      sub_test_case "#{dtype}, #clip" do
+        test "clip" do
+          a = dtype[0..9]
+          assert { a.clip(1, 8) == [1, 1, 2, 3, 4, 5, 6, 7, 8, 8] }
+          assert { a.clip(nil, 8) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 8] }
+          assert { a.clip(3, nil) == [3, 3, 3, 3, 4, 5, 6, 7, 8, 9] }
+        end
+
+        test "clip with array bounds" do
+          a = dtype[0..9]
+          assert { a.clip(dtype[3, 4, 1, 1, 1, 4, 4, 4, 4, 4], 8) == [3, 4, 2, 3, 4, 5, 6, 7, 8, 8] }
+          assert { a.clip(1, dtype[9, 9, 9, 5, 5, 5, 5, 5, 5, 5]) == [1, 1, 2, 3, 4, 5, 5, 5, 5, 5] }
+          assert { a.clip(dtype.new(10).fill(2), dtype.new(10).fill(7)) == [2, 2, 2, 3, 4, 5, 6, 7, 7, 7] }
+        end
+
+        test "clip in place" do
+          a = dtype[0..9]
+          a.inplace.clip(3, 6)
+          assert { a == [3, 3, 3, 3, 4, 5, 6, 6, 6, 6] }
+        end
+
+        test "clip over views" do
+          a = dtype[0..11].reshape(3, 4)
+          assert { a[1..2, 1..2].clip(6, 9) == [[6, 6], [9, 9]] }
+          assert { a.transpose.clip(2, 8) == [[2, 4, 8], [2, 5, 8], [2, 6, 8], [3, 7, 8]] }
+          assert { a.reverse(1).clip(2, 8) == [[3, 2, 2, 2], [7, 6, 5, 4], [8, 8, 8, 8]] }
+        end
+
+        # More than one block, so the whole launch is exercised.
+        test "clip over a large array" do
+          a = dtype.cast(Array.new(100_000) { |i| i % 100 })
+          c = a.clip(20, 80)
+          assert { c.min == 20 }
+          assert { c.max == 80 }
+          assert { c[0..24].to_a == ([20] * 21) + [21, 22, 23, 24] }
+        end
+
+        test "clip raises without a usable range" do
+          a = dtype[0..9]
+          assert_raise(Cumo::NArray::OperationError) { a.clip(6, 3) }
+          assert_raise(ArgumentError) { a.clip(nil, nil) }
+        end
+
+        test "clip leaves the array untouched when it raises" do
+          a = dtype[0..9]
+          assert_raise(Cumo::NArray::OperationError) { a.inplace.clip(6, 3) }
+          assert { a == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] }
+        end
+      end
+    end
+
     sub_test_case "#{dtype}, #mulsum" do
       test "vector.mulsum(vector)" do
         a = dtype[1..3]


### PR DESCRIPTION
`clip` still ran a host loop for every dtype: `cudaDeviceSynchronize` and then a CPU pass over managed memory. Besides being slow on its own, it drags the pages it touches back to the host, so the next kernel to use that memory pays a migration.

| best of 3 | host loop | kernel |
|---|---|---|
| `SFloat` n=1000 `clip(a, b)` | 154.7 us | 17.5 us |
| `SFloat` n=1000 `clip(nil, b)` | 204.4 us | 7.9 us |
| `SFloat` n=1e6 `clip(a, b)` | 712.7 us | 21.4 us |
| `SFloat` n=1e6 `clip(nil, b)` | 462.9 us | 8.5 us |
| `Int32` n=1e6 `clip(a, b)` | 795.5 us | 20.2 us |

The migration cost is the larger half. `bench/bench.rb` with `GPU=1 SIZE=1024 STEPS=200 ITER=1` calls `clip` three times per mandelbrot step:

| | before | after |
|---|---|---|
| mandelbrot | 9.935 s | 0.083 s |
| diffusion | 0.373 s | 0.353 s |
| nbody | 0.058 s | 0.058 s |
| monte_carlo | 0.113 s | 0.096 s |

Recycled pool memory is what makes the migration visible: with a host loop in the loop body, running the same mandelbrot with a 73 MB pool took 1.40 s against 0.35 s with a 907 MB one, and with `clip` removed the ordering reverses to 0.010 s against 0.077 s. `Cumo::RObject` keeps its host loop, since its comparisons are `rb_funcall`.

## min greater than max

A kernel cannot raise, so it reports through the pinned flag added for integer division by zero in #218, which is renamed from `divzero_flag` to `error_flag` now that a second caller uses it. The exception class and message are unchanged.

An element whose `min > max` is left unwritten rather than clipped. For scalar bounds — where every element takes that branch — the array is therefore untouched when `clip` raises, which is what the host loop did by raising on the first element. For array bounds the host loop wrote the elements ahead of the offending one and this writes the elements whose own bounds are usable; neither order is meaningful for a parallel launch.

## Verified

- 154 comparisons against numo-narray-alt 0.11.2 over all 11 dtypes: scalar bounds, one-sided, array bounds, 2-D, views, transposed, in place, `min > max`, `clip(nil, nil)`, and a 100k array. Every clipped array matches element for element. The 4 remaining differences are `sum` overflowing on `Int8`/`Int16`/`Int32`/`UInt8`/`UInt16`, which predates this change and is unrelated to `clip`.
- `compute-sanitizer --tool memcheck`: 0 errors over every dtype, both one-sided forms, views, transposed, reversed, in place, and the raising path.
- The new tests pass on master as well — `clip` was correct, only slow — so they pin the behaviour the kernel has to reproduce rather than catch a regression.
- Full suite: 1358 tests, 17231 assertions, 0 failures.
