### PR TITLE
Fix the GC free hook raising when a device free fails

### DIFF
--- a/ext/cumo/cuda/memory_pool.cpp
+++ b/ext/cumo/cuda/memory_pool.cpp
@@ -4,6 +4,7 @@
 #include "cumo/cuda/memory_pool.h"
 #include "cumo/cuda/runtime.h"
 
+#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -47,8 +48,8 @@ cumo_cuda_runtime_malloc(size_t size)
     return 0; // should not reach here
 }
 
-void
-cumo_cuda_runtime_free(char *ptr)
+static cudaError_t
+runtime_free(char *ptr)
 {
     // Always offer the pointer to the pool first, whatever memory_pool_enabled
     // says now: MemoryPool.enable/disable is public, so the state can differ
@@ -57,14 +58,33 @@ cumo_cuda_runtime_free(char *ptr)
     // which is not at the head of its buffer.
     try {
         if (pool.Free(reinterpret_cast<intptr_t>(ptr))) {
-            return;
+            return cudaSuccess;
         }
     } catch (const cumo::internal::CUDARuntimeError& e) {
-        cumo_cuda_runtime_check_status(e.status());
-        return;
+        return e.status();
     }
     // No pool owns it, so it came straight from cudaMallocManaged.
-    cumo_cuda_runtime_check_status(cudaFree((void*)ptr));
+    return cudaFree((void*)ptr);
+}
+
+void
+cumo_cuda_runtime_free(char *ptr)
+{
+    cumo_cuda_runtime_check_status(runtime_free(ptr));
+}
+
+void
+cumo_cuda_runtime_free_no_raise(char *ptr)
+{
+    cudaError_t status = runtime_free(ptr);
+    // rb_raise from a GC free hook longjmps out of the sweep, so report the
+    // failure the way ~Memory does. cudaFree only fails once the context is
+    // unusable, and the next runtime call reports the same status anyway.
+    if (status == cudaSuccess || status == cudaErrorCudartUnloading) {
+        return;
+    }
+    std::fprintf(stderr, "cumo: failed to free device memory: %s (error=%d)\n",
+                 cudaGetErrorString(status), static_cast<int>(status));
 }
 
 /*

--- a/ext/cumo/include/cumo/cuda/memory_pool.h
+++ b/ext/cumo/include/cumo/cuda/memory_pool.h
@@ -18,6 +18,11 @@ cumo_cuda_runtime_malloc(size_t size);
 void
 cumo_cuda_runtime_free(char *ptr);
 
+// For GC free hooks, which cannot take a raise: reports a failed free on stderr
+// instead of raising.
+void
+cumo_cuda_runtime_free_no_raise(char *ptr);
+
 #if defined(__cplusplus)
 #if 0
 { /* satisfy cc-mode */

--- a/ext/cumo/narray/gen/tmpl/alloc_func.c
+++ b/ext/cumo/narray/gen/tmpl/alloc_func.c
@@ -42,7 +42,7 @@ static void
   <% if is_object %>
             xfree(na->ptr);
   <% else %>
-            cumo_cuda_runtime_free(na->ptr);
+            cumo_cuda_runtime_free_no_raise(na->ptr);
             rb_gc_adjust_memory_usage(-(ssize_t)<%=type_name%>_data_bytes(na));
   <% end %>
         }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -172,7 +172,7 @@ cumo_na_view_free(void* ptr)
         for (i=0; i<na->base.ndim; i++) {
             if (CUMO_SDX_IS_INDEX(na->stridx[i])) {
                 void *idx = CUMO_SDX_GET_INDEX(na->stridx[i]);
-                cumo_cuda_runtime_free(idx);
+                cumo_cuda_runtime_free_no_raise(idx);
             }
         }
         xfree(na->stridx);

--- a/test/cuda/memory_pool_test.rb
+++ b/test/cuda/memory_pool_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "tempfile"
 
 module Cumo::CUDA
   class MemoryPoolTest < Test::Unit::TestCase
@@ -64,6 +65,69 @@ module Cumo::CUDA
       1024.times { Cumo::Bit.new(1 << 23).allocate }
       GC.start
       assert { MemoryPool.total_bytes - base < 256 << 20 }
+    end
+
+    # Destroying the context leaves every pointer allocated under it invalid, so
+    # cudaFree fails for the rest of the process. That has to be reported rather
+    # than raised: the free runs from the GC sweep, where a raise surfaces at
+    # whatever line happened to trigger the collection. Needs a fresh
+    # interpreter because it makes CUDA unusable for good.
+    def test_a_failing_free_from_the_gc_hook_does_not_raise
+      lib = File.expand_path("../../lib", __dir__)
+      script = <<~'RUBY'
+        require "cumo/narray"
+        require "fiddle"
+
+        # Unbuffered, or the answer is lost with the process when the raise the
+        # test is about takes the interpreter down with it.
+        STDOUT.sync = true
+
+        name = %w[cuCtxDestroy_v2 cuCtxDestroy].find do |sym|
+          begin
+            Fiddle::Handle::DEFAULT[sym]
+            true
+          rescue Fiddle::DLError
+            false
+          end
+        end
+        if name.nil?
+          print "no-cuCtxDestroy"
+          exit
+        end
+        destroy = Fiddle::Function.new(Fiddle::Handle::DEFAULT[name],
+                                       [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+
+        def make_garbage
+          200.times { Cumo::DFloat.new(4096).seq }
+          nil
+        end
+
+        # A pooled chunk goes back to the free list without a CUDA call, so the
+        # free only reaches cudaFree for memory allocated with the pool off.
+        Cumo::CUDA::MemoryPool.disable
+
+        GC.disable
+        make_garbage
+        ctx = Cumo::CUDA::Driver.cuCtxGetCurrent
+
+        STDERR.reopen(ARGV.fetch(0), "w")
+        destroy.call(ctx)
+        GC.enable
+        begin
+          GC.start
+          print "ok"
+        rescue Exception => e
+          print "raised #{e.class}"
+        end
+      RUBY
+
+      Tempfile.create("cumo-free-hook") do |log|
+        out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script, log.path], &:read)
+        omit("cuCtxDestroy is not available") if out == "no-cuCtxDestroy"
+        assert_equal("ok", out)
+        # Without this the test passes even when nothing was freed at all.
+        assert_match(/failed to free device memory/, log.read)
+      end
     end
 
     def test_malloc_with_size_whose_rounding_overflows


### PR DESCRIPTION
## Summary

The free hook a `Cumo::NArray` registers with the GC releases its device memory through `cumo_cuda_runtime_free`, which raises `Cumo::CUDA::RuntimeError` when the free fails. Raising from there longjmps out of the sweep. Report the failure on stderr instead, the way `Memory::~Memory` already does for the same reason. `cumo_cuda_runtime_free` keeps raising for the call sites which are not GC hooks.

## Problem

`cudaFree` fails for every pointer belonging to a context once that context is gone — after a faulting kernel leaves a sticky error, or once the context itself is destroyed. Measured on RTX 5070 Ti Laptop / CUDA 13.0, with the memory pool off so that the free reaches `cudaFree` (a pooled chunk goes back to the free list without a CUDA call):

| trigger | master | this PR |
|---|---|---|
| `GC.start` after the context is destroyed | `Cumo::CUDA::RuntimeError: invalid argument (error=1)` | returns normally |
| `GC.start` after a faulting kernel | `Cumo::CUDA::RuntimeError: ... (error=700)` | returns normally |
| `RUBY_FREE_AT_EXIT=1` teardown after a faulting kernel | **SIGSEGV** | exits 0 |

The exception surfaces at whatever line happened to trigger the collection, so the reported error has nothing to do with the code it points at. The `RUBY_FREE_AT_EXIT=1` run is the control for that: the same script without the fault exits cleanly.

The new test destroys the context with `cuCtxDestroy` through `fiddle` and asserts that `GC.start` returns. It runs in a fresh interpreter because it leaves CUDA unusable, and it also asserts that the failure was reported — otherwise it would pass even when nothing was freed at all.

## Note

The free is still not synchronized against work the GPU may still be doing on that buffer, which is the other half of the original report. Everything cumo launches goes on stream 0, so a chunk the pool hands out again is written by a kernel ordered behind the one that was reading it; the host-side writes that do bypass that ordering were the subject of #177 and #226. A `cudaDeviceSynchronize` per freed array would cost far more than it buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaUsqaorWdvogdQuijsMnB
