### PR TITLE
Raise on a numeric index into an unallocated NArray

### DIFF
--- a/ext/cumo/narray/gen/tmpl/aref.c
+++ b/ext/cumo/narray/gen/tmpl/aref.c
@@ -61,6 +61,12 @@ static VALUE
         size_t pos;
 
         result_nd = cumo_na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
+        if (result_nd == 0) {
+            // Numeric indices read an element, so an unallocated array has to
+            // raise here. Returning the view instead only defers it to whatever
+            // touches the data, and each_over_axis never does.
+            (void)cumo_na_get_pointer_for_read(self);
+        }
         return cumo_na_aref_main(argc, argv, self, 0, result_nd, pos);
     }
 }

--- a/ext/cumo/narray/gen/tmpl_bit/aref.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aref.c
@@ -43,6 +43,12 @@ static VALUE
         size_t pos;
 
         result_nd = cumo_na_get_result_dimension(self, argc, argv, 1, &pos);
+        if (result_nd == 0) {
+            // Numeric indices read an element, so an unallocated array has to
+            // raise here. Returning the view instead only defers it to whatever
+            // touches the data, and each_over_axis never does.
+            (void)cumo_na_get_pointer_for_read(self);
+        }
         return cumo_na_aref_main(argc, argv, self, 0, result_nd, pos);
     }
 }

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -168,8 +168,26 @@ class NArrayExtraTest < CumoTestBase
   end
 
   def test_each_over_axis_on_an_unallocated_array
-    omit("Cumo yields the array instead of raising on an unallocated one")
     assert_raise(RuntimeError) { Cumo::DFloat.new.each_over_axis { |_v| nil } }
+
+    # Above zero dimensions it yields slices, which stay views whether or not
+    # the array is allocated.
+    yielded = []
+    Cumo::DFloat.new(2, 3).each_over_axis { |v| yielded << v.shape }
+    assert_equal([[3], [3]], yielded)
+  end
+
+  def test_aref_on_an_unallocated_array
+    # A numeric index reads an element, so it has to raise rather than hand back
+    # a view of memory that was never allocated.
+    assert_raise(RuntimeError) { Cumo::DFloat.new(3)[1] }
+    assert_raise(RuntimeError) { Cumo::DFloat.new(4, 5)[1, 1] }
+    assert_raise(RuntimeError) { Cumo::Bit.new(3)[1] }
+    assert_raise(RuntimeError) { Cumo::RObject.new(3)[1] }
+
+    # A slice stays a view, allocated or not.
+    assert_equal([2], Cumo::DFloat.new(3)[0..1].shape)
+    assert_equal(2.0, Cumo::DFloat.new(3).seq(1)[1].extract_cpu)
   end
 
   def test_append


### PR DESCRIPTION
A numeric index reads an element, so numo raises on an array that was never allocated:

```ruby
Numo::DFloat.new(3)[0]   #=> RuntimeError: cannot read unallocated NArray
```

`aref_cpu` does the same, because it goes through `cumo_na_get_pointer_for_read`. The default path returns the zero-dimensional view instead and never touches the pointer, so nothing raised until something else read the data — and `each_over_axis` never does:

```ruby
Cumo::DFloat.new(3)[0]                          #=> Cumo::DFloat(view)#shape=[]
Cumo::DFloat.new.each_over_axis { |v| p v }     # yielded a view of memory that does not exist
```

`each_over_axis` is where it surfaces because `idx[axis] = i` on the empty index array of a zero-dimensional receiver appends rather than replaces, turning `a[]` — which did raise — into `a[0]`, which did not.

The default path now takes the same pointer as `aref_cpu` when the result is zero-dimensional. It is a NULL check, not a read, so nothing is copied and nothing synchronizes; slices are untouched and stay views whether or not the array is allocated. `Cumo::Bit` carries the same fix.

This does not change what `[]` returns. A numeric index still answers a zero-dimensional NArray rather than a Ruby scalar unless `Cumo.enable_compatible_mode` is on.

## Verified

- Unallocated `DFloat`, `Bit` and `RObject` now raise for `[0]` and `[1, 1]`, matching numo-narray-alt 0.11.2; ranges still return an empty view, and an allocated array is unaffected.
- `test_each_over_axis_on_an_unallocated_array` was omitted and now runs. Above zero dimensions `each_over_axis` yields slices, so it keeps working on an unallocated array there — the test pins that too.
- Both tests fail on master.
- Full suite: 1459 tests, 17322 assertions, 0 failures, omissions down from 2 to 1.
