### PR TITLE
Fix from_binary and store_binary racing with running kernels

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -700,6 +700,8 @@ cumo_na_pointer_copy_on_write(VALUE self)
     }
     CUMO_NA_DATA_PTR(na) = NULL;
     rb_funcall(self, cumo_id_allocate, 0);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_pointer_copy_on_write", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     memcpy(CUMO_NA_DATA_PTR(na), ptr, byte_size);
     rb_ivar_set(self, cumo_id_source, Qnil);
 }
@@ -1440,6 +1442,11 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
     vna = cumo_na_new(type, nd, shape);
     ptr = cumo_na_get_pointer_for_write(vna);
 
+    // The pool hands back chunks a still-running kernel may be writing, and a
+    // host write into managed memory does not wait for the stream. to_binary
+    // synchronizes for the same reason on the way out.
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_s_from_binary", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     memcpy(ptr, RSTRING_PTR(vstr), byte_size);
 
     return vna;
@@ -1495,6 +1502,8 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
         rb_ivar_set(self, cumo_id_source, vstr);
     } else {
         void *ptr = cumo_na_get_pointer_for_write(self);
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_store_binary", "any");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         memcpy(ptr, RSTRING_PTR(vstr)+offset, byte_size);
     }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2015,6 +2015,40 @@ class NArrayTest < Test::Unit::TestCase
   # These all run a host loop over managed memory, so they read whatever the
   # last kernel has written so far unless they synchronize first. The arrays
   # are large enough that the kernel filling them is still in flight.
+  # A host memcpy into managed memory does not wait for the stream, and the pool
+  # hands back chunks a still-running kernel may be writing.
+  sub_test_case "host writes synchronize before touching device memory" do
+    n = 1 << 18
+    rounds = 30
+
+    test "from_binary over a recycled chunk" do
+      zeros = ("\0" * (n * 8)).freeze
+      rounds.times do
+        a = Cumo::DFloat.new(n).seq(1)
+        a.free
+        b = Cumo::DFloat.from_binary(zeros)
+        Cumo::CUDA::Runtime.cudaDeviceSynchronize
+        assert_equal(0, b.ne(0.0).count_true.to_i)
+      end
+    end
+
+    test "store_binary over memory a kernel is still writing" do
+      rounds.times do
+        a = Cumo::DFloat.new(n).seq(1)
+        a.store_binary(+("\0" * (n * 8)))
+        Cumo::CUDA::Runtime.cudaDeviceSynchronize
+        assert_equal(0, a.ne(0.0).count_true.to_i)
+      end
+    end
+
+    # A frozen string is pointed at rather than copied, so nothing is written.
+    test "store_binary of a frozen string" do
+      a = Cumo::DFloat.new(n).seq(1)
+      a.store_binary(("\0" * (n * 8)).freeze)
+      assert_equal(0, a.ne(0.0).count_true.to_i)
+    end
+  end
+
   sub_test_case "host loops synchronize before reading device memory" do
     n = 1 << 20
     last = n.to_f


### PR DESCRIPTION
A host `memcpy` into managed memory does not wait for the stream, and the pool hands back chunks a still-running kernel may be writing. `to_binary` and `marshal_dump` synchronize before reading for that reason; the three sites that write did not.

```ruby
n = 1 << 22
zeros = ("\0" * (n * 8)).freeze
a = Cumo::DFloat.new(n).seq(1)   # the kernel is still running
a.free                           # the chunk goes back to the pool
b = Cumo::DFloat.from_binary(zeros)
Cumo::CUDA::Runtime.cudaDeviceSynchronize
b.ne(0.0).count_true             #=> 88832 of 4194304 on one run
```

Reproduced over 20 rounds at a time:

| | corrupted |
|---|---|
| `from_binary` onto a recycled chunk | 20 of 30 rounds, up to 88832 of 4194304 elements |
| `store_binary` of a mutable string | 5 of 30 rounds |
| `store_binary` of a frozen string | 0 of 30 — it points at the string's bytes rather than copying |

`cumo_na_pointer_copy_on_write` allocates from the pool and copies into it the same way. I could not get it to race, so that one is fixed by pattern rather than from a reproduction.

`marshal_load` looked like a fourth site but is not one: it hands the string to `store_binary`, and its own `memcpy` is the `Cumo::RObject` branch, which is `xmalloc`ed host memory.

## Cost

One `cudaDeviceSynchronize` on calls that already do an O(n) host copy, and it costs nothing when the queue is empty:

| | before | after |
|---|---|---|
| `from_binary` n=1e6 | 1466.5 us | 1489.9 us |
| `store_binary` n=1e6 | 1439.7 us | 1466.0 us |
| `from_binary` n=1000 | 3.3 us | 3.5 us |
| `to_binary` (already synchronized) | 436.4 us | 444.4 us |

## Verified

- The two reproducible races are clean over 100 rounds after the fix, having been caught 20 of 30 and 5 of 30 before it.
- The new tests use 30 rounds at 1 << 18 elements, where the miss rate per round is about 35% and 60%, so a broken build gets past them with probability under 1e-8. They fail on master.
- Full suite: 1462 tests, 17383 assertions, 0 failures.
