### PR TITLE
Add isnan kernel for the cond_unary template

### DIFF
--- a/ext/cumo/narray/gen/tmpl/cond_unary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_unary.c
@@ -1,34 +1,54 @@
+<% unless type_name == 'robject' %>
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n);
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n);
+<% end %>
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t    i;
+    size_t    n;
     char     *p1;
     CUMO_BIT_DIGIT *a2;
     size_t    p2;
     ssize_t   s1, s2;
     size_t   *idx1;
-    dtype     x;
-    CUMO_BIT_DIGIT b;
-    CUMO_INIT_COUNTER(lp, i);
+
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_BIT(lp, 1, a2, p2, s2);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    if (idx1) {
-        for (; i--;) {
-            CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
-            b = (m_<%=name%>(x)) ? 1:0;
-            CUMO_STORE_BIT(a2,p2,b);
-            p2+=s2;
-        }
-    } else {
-        for (; i--;) {
-            CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-            b = (m_<%=name%>(x)) ? 1:0;
-            CUMO_STORE_BIT(a2,p2,b);
-            p2+=s2;
+
+    <% if type_name == 'robject' %>
+    {
+        size_t i;
+        dtype x;
+        CUMO_BIT_DIGIT b;
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        if (idx1) {
+            for (i=0; i<n; i++) {
+                CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
+                b = (m_<%=name%>(x)) ? 1:0;
+                CUMO_STORE_BIT(a2,p2,b);
+                p2+=s2;
+            }
+        } else {
+            for (i=0; i<n; i++) {
+                CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
+                b = (m_<%=name%>(x)) ? 1:0;
+                CUMO_STORE_BIT(a2,p2,b);
+                p2+=s2;
+            }
         }
     }
+    <% else %>
+    {
+        if (idx1) {
+            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,a2,p2,idx1,s2,n);
+        } else {
+            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,a2,p2,s1,s2,n);
+        }
+    }
+    <% end %>
 }
 
 /*

--- a/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
@@ -1,0 +1,35 @@
+<% unless type_name == 'robject' %>
+__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1 + idx1[i]);
+        CUMO_BIT_DIGIT b = (m_<%=name%>(x)) ? 1:0;
+        CUMO_STORE_BIT(a2,p2+(i*s2),b);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        CUMO_BIT_DIGIT b = (m_<%=name%>(x)) ? 1:0;
+        CUMO_STORE_BIT(a2,p2+(i*s2),b);
+    }
+}
+
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,a2,p2,idx1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,a2,p2,s1,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2243,4 +2243,46 @@ class NArrayTest < Test::Unit::TestCase
       assert_equal(dtype[1, 2], dtype[-1, 2].abs)
     end
   end
+
+  def cond_unary_expect(meth, val)
+    case meth
+    when :isnan then val.nan?
+    when :isinf then val.infinite?
+    when :isposinf then val.infinite? == 1
+    when :isneginf then val.infinite? == -1
+    when :isfinite then val.finite?
+    end
+  end
+
+  test "cond_unary over long arrays and views" do
+    inf = Float::INFINITY
+    n = 200
+    specials = { 0 => Float::NAN, 1 => inf, 2 => -inf }
+    values = Array.new(n) { |i| specials.fetch(i % 7, i - 100.0) }
+    a = Cumo::DFloat.cast(values)
+    stepped = (0...n).step(3).to_a
+    picked = [5, 0, 199, 64, 63, 32, 31, 100]
+    # a strided 2-d view runs the loop once per row, so the result starts at a
+    # bit offset which is not a multiple of the bit-digit width
+    cols = (0...25).step(2).to_a
+    grid = (0...8).flat_map { |r| cols.map { |c| (r * 25) + c } }
+
+    [:isnan, :isinf, :isposinf, :isneginf, :isfinite].each do |meth|
+      bits = ->(idxs) { Cumo::Bit.cast(idxs.map { |i| cond_unary_expect(meth, values[i]) ? 1 : 0 }) }
+      assert_equal(bits.call((0...n).to_a), a.public_send(meth), meth)
+      assert_equal(bits.call(stepped), a[(0...n).step(3)].public_send(meth), meth)
+      assert_equal(bits.call(picked), a[picked].public_send(meth), meth)
+      actual = a.reshape(8, 25)[true, (0...25).step(2)].public_send(meth)
+      assert_equal(bits.call(grid).reshape(8, cols.size), actual, meth)
+    end
+  end
+
+  test "signbit over a view" do
+    values = [1.0, -2.0, 0.0, -0.0, 3.5, -0.25] * 20
+    a = Cumo::SFloat.cast(values)
+    expected = values.map { |x| x.negative? || (x.zero? && (1 / x).negative?) ? 1 : 0 }
+    assert_equal(Cumo::Bit.cast(expected), a.signbit)
+    every_other = Cumo::Bit.cast(expected.each_slice(2).map(&:first))
+    assert_equal(every_other, a[(0...values.size).step(2)].signbit)
+  end
 end


### PR DESCRIPTION
## Summary

`cond_unary` was still a host loop, so `isnan`, `isinf`, `isposinf`, `isneginf`, `isfinite` and `signbit` each ran `cudaDeviceSynchronize()` and then pulled the whole array back over the managed-memory fault path. The template now launches a kernel, in the same shape `cond_binary` already uses: one variant for a strided input and one for an index view. `RObject` keeps the host loop, since its predicates are `rb_funcall`s.

Measured on an RTX 5070 Ti Laptop, `2**22` elements, input left resident on the device:

| method | before | after |
| --- | --- | --- |
| DFloat `isnan` | 13.49 ms | 0.59 ms |
| DFloat `isfinite` | 12.69 ms | 0.61 ms |
| DFloat `signbit` | 12.64 ms | 0.61 ms |
| SFloat `isinf` | 8.19 ms | 0.55 ms |
| DComplex `isnan` | 19.85 ms | 0.79 ms |

## Problem

Writing a Bit result from a kernel means many threads touching the same word, which `CUMO_STORE_BIT` already handles for the device with `atomicOr`/`atomicAnd`. The cost of those atomics is what keeps this at 0.6 ms where an element-wise kernel of the same width runs in 0.16 ms — `cond_binary` measures the same 0.73 ms on this machine, so the two templates are now on par and the atomic traffic is a separate, shared thing to look at later.

The starting bit offset matters and is not always zero: a strided 2-d view runs the loop once per row, so `p2` arrives as a bit position inside the first word (13, 26, 7, 20 … for the case in the test). Verified by dropping `p2` from the kernel and confirming the new test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
