### PR TITLE
Add minmax kernel for the minmax template

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -116,8 +116,10 @@ cumo_na_make_iarray(cumo_na_loop_args_t* arg)
     return cumo_na_make_iarray_given_ndim(arg, arg->ndim);
 }
 
+// out_arg names the loop argument to reduce into. It is 1 for a reduction with
+// a single result; minmax has two and reduces the same input into each.
 static cumo_na_reduction_arg_t
-cumo_na_make_reduction_arg(cumo_na_loop_t* lp_user)
+cumo_na_make_reduction_arg(cumo_na_loop_t* lp_user, int out_arg)
 {
     cumo_na_reduction_arg_t arg;
     int i;
@@ -140,7 +142,7 @@ cumo_na_make_reduction_arg(cumo_na_loop_t* lp_user)
             ++arg.out_indexer.ndim;
         }
     }
-    arg.out = cumo_na_make_iarray_given_ndim(&lp_user->args[1], arg.out_indexer.ndim);
+    arg.out = cumo_na_make_iarray_given_ndim(&lp_user->args[out_arg], arg.out_indexer.ndim);
 
     if (cumo_na_debug_flag) {
         print_cumo_na_reduction_arg_t(&arg);

--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -147,6 +147,65 @@ __global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, int out
     }
 }
 
+// Variant of reduction_kernel writing two results per output element, so that
+// minmax reads the input once instead of reducing it twice. The impl stores
+// through the pointers rather than returning, since there are two of them.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2_iarray, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    cumo_na_iarray_t& in_iarray = arg.in;
+    cumo_na_iarray_t& out_iarray = arg.out;
+    cumo_na_indexer_t& in_indexer = arg.in_indexer;
+    cumo_na_indexer_t& out_indexer = arg.out_indexer;
+
+    using TypeReduce = decltype(impl.Identity(0));
+
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
+    int64_t reduce_offset = tid / out_block_size;
+
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_out = out_base + out_offset; i_out < out_indexer.total_size; i_out += out_stride) {
+        cumo_na_indexer_set_dim(&out_indexer, i_out);
+        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
+
+        cumo_na_indexer_set_dim(&in_indexer, i_in);
+        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
+        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
+
+        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+            cumo_na_indexer_set_dim(&in_indexer, i_in);
+            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
+            impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
+        }
+
+        if (out_block_size <= max_block_size / 2) {
+            sdata[tid] = accum;
+            __syncthreads();
+            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
+                if (out_block_size <= stride) {
+                    if (tid < stride) {
+                        impl.Reduce(sdata[tid + stride], sdata[tid]);
+                    }
+                    __syncthreads();
+                }
+            }
+            accum = sdata[tid];
+            __syncthreads();
+        }
+        if (reduce_offset == 0 && i_out < out_indexer.total_size) {
+            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out_iarray, &out_indexer));
+            TypeOut* out2_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out2_iarray, &out_indexer));
+            impl.MapOut(accum, out_ptr, out2_ptr);
+        }
+    }
+}
+
 }  // cumo_detail
 
 // TODO(sonots): Optimize indexer by squashing (or reducing) dimensions
@@ -169,6 +228,31 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
     cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+// Variant of cumo_reduce writing two results per output element, for minmax.
+// See reduction_pair_kernel above. out2 has to describe the same shape as
+// arg.out, since the one out_indexer addresses both.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_pair(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, ReductionImpl&& impl) {
+    cumo_na_indexer_t& in_indexer = arg.in_indexer;
+    cumo_na_indexer_t& out_indexer = arg.out_indexer;
+
+    if (out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(size_t{1}, in_indexer.total_size / out_indexer.total_size));
+    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
+    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
+    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t block_size = cumo_detail::max_block_size;
+    int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
+    int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
+
+    cumo_detail::reduction_pair_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out2, out_block_size, reduce_block_size, impl);
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -42,7 +42,7 @@ static void
     {
         // TODO(sonots): How to compute Kahan summation algorithm in parallel?
         // TODO(sonots): Implement nan CUDA version
-        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp);
+        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
         cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(&arg);
     }
     <% end %>

--- a/ext/cumo/narray/gen/tmpl/accum_arg.c
+++ b/ext/cumo/narray/gen/tmpl/accum_arg.c
@@ -27,7 +27,7 @@ static void
     }
     <% else %>
     {
-        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp);
+        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
         cumo_<%=type_name%>_<%=name%>_int<%=i%>_kernel_launch(&arg);
     }
     <% end %>

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -28,7 +28,7 @@ static void
     }
     <% else %>
     {
-        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp);
+        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
         cumo_<%=type_name%>_<%=name%><%=nan%>_int<%=i%>_kernel_launch(&arg);
     }
     <% end %>

--- a/ext/cumo/narray/gen/tmpl/minmax.c
+++ b/ext/cumo/narray/gen/tmpl/minmax.c
@@ -1,21 +1,35 @@
+<% unless type_name == 'robject' %>
+void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2);
+<% end %>
+
 <% (is_float ? ["","_nan"] : [""]).each do |j| %>
 static void
 <%=c_iter%><%=j%>(cumo_na_loop_t *const lp)
 {
-    size_t   n;
-    char    *p1;
-    ssize_t  s1;
-    dtype    xmin,xmax;
+    <% if type_name == 'robject' || j == '_nan' %>
+    {
+        size_t   n;
+        char    *p1;
+        ssize_t  s1;
+        dtype    xmin,xmax;
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
 
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    f_<%=name%><%=j%>(n,p1,s1,&xmin,&xmax);
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        f_<%=name%><%=j%>(n,p1,s1,&xmin,&xmax);
 
-    *(dtype*)(lp->args[1].ptr + lp->args[1].iter[0].pos) = xmin;
-    *(dtype*)(lp->args[2].ptr + lp->args[2].iter[0].pos) = xmax;
+        *(dtype*)(lp->args[1].ptr + lp->args[1].iter[0].pos) = xmin;
+        *(dtype*)(lp->args[2].ptr + lp->args[2].iter[0].pos) = xmax;
+    }
+    <% else %>
+    {
+        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
+        cumo_na_iarray_t out2 = cumo_na_make_iarray_given_ndim(&lp->args[2], arg.out_indexer.ndim);
+        cumo_<%=type_name%>_minmax_kernel_launch(&arg, &out2);
+    }
+    <% end %>
 }
 <% end %>
 
@@ -44,7 +58,19 @@ static VALUE
   <% else %>
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
   <% end %>
-    ret = cumo_na_ndloop(&ndf, 2, self, reduce);
+    //<% unless type_name == 'robject' %>
+    // Only the kernel reads the indexer. The nan iterator above is a host loop
+    // over lp->args[0].iter[0], which CUMO_NDF_INDEXER_LOOP does not set up.
+    if (ndf.func == <%=c_iter%>) {
+        ndf.flag |= CUMO_NDF_INDEXER_LOOP;
+    }
+    //<% end %>
+    if (cumo_na_has_idx_p(self)) {
+        VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
+        ret = cumo_na_ndloop(&ndf, 2, copy, reduce);
+    } else {
+        ret = cumo_na_ndloop(&ndf, 2, self, reduce);
+    }
     // ndloop ignores CUMO_NDF_EXTRACT, so each method carrying it extracts for itself.
     if (cumo_compatible_mode_enabled_p()) {
         return rb_assoc_new(rb_funcall(RARRAY_AREF(ret,0), rb_intern("extract_cpu"), 0),

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -51,6 +51,35 @@ struct cumo_<%=type_name%>_max_impl {
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 
+// min and max fused, so that minmax reads the input once. The rules per
+// component are the two above verbatim: minmax must not answer differently
+// from min and max.
+struct cumo_<%=type_name%>_minmax_impl {
+    struct MinAndMax {
+        dtype min;
+        dtype max;
+    };
+<% if is_float %>
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {(dtype)nan(""), (dtype)nan("")}; }
+    __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
+    __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
+        if (next.min < accum.min || !not_nan(accum.min)) { accum.min = next.min; }
+        if (accum.max < next.max || !not_nan(accum.max)) { accum.max = next.max; }
+    }
+<% else %>
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
+    __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
+    __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
+        accum.min = next.min < accum.min ? next.min : accum.min;
+        accum.max = next.max < accum.max ? accum.max : next.max;
+    }
+<% end %>
+    __device__ void MapOut(MinAndMax accum, dtype* out_min, dtype* out_max) {
+        *out_min = accum.min;
+        *out_max = accum.max;
+    }
+};
+
 struct cumo_<%=type_name%>_ptp_impl {
     struct MinAndMax {
         dtype min;
@@ -102,4 +131,9 @@ void cumo_<%=type_name%>_max_kernel_launch(cumo_na_reduction_arg_t* arg)
 void cumo_<%=type_name%>_ptp_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     cumo_reduce<dtype, dtype, cumo_<%=type_name%>_ptp_impl>(*arg, cumo_<%=type_name%>_ptp_impl{});
+}
+
+void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2)
+{
+    cumo_reduce_pair<dtype, dtype, cumo_<%=type_name%>_minmax_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_impl{});
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2347,4 +2347,54 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
   end
+
+  def reduction_to_a(val)
+    val.is_a?(Numeric) ? [val] : val.to_a
+  end
+
+  test "minmax answers the same as min and max" do
+    # the kernel fuses the two reductions into one pass over the input, so the
+    # pair has to stay identical to running min and max separately
+    reductions = [{}, { axis: 0 }, { axis: 1 }, { axis: 1, keepdims: true }]
+    dtypes = [Cumo::DFloat, Cumo::SFloat, Cumo::Int32, Cumo::Int64, Cumo::Int8, Cumo::UInt8]
+    dtypes.each do |dtype|
+      # 3000 elements so the reduction spans more than one block
+      a = ((dtype.new(3000).seq * 37) % 251).reshape(30, 100)
+      { whole: a, strided: a[true, (0...100).step(7)] }.each do |what, view|
+        reductions.each do |opts|
+          min, max = view.minmax(**opts)
+          assert_equal(reduction_to_a(view.min(**opts)), reduction_to_a(min), "#{dtype} #{what} #{opts}")
+          assert_equal(reduction_to_a(view.max(**opts)), reduction_to_a(max), "#{dtype} #{what} #{opts}")
+        end
+      end
+    end
+  end
+
+  test "minmax over several axes" do
+    a = ((Cumo::Int32.new(2 * 3 * 4 * 5).seq * 17) % 61).reshape(2, 3, 4, 5)
+    [[0, 2], [1, 3], [0, 1, 2, 3], [3]].each do |axis|
+      min, max = a.minmax(axis: axis)
+      assert_equal(reduction_to_a(a.min(axis: axis)), reduction_to_a(min), axis.inspect)
+      assert_equal(reduction_to_a(a.max(axis: axis)), reduction_to_a(max), axis.inspect)
+    end
+  end
+
+  test "minmax of an all-NaN reduction is NaN on both sides" do
+    # numo answers 0.0 for the max here, which disagrees with its own max.
+    # cumo's max returns NaN (PR #219), and minmax now says the same.
+    nan = Float::NAN
+    [Cumo::DFloat, Cumo::SFloat].each do |dtype|
+      a = dtype[[1.0, nan, -3.0, 2.0], [nan, nan, nan, nan]]
+      min, max = a.minmax(axis: 1)
+      assert_equal([-3.0, :nan], float_tags(min.to_a), dtype.to_s)
+      assert_equal([2.0, :nan], float_tags(max.to_a), dtype.to_s)
+      assert_equal(float_tags(a.max(axis: 1).to_a), float_tags(max.to_a), dtype.to_s)
+
+      # nan: true is still the host loop, and keeps numo's rule of answering
+      # NaN as soon as one element is NaN
+      min, max = a.minmax(axis: 1, nan: true)
+      assert_equal([:nan, :nan], float_tags(min.to_a), dtype.to_s)
+      assert_equal([:nan, :nan], float_tags(max.to_a), dtype.to_s)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`minmax` was still a host loop: it ran `cudaDeviceSynchronize()` and then walked the elements on the CPU. It now reduces on the device the way `ptp` already does, with a min-max pair as the accumulator, so the input is read once rather than twice. `cumo_reduce_pair` is `cumo_reduce` with the final store writing through the impl into two output arrays instead of returning one value.

The accumulator repeats `min_impl` and `max_impl` per component rather than inventing its own rule, so `minmax` cannot answer differently from `min` and `max`. `RObject` and `nan:true` keep the host loop.

Measured on an RTX 5070 Ti Laptop, `2**20` elements, with a device kernel in front of each call so the input stays on the GPU:

| method | before | after |
| --- | --- | --- |
| DFloat `minmax` | 2.75 ms | 1.52 ms |
| DFloat `minmax(axis: 0)` | 4.96 ms | 1.32 ms |
| DFloat `minmax(axis: 1)` | 3.29 ms | 1.21 ms |
| Int32 `minmax(axis: 0)` | 21.1 ms | 1.32 ms |

## Problem

An all-NaN reduction answered `[NaN, 0.0]`, because the host loop leaves the max at its initial value. cumo's own `max` answers `NaN` there, so the two disagreed; numo has the same disagreement with itself. The pair now says `NaN` on both sides, which is a change for that one case.

`CUMO_NDF_INDEXER_LOOP` is set only after `cumo_na_reduce_dimension` has been given the chance to swap in the nan iterator, since that iterator is a host loop over `lp->args[0].iter[0]` and the flag does not set that up.

Numbers to read with care: calling `minmax` in a tight loop and nothing else is *faster* before this change, because the first host loop drags the array to the CPU and every later call then reads it there. That pattern hides what a reduction costs on the device — `cumo_reduce` gives a full reduce a grid of one block (`out_indexer.total_size` is 1, so `out_block_num` is 1), which is why `sum`, `min`, `max`, `prod` and `ptp` all take about 3 ms for `2**22` doubles. Worth looking at separately; it is not specific to `minmax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
