### PR TITLE
Fix rb_raise from inside a C++ catch leaking the exception object

### DIFF
--- a/ext/cumo/cuda/memory_pool.cpp
+++ b/ext/cumo/cuda/memory_pool.cpp
@@ -20,30 +20,77 @@ static bool memory_pool_enabled;
 
 VALUE cumo_cuda_eOutOfMemoryError;
 
+// How a call into the pool ended, so that the raise can wait until the handler
+// has been left. rb_raise longjmps, and a longjmp out of an active handler
+// skips __cxa_end_catch: the exception object is never destroyed and leaks for
+// the life of the process.
+enum pool_outcome {
+    POOL_OK,
+    POOL_CUDA_ERROR,
+    POOL_OUT_OF_MEMORY,
+    POOL_UNKNOWN_ERROR,
+};
+
+struct pool_error {
+    cudaError_t status;
+    char message[256];
+};
+
+static enum pool_outcome
+pool_malloc(size_t size, char **ptr, struct pool_error *err)
+{
+    try {
+        // TODO(sonots): Get current CUDA stream and pass it
+        *ptr = reinterpret_cast<char*>(pool.Malloc(size));
+        return POOL_OK;
+    } catch (const cumo::internal::CUDARuntimeError& e) {
+        err->status = e.status();
+        return POOL_CUDA_ERROR;
+    } catch (const cumo::internal::OutOfMemoryError& e) {
+        // A std::string here would in turn be leaked by the raise.
+        std::snprintf(err->message, sizeof(err->message), "%s", e.what());
+        return POOL_OUT_OF_MEMORY;
+    } catch (const std::exception& e) {
+        // Nothing may reach the C caller: it has no handler, so an escaping
+        // exception is std::terminate.
+        std::snprintf(err->message, sizeof(err->message), "%s", e.what());
+        return POOL_UNKNOWN_ERROR;
+    } catch (...) {
+        std::snprintf(err->message, sizeof(err->message), "unknown C++ exception");
+        return POOL_UNKNOWN_ERROR;
+    }
+}
+
 char*
 cumo_cuda_runtime_malloc(size_t size)
 {
-    if (memory_pool_enabled) {
-        try {
-            // TODO(sonots): Get current CUDA stream and pass it
-            return reinterpret_cast<char*>(pool.Malloc(size));
-        } catch (const cumo::internal::CUDARuntimeError& e) {
-            cumo_cuda_runtime_check_status(e.status());
-        } catch (const cumo::internal::OutOfMemoryError& e) {
-            // retry after GC
-            rb_funcall(rb_define_module("GC"), rb_intern("start"), 0);
-            try {
-                return reinterpret_cast<char*>(pool.Malloc(size));
-            } catch (const cumo::internal::CUDARuntimeError& e) {
-                cumo_cuda_runtime_check_status(e.status());
-            } catch (const cumo::internal::OutOfMemoryError& e) {
-                rb_raise(cumo_cuda_eOutOfMemoryError, "%s", e.what());
-            }
-        }
-    } else {
-        void *ptr = 0;
-        cumo_cuda_runtime_check_status(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
-        return reinterpret_cast<char*>(ptr);
+    char *ptr = 0;
+    struct pool_error err;
+    enum pool_outcome outcome;
+
+    if (!memory_pool_enabled) {
+        void *raw = 0;
+        cumo_cuda_runtime_check_status(cudaMallocManaged(&raw, size, cudaMemAttachGlobal));
+        return reinterpret_cast<char*>(raw);
+    }
+
+    outcome = pool_malloc(size, &ptr, &err);
+    if (outcome == POOL_OUT_OF_MEMORY) {
+        // retry after GC
+        rb_funcall(rb_define_module("GC"), rb_intern("start"), 0);
+        outcome = pool_malloc(size, &ptr, &err);
+    }
+
+    switch (outcome) {
+    case POOL_OK:
+        return ptr;
+    case POOL_CUDA_ERROR:
+        cumo_cuda_runtime_check_status(err.status);
+        break;
+    case POOL_OUT_OF_MEMORY:
+        rb_raise(cumo_cuda_eOutOfMemoryError, "%s", err.message);
+    case POOL_UNKNOWN_ERROR:
+        rb_raise(rb_eRuntimeError, "%s", err.message);
     }
     return 0; // should not reach here
 }
@@ -62,6 +109,8 @@ runtime_free(char *ptr)
         }
     } catch (const cumo::internal::CUDARuntimeError& e) {
         return e.status();
+    } catch (...) {
+        return cudaErrorUnknown;
     }
     // No pool owns it, so it came straight from cudaMallocManaged.
     return cudaFree((void*)ptr);
@@ -130,17 +179,22 @@ rb_memory_pool_enabled_p(VALUE self)
 static VALUE
 rb_memory_pool_free_all_blocks(int argc, VALUE* argv, VALUE self)
 {
+    // TODO(sonots): FIX if we create a Stream object
+    cudaStream_t stream_ptr = (argc < 1) ? 0 : (cudaStream_t)NUM2SIZET(argv[0]);
+    cudaError_t status = cudaSuccess;
+
     try {
         if (argc < 1) {
             pool.FreeAllBlocks();
         } else {
-            // TODO(sonots): FIX if we create a Stream object
-            cudaStream_t stream_ptr = (cudaStream_t)NUM2SIZET(argv[0]);
             pool.FreeAllBlocks(stream_ptr);
         }
     } catch (const cumo::internal::CUDARuntimeError& e) {
-        cumo_cuda_runtime_check_status(e.status());
+        status = e.status();
+    } catch (...) {
+        status = cudaErrorUnknown;
     }
+    cumo_cuda_runtime_check_status(status);
     return Qnil;
 }
 

--- a/test/cuda/memory_pool_test.rb
+++ b/test/cuda/memory_pool_test.rb
@@ -130,6 +130,41 @@ module Cumo::CUDA
       end
     end
 
+    # Both handlers around pool.Malloc used to raise from inside the catch, and
+    # rb_raise longjmps: __cxa_end_catch never runs, so the exception object is
+    # never destroyed. An allocation which fails twice has two of them live.
+    # In a fresh interpreter, because the retry runs GC.start and marking this
+    # suite's heap makes each failed allocation eight times more expensive.
+    def test_a_failing_allocation_does_not_leak_the_cxx_exception
+      omit "needs /proc/self/status" unless File.readable?("/proc/self/status")
+      lib = File.expand_path("../../lib", __dir__)
+      script = <<~'RUBY'
+        require "cumo/narray"
+
+        rss = -> { Integer(File.read("/proc/self/status")[/VmRSS:\s+(\d+)/, 1], 10) }
+        too_big = (2**61) - 1
+        burn = lambda do |n|
+          n.times do
+            Cumo::DFloat.new(too_big).allocate
+          rescue Cumo::CUDA::OutOfMemoryError
+            nil
+          end
+        end
+
+        burn.call(200)
+        GC.start
+        before = rss.call
+        burn.call(2000)
+        GC.start
+        print "rss:#{rss.call - before}"
+      RUBY
+
+      out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+      assert_match(/\Arss:-?\d+\z/, out)
+      # the leak alone was 1060 KB for 2000 failed allocations
+      assert { Integer(out[/-?\d+/], 10) < 256 }
+    end
+
     def test_malloc_with_size_whose_rounding_overflows
       MemoryPool.enable
       # 8 * (2**61 - 1) is SIZE_MAX - 7. Rounding it up to a multiple of the


### PR DESCRIPTION
## Summary

The handlers around `pool.Malloc` raised while they were still running. `rb_raise` longjmps, so `__cxa_end_catch` never ran and the exception object was never destroyed. Record the outcome in the catch and return, then raise once the handler has been left — the shape `cumo_cuda_runtime_free` already has since #227.

## Problem

Measured on RTX 5070 Ti Laptop / CUDA 13.0, with the memory pool off as the control: that path does the same Ruby work and raises the same exception class, but reaches `rb_raise` without a C++ handler on the stack.

| failing allocation | live handlers | pool on | pool off |
|---|---|---|---|
| after a sticky CUDA error | 1 | **259 B each** | 3 B each |
| `Cumo::DFloat.new(2**61 - 1)` | 2 | **544 B each** | 59 B each |

Over 200,000 and 20,000 failures respectively. The leak scales with the number of live handlers, which is what pins the cause; a standalone probe agrees, running 0 destructors for 200,000 longjmps out of a catch against 200,000 when the catch is left by `return`. `Cumo::DFloat.new(2**61 - 1)` needs nothing unusual to reach, and the `GC.start` on its retry path makes it the expensive one: 20,000 of them take 10.0 s with the pool on against 0.0 s with it off.

The message now goes into a plain buffer instead of a `std::string`, which the raise would leak in turn.

## Note

The handlers are also widened to `catch (...)`. An exception neither of them names has no handler in the C caller either, so it is `std::terminate`; a C caller and a C++ callee throwing `std::bad_alloc` does abort that way, but nothing in the pool was shown to throw one, so that half is a precaution rather than a fix for something observed.

What is *not* affected: `__cxa_get_globals()->caughtExceptions` was left non-null and growing by the old code, but `uncaughtExceptions` was untouched and later throw/catch kept working. The only reachable consequence would be a bare `throw;` at top level rethrowing a stale exception, and both `throw;` in this codebase sit inside their own handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaUsqaorWdvogdQuijsMnB
