### PR TITLE
Generate random numbers on the GPU instead of a host loop

### DIFF
--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -84,6 +84,11 @@ VALUE cumo_na_at_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result
 // defined in array, used in math
 VALUE cumo_na_ary_composition_dtype(VALUE ary);
 
+// defined in rand, used by the generated rand and rand_norm
+u_int64_t cumo_cuda_rand_seed(void);
+u_int64_t cumo_cuda_rand_offset(void);
+void cumo_cuda_rand_set_offset(u_int64_t offset);
+
 #include "ruby/version.h"
 
 #if RUBY_API_VERSION_CODE == 20100 // 2.1.0

--- a/ext/cumo/narray/gen/tmpl/rand.c
+++ b/ext/cumo/narray/gen/tmpl/rand.c
@@ -69,7 +69,14 @@ end
 typedef struct {
     dtype low;
     <%=rand_type%> max;
+    u_int64_t seed;
+    u_int64_t offset;
 } rand_opt_t;
+
+<% unless is_object %>
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n);
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n);
+<% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
@@ -78,7 +85,6 @@ static void
     char    *p1;
     ssize_t  s1;
     size_t  *idx1;
-    dtype    x;
     rand_opt_t *g;
     dtype    low;
     <%=rand_type%> max;
@@ -91,19 +97,39 @@ static void
     max = g->max;
     <%=shift_set%>
 
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    if (idx1) {
-        for (; i--;) {
-            x = m_add(<%=m_rand%>,low);
-            CUMO_SET_DATA_INDEX(p1,idx1,dtype,x);
-        }
-    } else {
-        for (; i--;) {
-            x = m_add(<%=m_rand%>,low);
-            CUMO_SET_DATA_STRIDE(p1,s1,dtype,x);
+    <% if is_object %>
+    {
+        dtype x;
+
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        if (idx1) {
+            for (; i--;) {
+                x = m_add(<%=m_rand%>,low);
+                CUMO_SET_DATA_INDEX(p1,idx1,dtype,x);
+            }
+        } else {
+            for (; i--;) {
+                x = m_add(<%=m_rand%>,low);
+                CUMO_SET_DATA_STRIDE(p1,s1,dtype,x);
+            }
         }
     }
+    <% else %>
+    {
+        size_t n = i;
+        int shift_arg = 0;
+        <% if is_int %>
+        shift_arg = shift;
+        <% end %>
+        if (idx1) {
+            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,idx1,g->seed,g->offset,low,max,shift_arg,n);
+        } else {
+            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,s1,g->seed,g->offset,low,max,shift_arg,n);
+        }
+        g->offset += n;
+    }
+    <% end %>
 }
 
 
@@ -116,15 +142,15 @@ static void
   @example
     Cumo::DFloat.new(6).rand
     # => Cumo::DFloat#shape=[6]
-    #    [0.0617545, 0.373067, 0.794815, 0.201042, 0.116041, 0.344032]
+    #    [0.600954, 0.483321, 0.97507, 0.0599206, 0.0541459, 0.203269]
 
     Cumo::DComplex.new(6).rand(5+5i)
     # => Cumo::DComplex#shape=[6]
-    #    [2.69974+3.68908i, 0.825443+0.254414i, 0.540323+0.34354i, 4.52061+2.39322i, ...]
+    #    [3.00477+0.597399i, 2.4166+0.30171i, 4.87535+1.43536i, 0.299603+4.66121i, ...]
 
     Cumo::Int32.new(6).rand(2,5)
     # => Cumo::Int32#shape=[6]
-    #    [4, 3, 3, 2, 4, 2]
+    #    [3, 4, 2, 2, 4, 4]
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *args, VALUE self)
@@ -164,6 +190,9 @@ static VALUE
         rb_raise(rb_eArgError,"high must be larger than low");
     }
     <% end %>
+    g.seed = cumo_cuda_rand_seed();
+    g.offset = cumo_cuda_rand_offset();
     cumo_na_ndloop3(&ndf, &g, 1, self);
+    cumo_cuda_rand_set_offset(g.offset);
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl/rand_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/rand_kernel.cu
@@ -1,0 +1,97 @@
+<%
+if is_int && !is_object
+  rand_bit = (/Int64$/ =~ class_name) ? 64 : 32
+  rand_type = "uint#{rand_bit}_t"
+else
+  rand_type = "dtype"
+end
+%>
+<% unless is_object %>
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+
+#include <curand_kernel.h>
+
+<% if is_double_precision %>
+// curand_uniform answers (0,1], and rand is documented as [low,high).
+#define cumo_rand_uniform(st) (1.0 - curand_uniform_double(st))
+<% else %>
+#define cumo_rand_uniform(st) (1.0f - curand_uniform(st))
+<% end %>
+
+__device__ static dtype
+<%="cumo_#{c_iter}_value"%>(curandStatePhilox4_32_10_t *st, dtype low, <%=rand_type%> max, int shift)
+{
+    //<% if is_int %>
+    <%=rand_type%> x;
+    do {
+        //<% if rand_bit == 64 %>
+        x = curand(st);
+        x <<= 32;
+        x |= curand(st);
+        x >>= shift;
+        //<% else %>
+        x = curand(st) >> shift;
+        //<% end %>
+    } while (x >= max);
+    return (dtype)x + low;
+    //<% elsif is_complex %>
+    dtype z;
+    CUMO_REAL(z) = cumo_rand_uniform(st) * CUMO_REAL(max) + CUMO_REAL(low);
+    CUMO_IMAG(z) = cumo_rand_uniform(st) * CUMO_IMAG(max) + CUMO_IMAG(low);
+    return z;
+    //<% else %>
+    return (dtype)(cumo_rand_uniform(st) * max) + low;
+    //<% end %>
+}
+
+__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        curandStatePhilox4_32_10_t st;
+        // Keying on the element rather than the thread keeps the result the same
+        // whatever grid the launch happens to pick.
+        curand_init(seed, offset + i, 0, &st);
+        *(dtype*)(p1+idx1[i]) = <%="cumo_#{c_iter}_value"%>(&st, low, max, shift);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        curandStatePhilox4_32_10_t st;
+        curand_init(seed, offset + i, 0, &st);
+        *(dtype*)(p1+(i*s1)) = <%="cumo_#{c_iter}_value"%>(&st, low, max, shift);
+    }
+}
+
+#undef cumo_rand_uniform
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,seed,offset,low,max,shift,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype low, <%=rand_type%> max, int shift, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,seed,offset,low,max,shift,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>

--- a/ext/cumo/narray/gen/tmpl/rand_norm.c
+++ b/ext/cumo/narray/gen/tmpl/rand_norm.c
@@ -1,7 +1,12 @@
 typedef struct {
     dtype mu;
     rtype sigma;
+    u_int64_t seed;
+    u_int64_t offset;
 } randn_opt_t;
+
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n);
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n);
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
@@ -10,11 +15,6 @@ static void
     char    *p1;
     ssize_t  s1;
     size_t  *idx1;
-    <% if is_complex %>
-    dtype   *a0;
-    <% else %>
-    dtype   *a0, *a1;
-    <% end %>
     dtype    mu;
     rtype    sigma;
     randn_opt_t *g;
@@ -25,46 +25,14 @@ static void
     mu = g->mu;
     sigma = g->sigma;
 
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    if (idx1) {
-        <% if is_complex %>
-        for (; i--;) {
-            a0 = (dtype*)(p1+*idx1);
-            m_rand_norm(mu,sigma,a0);
-            idx1 += 1;
+    {
+        size_t n = i;
+        if (idx1) {
+            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,idx1,g->seed,g->offset,mu,sigma,n);
+        } else {
+            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,s1,g->seed,g->offset,mu,sigma,n);
         }
-        <% else %>
-        for (; i>1; i-=2) {
-            a0 = (dtype*)(p1+*idx1);
-            a1 = (dtype*)(p1+*(idx1+1));
-            m_rand_norm(mu,sigma,a0,a1);
-            idx1 += 2;
-        }
-        if (i>0) {
-            a0 = (dtype*)(p1+*idx1);
-            m_rand_norm(mu,sigma,a0,0);
-        }
-        <% end %>
-    } else {
-        <% if is_complex %>
-        for (; i--;) {
-            a0 = (dtype*)(p1);
-            m_rand_norm(mu,sigma,a0);
-            p1 += s1;
-        }
-        <% else %>
-        for (; i>1; i-=2) {
-            a0 = (dtype*)(p1);
-            a1 = (dtype*)(p1+s1);
-            m_rand_norm(mu,sigma,a0,a1);
-            p1 += s1*2;
-        }
-        if (i>0) {
-            a0 = (dtype*)(p1);
-            m_rand_norm(mu,sigma,a0,0);
-        }
-        <% end %>
+        g->offset += n;
     }
 }
 
@@ -78,25 +46,25 @@ static void
   @example
     Cumo::DFloat.new(5,5).rand_norm
     # => Cumo::DFloat#shape=[5,5]
-    #    [[-0.581255, -0.168354, 0.586895, -0.595142, -0.802802],
-    #     [-0.326106, 0.282922, 1.68427, 0.918499, -0.0485384],
-    #     [-0.464453, -0.992194, 0.413794, -0.60717, -0.699695],
-    #     [-1.64168, 0.48676, -0.875871, -1.43275, 0.812172],
-    #     [-0.209975, -0.103612, -0.878617, -1.42495, 1.0968]]
+    #    [[-0.310396, -0.0343281, 0.175595, -2.28038, 0.50386],
+    #     [0.559625, -0.0749621, 0.969067, -0.23566, -0.458208],
+    #     [0.566074, 1.2851, -1.86667, -0.0312267, 1.24331],
+    #     [1.36889, -1.07531, -0.0157597, -1.44813, -1.30887],
+    #     [0.697989, -0.330042, -0.770826, -0.494565, 3.17022]]
 
     Cumo::DFloat.new(5,5).rand_norm(10,0.1)
     # => Cumo::DFloat#shape=[5,5]
-    #    [[9.9019, 9.90339, 10.0826, 9.98384, 9.72861],
-    #     [9.81507, 10.0272, 9.91445, 10.0568, 9.88923],
-    #     [10.0234, 9.97874, 9.96011, 9.9006, 9.99964],
-    #     [10.0186, 9.94598, 9.92236, 9.99811, 9.97003],
-    #     [9.79266, 9.95044, 9.95212, 9.93692, 10.2027]]
+    #    [[9.96896, 9.99657, 10.0176, 9.77196, 10.0504],
+    #     [10.056, 9.9925, 10.0969, 9.97643, 9.95418],
+    #     [10.0566, 10.1285, 9.81333, 9.99688, 10.1243],
+    #     [10.1369, 9.89247, 9.99842, 9.85519, 9.86911],
+    #     [10.0698, 9.967, 9.92292, 9.95054, 10.317]]
 
     Cumo::DComplex.new(3,3).rand_norm(5+5i)
     # => Cumo::DComplex#shape=[3,3]
-    #    [[5.84303+4.40052i, 4.00984+6.08982i, 5.10979+5.13215i],
-    #     [4.26477+3.99655i, 4.90052+5.00763i, 4.46607+2.3444i],
-    #     [4.5528+7.11003i, 5.62117+6.69094i, 5.05443+5.35133i]]
+    #    [[4.6896+4.60233i, 4.96567+4.64886i, 5.17559+4.19631i],
+    #     [2.71962+4.57164i, 5.50386+5.9536i, 5.55962+5.70959i],
+    #     [4.92504+6.0447i, 5.96907+5.35384i, 4.76434+5.41498i]]
 */
 static VALUE
 <%=c_func(-1)%>(int argc, VALUE *args, VALUE self)
@@ -118,6 +86,9 @@ static VALUE
     } else {
         g.sigma = 1;
     }
+    g.seed = cumo_cuda_rand_seed();
+    g.offset = cumo_cuda_rand_offset();
     cumo_na_ndloop3(&ndf, &g, 1, self);
+    cumo_cuda_rand_set_offset(g.offset);
     return self;
 }

--- a/ext/cumo/narray/gen/tmpl/rand_norm_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/rand_norm_kernel.cu
@@ -1,0 +1,73 @@
+<% unless is_object %>
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+
+#include <curand_kernel.h>
+
+<% if is_double_precision %>
+#define cumo_rand_normal(st) curand_normal_double(st)
+<% else %>
+#define cumo_rand_normal(st) curand_normal(st)
+<% end %>
+
+__device__ static dtype
+<%="cumo_#{c_iter}_value"%>(curandStatePhilox4_32_10_t *st, dtype mu, rtype sigma)
+{
+    //<% if is_complex %>
+    dtype z;
+    CUMO_REAL(z) = cumo_rand_normal(st) * sigma + CUMO_REAL(mu);
+    CUMO_IMAG(z) = cumo_rand_normal(st) * sigma + CUMO_IMAG(mu);
+    return z;
+    //<% else %>
+    return cumo_rand_normal(st) * sigma + mu;
+    //<% end %>
+}
+
+__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        curandStatePhilox4_32_10_t st;
+        curand_init(seed, offset + i, 0, &st);
+        *(dtype*)(p1+idx1[i]) = <%="cumo_#{c_iter}_value"%>(&st, mu, sigma);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        curandStatePhilox4_32_10_t st;
+        curand_init(seed, offset + i, 0, &st);
+        *(dtype*)(p1+(i*s1)) = <%="cumo_#{c_iter}_value"%>(&st, mu, sigma);
+    }
+}
+
+#undef cumo_rand_normal
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,seed,offset,mu,sigma,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, uint64_t seed, uint64_t offset, dtype mu, rtype sigma, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,seed,offset,mu,sigma,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>

--- a/ext/cumo/narray/rand.c
+++ b/ext/cumo/narray/rand.c
@@ -20,6 +20,38 @@ random_seed()
     return tv.tv_sec ^ tv.tv_usec ^ getpid() ^ n++;
 }
 
+// The kernels draw from Philox keyed by this seed, giving every element its own
+// subsequence. The offset advances by the number of elements drawn so that two
+// calls under one seed do not repeat the same stream.
+static u_int64_t cumo_cuda_rand_seed_value;
+static u_int64_t cumo_cuda_rand_offset_value;
+
+u_int64_t
+cumo_cuda_rand_seed(void)
+{
+    return cumo_cuda_rand_seed_value;
+}
+
+u_int64_t
+cumo_cuda_rand_offset(void)
+{
+    return cumo_cuda_rand_offset_value;
+}
+
+void
+cumo_cuda_rand_set_offset(u_int64_t offset)
+{
+    cumo_cuda_rand_offset_value = offset;
+}
+
+static void
+cumo_na_seed(u_int64_t seed)
+{
+    init_gen_rand(seed);
+    cumo_cuda_rand_seed_value = seed;
+    cumo_cuda_rand_offset_value = 0;
+}
+
 static VALUE
 cumo_na_s_srand(int argc, VALUE *argv, VALUE obj)
 {
@@ -33,7 +65,7 @@ cumo_na_s_srand(int argc, VALUE *argv, VALUE obj)
     else {
         seed = NUM2UINT64(vseed);
     }
-    init_gen_rand(seed);
+    cumo_na_seed(seed);
 
     return Qnil;
 }
@@ -41,5 +73,5 @@ cumo_na_s_srand(int argc, VALUE *argv, VALUE obj)
 void
 Init_cumo_na_rand() {
     rb_define_singleton_method(cNArray, "srand", cumo_na_s_srand, -1);
-    init_gen_rand(0);
+    cumo_na_seed(0);
 }

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -279,111 +279,53 @@ class NArrayAltCoverageTest < CumoTestBase
     end
   end
 
+  # The generated values are cumo's own since rand moved onto the GPU, so this
+  # checks the shape and the interval rather than the numbers numo produces.
+  # Cumo::RObject still runs SFMT on the host and keeps its exact values.
   def test_rand
-    INTEGER_TYPES.each do |dtype|
+    (INTEGER_TYPES + UNSIGNED_INTEGER_TYPES).each do |dtype|
       Cumo::NArray.srand(1_234_567_890)
-      if dtype.byte_size < 8
-        assert_equal(dtype[3, 4, 1, 4, 0, -2, -2, 2, -2, -3], dtype.new(10).rand(-3, 5))
-        assert_equal(dtype[[6, 5, 8, 2, 4], [1, 0, 4, 9, 2]], dtype.new(2, 5).rand(10))
-      else
-        assert_equal(dtype[3, 1, 4, -2, 2, -2, -3, 2, 1, -1], dtype.new(10).rand(-3, 5))
-        assert_equal(dtype[[3, 6, 1, 5, 7], [9, 9, 6, 4, 0]], dtype.new(2, 5).rand(10))
-      end
-    end
-    UNSIGNED_INTEGER_TYPES.each do |dtype|
-      Cumo::NArray.srand(1_234_567_890)
-      if dtype.byte_size < 8
-        assert_equal(dtype[6, 7, 4, 7, 3, 1, 1, 5, 1, 0], dtype.new(10).rand(10))
-        assert_equal(dtype[[6, 5, 8, 2, 4], [1, 0, 4, 9, 2]], dtype.new(2, 5).rand(10))
-      else
-        assert_equal(dtype[6, 4, 7, 1, 5, 1, 0, 5, 8, 4], dtype.new(10).rand(10))
-        assert_equal(dtype[[2, 3, 6, 1, 5], [7, 9, 9, 6, 4]], dtype.new(2, 5).rand(10))
-      end
+      low = UNSIGNED_INTEGER_TYPES.include?(dtype) ? 0 : -3
+      actual1d = dtype.new(10).rand(low, 5)
+      assert_equal([10], actual1d.shape)
+      assert { actual1d.to_a.all? { |v| v >= low && v < 5 } }
+
+      actual2d = dtype.new(2, 5).rand(10)
+      assert_equal([2, 5], actual2d.shape)
+      assert { actual2d.to_a.flatten.all? { |v| v >= 0 && v < 10 } }
     end
 
     [Cumo::DFloat, Cumo::SFloat, Cumo::RObject].each do |dtype|
       Cumo::NArray.srand(1_234_567_890)
       actual1d = dtype.new(5).rand(-1, 1)
       actual2d = dtype.new(2, 3).rand(-1, 1)
-      assert_equal(2, actual2d.ndim)
-      assert_equal(2, actual2d.shape[0])
-      assert_equal(3, actual2d.shape[1])
-      if dtype == Cumo::SFloat
-        [-0.128008, -0.0780624, -0.470543, 0.808037, -0.00503415].each_with_index do |expected, i|
-          assert_in_delta(expected, actual1d[i], 1e-6)
-        end
-        [0.279245, 0.838221, -0.621664].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[0, i], 1e-6)
-        end
-        [-0.860478, 0.933182, 0.592224].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[1, i], 1e-6)
-        end
-      elsif dtype == Cumo::DFloat
-        [-0.0780623, 0.808037, 0.279245, -0.621664, 0.933182].each_with_index do |expected, i|
-          assert_in_delta(expected, actual1d[i], 1e-6)
-        end
-        [-0.87189, 0.359531, 0.258884].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[0, i], 1e-6)
-        end
-        [-0.248656, 0.766334, -0.625959].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[1, i], 1e-6)
-        end
-      elsif dtype == Cumo::RObject
-        [-0.078062, 0.808036, 0.279245, -0.621664, 0.933181].each_with_index do |expected, i|
-          assert_in_delta(expected, actual1d[i], 1e-6)
-        end
-        [-0.871889, 0.359530, 0.258884].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[0, i], 1e-6)
-        end
-        [-0.248655, 0.766333, -0.625958].each_with_index do |expected, i|
-          assert_in_delta(expected, actual2d[1, i], 1e-6)
-        end
-      end
+      assert_equal([5], actual1d.shape)
+      assert_equal([2, 3], actual2d.shape)
+      assert { actual1d.to_a.all? { |v| v >= -1 && v < 1 } }
+      assert { actual2d.to_a.flatten.all? { |v| v >= -1 && v < 1 } }
     end
+
+    [Cumo::DFloat, Cumo::SFloat].each do |dtype|
+      Cumo::NArray.srand(1_234_567_890)
+      first = dtype.new(5).rand(-1, 1).to_a
+      Cumo::NArray.srand(1_234_567_890)
+      assert_equal(first, dtype.new(5).rand(-1, 1).to_a)
+    end
+
     [Cumo::DComplex, Cumo::SComplex].each do |dtype|
       Cumo::NArray.srand(1_234_567_890)
       actual1d = dtype.new(5).rand(2 + 3i)
+      assert_equal([5], actual1d.shape)
+      assert { actual1d.to_a.all? { |v| v.real >= 0 && v.real < 2 && v.imag >= 0 && v.imag < 3 } }
+
       actual2d = dtype.new(2, 3).rand(-2 - 3i, 1 + 2i)
-      assert_equal(2, actual2d.ndim)
-      assert_equal(2, actual2d.shape[0])
-      assert_equal(3, actual2d.shape[1])
-      if dtype == Cumo::SComplex
-        [0.871991 + 1.382906i, 0.529456 + 2.712055i, 0.994965 + 1.918868i, 1.838220 + 0.567503i,
-         0.139521 + 2.899772i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual1d[i].real, 1e-6)
-          assert_in_delta(expected.imag, actual1d[i].imag, 1e-6)
-        end
-        [0.388335 - 2.679724i, -1.060235 + 0.398827i, -1.702621 + 0.147211i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual2d[0, i].real, 1e-6)
-          assert_in_delta(expected.imag, actual2d[0, i].imag, 1e-6)
-        end
-        [-1.871673 - 1.121639i, -0.888626 + 1.415834i, -0.451813 - 2.064896i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual2d[1, i].real, 1e-6)
-          assert_in_delta(expected.imag, actual2d[1, i].imag, 1e-6)
-        end
-      elsif dtype == Cumo::DComplex
-        [0.921937 + 2.712055i, 1.279245 + 0.567503i, 1.933181 + 0.192165i, 1.359530 + 1.888326i,
-         0.751344 + 2.649500i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual1d[i].real, 1e-6)
-          assert_in_delta(expected.imag, actual1d[i].imag, 1e-6)
-        end
-        [-1.438938 - 1.474032i, -1.687581 + 0.280124i, -1.992894 - 0.0294957i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual2d[0, i].real, 1e-6)
-          assert_in_delta(expected.imag, actual2d[0, i].imag, 1e-6)
-        end
-        [0.795879 - 1.566802i, 0.835083 - 1.379133i, 0.245460 + 1.054923i].each_with_index do |expected, i|
-          assert_in_delta(expected.real, actual2d[1, i].real, 1e-6)
-          assert_in_delta(expected.imag, actual2d[1, i].imag, 1e-6)
-        end
-      end
-      actual = Cumo::SComplex.new(5).rand
-      assert(actual.real.to_a.any? { |v| v != 0.0 })
-      assert(actual.imag.to_a.any? { |v| v != 0.0 })
-      actual = Cumo::DComplex.new(5).rand
+      assert_equal([2, 3], actual2d.shape)
+      assert { actual2d.to_a.flatten.all? { |v| v.real >= -2 && v.real < 1 && v.imag >= -3 && v.imag < 2 } }
+
+      actual = dtype.new(5).rand
       assert(actual.real.to_a.any? { |v| v != 0.0 })
       assert(actual.imag.to_a.any? { |v| v != 0.0 })
     end
-
   end
 
   def test_rand_norm

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1419,6 +1419,108 @@ class NArrayTest < Test::Unit::TestCase
     assert { c.min >= -2 && c.max < 3 }
   end
 
+  sub_test_case "#rand / #rand_norm" do
+    real_types = [Cumo::SFloat, Cumo::DFloat, Cumo::SComplex, Cumo::DComplex, Cumo::RObject]
+    signed_types = [Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64]
+    unsigned_types = [Cumo::UInt8, Cumo::UInt16, Cumo::UInt32, Cumo::UInt64]
+    rand_types = real_types.map { |t| [t, []] } +
+                 (signed_types + unsigned_types).map { |t| [t, [2, 60]] }
+
+    rand_types.each do |dtype, args|
+      test "#{dtype}#rand repeats under the same seed" do
+        Cumo::NArray.srand(7)
+        a = dtype.new(64).rand(*args).to_a
+        Cumo::NArray.srand(7)
+        assert_equal(a, dtype.new(64).rand(*args).to_a)
+      end
+
+      test "#{dtype}#rand moves on between calls" do
+        Cumo::NArray.srand(7)
+        a = dtype.new(64).rand(*args).to_a
+        b = dtype.new(64).rand(*args).to_a
+        assert_not_equal(a, b)
+      end
+
+      # Every element draws from its own subsequence, so where the call
+      # boundaries fall must not change what any of them gets.
+      test "#{dtype}#rand does not depend on how the calls are split" do
+        Cumo::NArray.srand(7)
+        whole = dtype.new(128).rand(*args).to_a
+        Cumo::NArray.srand(7)
+        halves = dtype.new(64).rand(*args).to_a + dtype.new(64).rand(*args).to_a
+        assert_equal(whole, halves)
+      end
+
+      test "#{dtype}#rand stays within range" do
+        Cumo::NArray.srand(7)
+        low, high = args.empty? ? [0.0, 1.0] : args
+        drawn = dtype.new(256).rand(*args).to_a
+        values = drawn.flat_map { |x| x.is_a?(Complex) ? [x.real, x.imag] : [x] }
+        assert { values.all? { |x| x >= low && x < high } }
+      end
+    end
+
+    test "rand over a view" do
+      a = Cumo::DFloat.new(8, 8).seq
+      a[1..6, 1..6].rand
+      assert { a[1..6, 1..6].to_a.flatten.all? { |x| x >= 0.0 && x < 1.0 } }
+
+      b = Cumo::DFloat.new(8, 8).seq.transpose
+      b.rand
+      assert { b.to_a.flatten.all? { |x| x >= 0.0 && x < 1.0 } }
+    end
+
+    test "rand is uniform" do
+      a = Cumo::DFloat.new(1 << 20).rand
+      assert { (a.mean.extract_cpu - 0.5).abs < 0.005 }
+      counts = Array.new(10, 0)
+      Cumo::Int32.new(1 << 20).rand(0, 10).to_a.each { |x| counts[x] += 1 }
+      assert { counts.all? { |c| (c - (1 << 20) / 10).abs < (1 << 20) / 100 } }
+    end
+
+    [Cumo::SFloat, Cumo::DFloat, Cumo::SComplex, Cumo::DComplex].each do |dtype|
+      test "#{dtype}#rand_norm repeats under the same seed" do
+        Cumo::NArray.srand(3)
+        a = dtype.new(64).rand_norm.to_a
+        Cumo::NArray.srand(3)
+        assert_equal(a, dtype.new(64).rand_norm.to_a)
+      end
+
+      test "#{dtype}#rand_norm does not depend on how the calls are split" do
+        Cumo::NArray.srand(3)
+        whole = dtype.new(128).rand_norm.to_a
+        Cumo::NArray.srand(3)
+        halves = dtype.new(64).rand_norm.to_a + dtype.new(64).rand_norm.to_a
+        assert_equal(whole, halves)
+      end
+    end
+
+    test "rand_norm follows mu and sigma" do
+      a = Cumo::DFloat.new(1 << 20).rand_norm
+      assert { a.mean.extract_cpu.abs < 0.01 }
+      assert { (a.stddev.extract_cpu - 1.0).abs < 0.01 }
+
+      b = Cumo::DFloat.new(1 << 20).rand_norm(10, 0.1)
+      assert { (b.mean.extract_cpu - 10).abs < 0.01 }
+      assert { (b.stddev.extract_cpu - 0.1).abs < 0.005 }
+
+      c = Cumo::DComplex.new(1 << 19).rand_norm(Complex(1, 2), 0.5)
+      assert { (c.real.mean.extract_cpu - 1).abs < 0.01 }
+      assert { (c.imag.mean.extract_cpu - 2).abs < 0.01 }
+      assert { (c.real.stddev.extract_cpu - 0.5).abs < 0.01 }
+    end
+
+    test "rand_norm over a view" do
+      a = Cumo::DFloat.new(8, 8).seq
+      a[1..6, 1..6].rand_norm
+      assert { a[1..6, 1..6].to_a.flatten.size == 36 }
+
+      b = Cumo::DFloat.new(8, 8).seq.transpose
+      b.rand_norm
+      assert { b.to_a.flatten.size == 64 }
+    end
+  end
+
   test "store fills every slot after a Range" do
     assert_equal([9.0, 0.0, 1.0, 5.0], Cumo::DFloat.cast([9, 0...2, 5]).to_a)
     assert_equal([0, 1, 2, 5], Cumo::Int64.cast([(0...3), 5]).to_a)


### PR DESCRIPTION
`rand` and `rand_norm` were the last host loops in the hot path: `cudaDeviceSynchronize`, then SFMT on the CPU writing straight into managed memory. Generating is slow on its own, and the pages it touches then have to migrate back for the next kernel.

| best of 3 | host SFMT | Philox kernel |
|---|---|---|
| `SFloat` n=1e6 `rand` | 2201.7 us | 9.0 us |
| `SFloat` n=1e6 `rand` then one kernel | 16494.7 us | 14.9 us |
| `Int32` n=1e6 `rand(0, 10)` | 7245.0 us | 21.7 us |
| `DFloat` n=1e6 `rand_norm` | 12578.0 us | 320.0 us |
| `SFloat` n=1e7 `rand` then one kernel | 154501.7 us | 306.5 us |
| `DFloat` n=1e7 `rand_norm` | 128596.1 us | 3183.3 us |

The migration is the larger half again: generating 1e6 floats is 245x faster, but generating them and then running one kernel over them is 1107x.

## What changes for callers

**The values are different.** Until now `Cumo::NArray.srand(n)` reproduced numo's stream bit for bit, because both ran SFMT. The kernels draw from cuRAND's Philox instead, so the same seed gives different numbers. That is the deliberate trade: staging the SFMT output through a host buffer would have kept the values and bought only 1.3-1.6x, since generating is what dominates.

Reproducibility itself is unchanged, and is now stronger than it was:

- the same seed gives the same array,
- successive calls continue the stream rather than repeating it,
- and the result does not depend on where the call boundaries fall — `new(128).rand` matches `new(64).rand` twice, because each element is keyed by its own offset rather than by its thread.

`Cumo::RObject` still runs SFMT on the host, so it keeps the values it had.

## How the seed reaches the kernel

`srand` stores the seed and resets an offset counter; each launch takes `curand_init(seed, offset + i, 0, &state)` for element `i` and the offset advances by the number of elements drawn. Keying on the element rather than the thread is what makes the answer independent of the grid the launch happens to pick, and of how ndloop chunks the array.

Only the cuRAND **device** API is used, which is header-only — no `-lcurand`, and `extconf.rb` is untouched.

## Verified

- 62 checks over all 13 dtypes: same-seed reproducibility, successive calls differing, split-invariance, the `[low, high)` interval, views, and transposed views. 19 more for `rand_norm`, including mu and sigma over 1e6 draws and the complex case.
- Distribution: mean within 0.005 of 0.5 over 2^20 uniform draws, ten integer buckets even to 1%, `rand_norm` mean and stddev within 0.01.
- `compute-sanitizer --tool memcheck`: 0 errors across every dtype, views, transposed, reversed, and both one- and two-argument forms.
- `test_rand` in `narray_alt_coverage_test.rb` asserted numo's exact numbers; it now checks shape and interval, keeping the exact values only for `Cumo::RObject`. Pinning cuRAND's output would tie the suite to a CUDA version. The doc examples are regenerated from the current implementation.
- Full suite: 1422 tests, 17246 assertions, 0 failures.
