### PR TITLE
Fix integer sum and prod truncating every merged partial

### DIFF
--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -7,15 +7,15 @@
 
 struct cumo_<%=type_name%>_sum_impl {
     __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_zero; }
-    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
-    __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum = m_add(next, accum); }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum = m_add(next, accum); }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_prod_impl {
     __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_one; }
-    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
-    __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum = m_mul(next, accum); }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum = m_mul(next, accum); }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -5,17 +5,20 @@
 }  /* extern "C" { */
 #endif
 
+// Reduce also combines two accumulators, so next has to be the accumulator type:
+// the integer types widen to 64 bits and taking dtype there truncates every
+// partial the shared-memory tree merges.
 struct cumo_<%=type_name%>_sum_impl {
     __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_zero; }
-    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
-    __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum += next; }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum += next; }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_prod_impl {
     __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_one; }
-    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
-    __device__ void Reduce(dtype next, <%=dtype%>& accum) { accum *= next; }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum *= next; }
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1872,6 +1872,63 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case "integer #sum / #prod widen to 64 bits" do
+    # The shared-memory tree merges partials that have already outgrown the
+    # element type, so anything narrower than 64 bits has to survive the merge.
+    sum_widths = {
+      Cumo::Int8 => 5,
+      Cumo::Int16 => 12,
+      Cumo::Int32 => 30,
+      Cumo::Int64 => 50,
+      Cumo::UInt8 => 5,
+      Cumo::UInt16 => 12,
+      Cumo::UInt32 => 30,
+      Cumo::UInt64 => 50
+    }
+
+    sum_widths.each do |dtype, bits|
+      test "#{dtype}#sum over partials wider than the element" do
+        [4, 8, 64, 1024].each do |n|
+          assert_equal(n * (2**bits), dtype.new(n).fill(2**bits).sum)
+        end
+      end
+
+      test "#{dtype}#sum over a long sequence" do
+        a = dtype.new(100_000).seq
+        assert_equal(a.to_a.sum, a.sum)
+      end
+
+      test "#{dtype}#sum over an axis" do
+        a = dtype.new(4, 256).seq
+        rows = a.to_a
+        assert_equal(rows.map(&:sum), a.sum(axis: 1).to_a)
+        assert_equal(rows.transpose.map(&:sum), a.sum(axis: 0).to_a)
+      end
+    end
+
+    # A merged partial only outgrows a 32 bit element once the whole product has
+    # outgrown the 64 bit accumulator, so prod can only show this on 8 and 16 bit.
+    prod_values = {
+      Cumo::Int8 => 8,
+      Cumo::UInt8 => 8,
+      Cumo::Int16 => 32,
+      Cumo::UInt16 => 32
+    }
+
+    prod_values.each do |dtype, value|
+      test "#{dtype}#prod over partials wider than the element" do
+        assert_equal(value**8, dtype.new(8).fill(value).prod)
+      end
+    end
+
+    sum_widths.each_key do |dtype|
+      test "#{dtype}#prod over small values" do
+        a = dtype.new(6).seq(1)
+        assert_equal(a.to_a.reduce(:*), a.prod)
+      end
+    end
+  end
+
   sub_test_case "bincount" do
     int_types = [
       Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64,


### PR DESCRIPTION
`spec.rb` asks for a 64 bit accumulator on integer `sum` and `prod`, and `cumo_reduce` is instantiated with one. But the reduction impls declared

```c
__device__ void Reduce(dtype next, int64_t& accum) { accum += next; }
```

and `reduce_kernel.h` calls `Reduce` twice for two different things: once per element with a mapped input, and once per level of the shared-memory tree with **another accumulator** (`impl.Reduce(sdata[tid + stride], sdata[tid])`). Taking `dtype` there truncates every partial the tree merges back to the element type.

```ruby
Cumo::Int32.new(4).fill(2**30).sum      #=> 0             (numo: 4294967296)
Cumo::Int32.new(100_000).seq.sum        #=> 704982704     (numo: 4999950000)
Cumo::UInt8.new(4, 256).seq.sum(axis: 1) #=> [128, 128, 128, 128]  (numo: [32640, 32640, 32640, 32640])
```

`704982704` is `4999950000 mod 2**32`, which is the tell. The value is only wrong once a merged partial outgrows the element type, so small arrays answer correctly and it looks like an overflow in the input rather than in the reduction.

`Int64` and `UInt64` were right because their accumulator is the element type, so the truncation was a no-op. Everything narrower was affected: 32 of 96 comparisons against numo-narray-alt 0.11.2 disagreed, over `Int8`, `Int16`, `Int32`, `UInt8`, `UInt16` and `UInt32`, flat and over an axis.

`Reduce` now takes the accumulator type on both sides, and `MapIn` returns it too so the widening is where the mapping happens. The float and complex types are unaffected either way, since their accumulator is already the element type — the complex impls carried the same signature and are made consistent so the next reader does not have to re-derive that it happens to be harmless there.

## Verified

- 96 comparisons against numo-narray-alt 0.11.2 over all eight integer types and the four float and complex ones: sequences, fills chosen so a merged partial outgrows the element, `prod`, and reductions over each axis. All match; 32 of them did not before.
- The new tests fail on master with 19 failures.
- `compute-sanitizer --tool memcheck`: 0 errors. The accumulator type itself is unchanged, so the shared-memory layout is the same as before.
- Full suite: 1458 tests, 17314 assertions, 0 failures.

`prod` can only show this on 8 and 16 bit: a merged partial does not outgrow a 32 bit element until the whole product has already outgrown the 64 bit accumulator.
