### PR TITLE
Fix a failed Array store leaking its staging buffer

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -3,12 +3,6 @@ void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t *idx1, dtype* z,
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, dtype* z, uint64_t n);
 void <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(char *p1, size_t *idx1, dtype z, uint64_t n);
 void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(char *p1, ssize_t s1, dtype z, uint64_t n);
-
-static void CUDART_CB
-<%=c_iter%>_callback(cudaStream_t stream, cudaError_t status, void *data)
-{
-    xfree(data);
-}
 //<% end %>
 
 static void
@@ -118,11 +112,12 @@ static void
         // 2. copy to contiguous device memory
         // 3. launch kernel to copy the contiguous device memory into strided (or indexed) narray cuda memory
         // 4. free the contiguous device memory
-        // 5. run callback to free the heap memory after kernel finishes
         //
-        // FYI: We may have to care of cuda stream callback serializes stream execution when we support stream.
-        // https://devtalk.nvidia.com/default/topic/822942/why-does-cudastreamaddcallback-serialize-kernel-execution-and-break-concurrency-/
-        dtype* host_z = ALLOC_N(dtype, n);
+        // The staging buffer is held by a Ruby object rather than a plain local:
+        // the conversion loop below raises for a value which is not a number,
+        // and ndloop has no way to free a buffer it does not know about.
+        VALUE  buf;
+        dtype* host_z = RB_ALLOCV_N(dtype, buf, n);
         for (i=i1=0; i1<n1 && i<n; i1++) {
             if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
@@ -144,13 +139,12 @@ static void
 
         if (!idx1 && s1 == sizeof(dtype)) {
             // optimization: Since p1 is contiguous, we skip creating another contiguous device memory
-            cudaError_t status = cudaMemcpyAsync(p1,host_z,sizeof(dtype)*i,cudaMemcpyHostToDevice,0);
-            if (status == 0) {
-                cumo_cuda_runtime_check_status(cudaStreamAddCallback(0,<%=c_iter%>_callback,host_z,0));
-            } else {
-                xfree(host_z);
-            }
-            cumo_cuda_runtime_check_status(status);
+            //
+            // host_z is pageable, so cudaMemcpyAsync only returns once it has
+            // been copied into the driver's staging buffer and the buffer may
+            // be released right away.
+            cumo_cuda_runtime_check_status(
+                cudaMemcpyAsync(p1,host_z,sizeof(dtype)*i,cudaMemcpyHostToDevice,0));
         } else {
             dtype* device_z = (dtype*)cumo_cuda_runtime_malloc(sizeof(dtype) * n);
             cudaError_t status = cudaMemcpyAsync(device_z,host_z,sizeof(dtype)*i,cudaMemcpyHostToDevice,0);
@@ -166,12 +160,10 @@ static void
                 // for the stream, so the kernel would read the new contents.
                 status = cudaStreamSynchronize(0);
             }
-            // Freeing here rather than from a stream callback: the copy is over
-            // by now, and a callback may not call the CUDA API anyway.
-            xfree(host_z);
             cumo_cuda_runtime_free((void*)device_z);
             cumo_cuda_runtime_check_status(status);
         }
+        RB_ALLOCV_END(buf);
     }
     //<% end %>
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2184,4 +2184,32 @@ class NArrayTest < Test::Unit::TestCase
     # the leak alone was 20_000 * 500 * 8 bytes = 78 MB
     assert { grew < 40_000 }
   end
+
+  test "a store which raises does not leak its staging buffer" do
+    # Storing a Ruby Array stages the values in a host buffer as wide as the
+    # destination. m_num_to_data raises for a value which is not a number, and
+    # the buffer used to be a plain malloc ndloop knew nothing about, so every
+    # failed store leaked all of it.
+    omit "needs /proc/self/status" unless File.readable?("/proc/self/status")
+    # Address space rather than RSS: the buffer is not zero filled, so a store
+    # which fails on the second element only ever touches its first page.
+    vm_size = -> { File.read("/proc/self/status")[/VmSize:\s+(\d+)/, 1].to_i }
+
+    n = 1 << 19 # 4 MiB of DFloat
+    a = Cumo::DFloat.new(n)
+    a.store(0)
+    bad = [1, "x"]
+    assert_raise(TypeError) { a.store(bad) }
+    GC.start
+
+    before = vm_size.call
+    100.times do
+      a.store(bad)
+    rescue TypeError
+      nil
+    end
+    GC.start
+    # the leak alone was 100 * 4 MiB = 400 MiB
+    assert { vm_size.call - before < 100 * 1024 }
+  end
 end


### PR DESCRIPTION
## Summary

Storing a Ruby Array copies the values into a host buffer as wide as the destination before handing them to the device. The buffer came from `ALLOC_N`, a plain local `ndloop` knows nothing about, so any raise between the allocation and the free leaked all of it. Take it from `RB_ALLOCV_N` instead, which leaves it to the GC when the frame is left through a raise.

## Problem

The loop filling that buffer calls `m_num_to_data`, which raises for a value that is not a number, and the caller picks how much is lost:

```ruby
a = Cumo::DFloat.new(1 << 19)   # 4 MiB
100.times { a.store([1, "x"]) rescue nil }
```

| | master | this PR |
|---|---|---|
| `VmSize` growth | +410,000 KB | ±0 KB |
| `VmRSS` growth, values before the bad one filling the buffer | +410,000 KB | ±0 KB |

409,600 KB is what 100 buffers of 4 MiB account for. `ALLOC_N` does not zero its memory, so a store failing on the second element only ever touches the first page of each buffer — the address space is where it shows unless the input fills it first. numo has no such buffer; it came in with the port.

The kernel launch check added in #195 and the `cumo_cuda_runtime_malloc` for the strided branch raise between the same two points, so they leaked it too.

## Note

This also removes the stream callback the contiguous branch used to free the buffer from. `cudaMemcpyAsync` out of pageable host memory only returns once the source has been copied into the driver's staging buffer, so the buffer may be released as soon as it returns — the same reasoning as #176, and the file's own FYI comment already noted that a stream callback serializes stream execution. Small stores get most of their time back (median of 3 runs, 4 elements): **22.6 us → 3.7 us**. A 1e6 element store is unchanged either way (contiguous 6688 → 6655 us, strided 6702 → 6663 us), being dominated by walking the Ruby Array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaUsqaorWdvogdQuijsMnB
