### PR TITLE
Add modf kernel for the unary_ret2 and frexp templates

### DIFF
--- a/ext/cumo/narray/gen/tmpl/frexp.c
+++ b/ext/cumo/narray/gen/tmpl/frexp.c
@@ -1,23 +1,18 @@
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t   i;
+    size_t   n;
     char    *p1, *p2, *p3;
     ssize_t  s1, s2, s3;
-    dtype    x;
-    int      y;
-    CUMO_INIT_COUNTER(lp, i);
+
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        x = m_<%=name%>(x,&y);
-        CUMO_SET_DATA_STRIDE(p2,s2,dtype,x);
-        CUMO_SET_DATA_STRIDE(p3,s3,int32_t,y);
-    }
+
+    <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
 }
 
 /*

--- a/ext/cumo/narray/gen/tmpl/frexp_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/frexp_kernel.cu
@@ -1,0 +1,18 @@
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        int y;
+        x = m_<%=name%>(x,&y);
+        *(dtype*)(p2+(i*s2)) = x;
+        *(int32_t*)(p3+(i*s3)) = y;
+    }
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/ext/cumo/narray/gen/tmpl/unary_ret2.c
+++ b/ext/cumo/narray/gen/tmpl/unary_ret2.c
@@ -1,22 +1,18 @@
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
+    size_t  n;
     char   *p1, *p2, *p3;
     ssize_t s1, s2, s3;
-    dtype   x, y, z;
-    CUMO_INIT_COUNTER(lp, i);
+
+    CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        m_<%=name%>(x,y,z);
-        CUMO_SET_DATA_STRIDE(p2,s2,dtype,y);
-        CUMO_SET_DATA_STRIDE(p3,s3,dtype,z);
-    }
+
+    <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
 }
 
 /*

--- a/ext/cumo/narray/gen/tmpl/unary_ret2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_ret2_kernel.cu
@@ -1,0 +1,18 @@
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        dtype x = *(dtype*)(p1+(i*s1));
+        dtype y, z;
+        m_<%=name%>(x,y,z);
+        *(dtype*)(p2+(i*s2)) = y;
+        *(dtype*)(p3+(i*s3)) = z;
+    }
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2285,4 +2285,66 @@ class NArrayTest < Test::Unit::TestCase
     every_other = Cumo::Bit.cast(expected.each_slice(2).map(&:first))
     assert_equal(every_other, a[(0...values.size).step(2)].signbit)
   end
+
+  # NaN never equals itself and -0.0 equals 0.0, so map both to a tag before
+  # comparing: the sign of a zero is exactly what modf and frexp have to keep
+  def float_tags(ary)
+    ary.map do |x|
+      if x.nan?
+        :nan
+      elsif x.zero?
+        (1 / x).negative? ? :negative_zero : :zero
+      else
+        x
+      end
+    end
+  end
+
+  def modf_expect(val)
+    return [val, val] if val.nan? || val.zero?
+
+    # modf keeps the sign of the argument in the fraction, zero included
+    signed_zero = val.negative? ? -(0.0) : 0.0
+    return [signed_zero, val] if val.infinite?
+
+    whole = val.abs.floor.to_f
+    whole = -whole if val.negative?
+    frac = val - whole
+    frac = signed_zero if frac.zero?
+    [frac, whole]
+  end
+
+  test "modf and frexp over long arrays and views" do
+    inf = Float::INFINITY
+    specials = { 0 => Float::NAN, 1 => inf, 2 => -inf, 3 => -0.0 }
+    values = Array.new(200) { |i| specials.fetch(i % 9, (i - 100) / 8.0) }
+    stepped = (0...200).step(3).to_a
+    reversed = (0...200).to_a.reverse
+
+    [Cumo::DFloat, Cumo::SFloat].each do |dtype|
+      a = dtype.cast(values)
+      # SFloat rounds on the way in, so the expectation has to start from the
+      # stored value rather than the literal
+      stored = a.to_a
+      cases = [
+        [:flat, a, (0...200).to_a],
+        [:stepped, a[(0...200).step(3)], stepped],
+        [:reversed, a[reversed], reversed]
+      ]
+      cases.each do |what, view, idxs|
+        src = idxs.map { |i| stored[i] }
+        expected = src.map { |x| modf_expect(x) }
+
+        frac, whole = view.modf
+        assert_equal(float_tags(expected.map(&:first)), float_tags(frac.to_a), "#{dtype} #{what} frac")
+        assert_equal(float_tags(expected.map(&:last)), float_tags(whole.to_a), "#{dtype} #{what} whole")
+
+        split = src.map { |x| Math.frexp(x) }
+        mantissa, exponent = dtype::Math.frexp(view)
+        assert_kind_of(Cumo::Int32, exponent)
+        assert_equal(float_tags(split.map(&:first)), float_tags(mantissa.to_a), "#{dtype} #{what} mantissa")
+        assert_equal(split.map(&:last), exponent.to_a, "#{dtype} #{what} exponent")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`modf` and `frexp` were the last plain element-wise host loops: each ran `cudaDeviceSynchronize()` and then walked the elements on the CPU. Both templates now launch a kernel. They take `CUMO_STRIDE_LOOP`, so one variant covers everything. Only `SFloat` and `DFloat` reach these templates — `RObject` has no `modf` and no `Math`, and `frexp` is excluded for the complex types — so neither needs a host fallback.

Measured on an RTX 5070 Ti Laptop, `2**22` elements:

| method | before | after |
| --- | --- | --- |
| DFloat `modf` | 6.72 ms | 0.27 ms |
| DFloat `frexp` | 5.87 ms | 0.22 ms |
| SFloat `modf` | 4.59 ms | 0.15 ms |
| SFloat `frexp` | 4.71 ms | 0.14 ms |

## Problem

Both methods return two freshly allocated arrays, which for `2**22` doubles is 64 MB of new managed memory per call. Until the pool stops growing, that allocation costs more than either loop and hides the difference entirely — the first fifteen calls of `DFloat#modf` measure 1.35 ms/call against 0.27 ms once the pool has settled. The figures above are from the last of six windows of fifteen calls, which is the first point at which the numbers converge.

`m_modf` takes the address of a local for the integral part, which is the kind of thing that spills to local memory in a kernel. It does not here: ptxas reports 28 registers and no stack frame for `cumo_iter_dfloat_modf_stride_kernel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
