### PR TITLE
Split a reduction with too few outputs across more blocks

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <type_traits>
+#include <utility>
 
 #include "cumo/indexer.h"
 
@@ -11,6 +12,15 @@ namespace cumo_detail {
 
 static constexpr int64_t max_block_size = 512;
 static constexpr int64_t max_grid_size = 0x7fffffff;
+
+// A reduction gets one block per output element, so reducing to a single value
+// leaves the whole grid at one block however long the reduce axis is. Below
+// this many blocks the axis is worth splitting across a second launch.
+static constexpr int64_t min_grid_size = 256;
+// Splitting costs a scratch buffer and a second launch, so keep a chunk that
+// still has work in it, and do not go wider than the combine pass can take.
+static constexpr int64_t min_split_chunk = 1024;
+static constexpr int64_t max_split = 1024;
 
 static inline int64_t round_up_to_power_of_2(int64_t x) {
     --x;
@@ -206,6 +216,115 @@ __global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_n
     }
 }
 
+static inline int64_t reduce_split_count(int64_t reduce_total_size, int64_t out_block_num) {
+    if (out_block_num >= min_grid_size) return 1;
+    if (reduce_total_size < min_split_chunk * 2) return 1;
+    int64_t want = (min_grid_size + out_block_num - 1) / out_block_num;
+    int64_t fits = reduce_total_size / min_split_chunk;
+    int64_t n = std::min(std::min(want, fits), max_split);
+    return n < 2 ? 1 : n;
+}
+
+// First pass of a split reduction: each block takes one chunk of one output's
+// reduce axis and writes its accumulator to partial[i_out * n_split + i_split].
+// MapOut is deliberately not applied — the combine pass needs the accumulator.
+template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
+__global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    cumo_na_iarray_t& in_iarray = arg.in;
+    cumo_na_indexer_t& in_indexer = arg.in_indexer;
+    cumo_na_indexer_t& out_indexer = arg.out_indexer;
+
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
+    int64_t partial_total_size = out_indexer.total_size * n_split;
+    int64_t reduce_offset = tid / out_block_size;
+
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_partial = out_base + out_offset; i_partial < partial_total_size; i_partial += out_stride) {
+        int64_t i_out = i_partial / n_split;
+        int64_t begin = (i_partial % n_split) * chunk;
+        int64_t end = begin + chunk;
+        if (end > reduce_indexer_total_size) end = reduce_indexer_total_size;
+        int64_t i_in = i_out * reduce_indexer_total_size + begin + reduce_offset;
+
+        cumo_na_indexer_set_dim(&in_indexer, i_in);
+        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
+        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
+
+        for (int64_t i_reduce = begin + reduce_offset; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+            cumo_na_indexer_set_dim(&in_indexer, i_in);
+            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
+            impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
+        }
+
+        if (out_block_size <= max_block_size / 2) {
+            sdata[tid] = accum;
+            __syncthreads();
+            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
+                if (out_block_size <= stride) {
+                    if (tid < stride) {
+                        impl.Reduce(sdata[tid + stride], sdata[tid]);
+                    }
+                    __syncthreads();
+                }
+            }
+            accum = sdata[tid];
+            __syncthreads();
+        }
+        if (reduce_offset == 0 && i_partial < partial_total_size) {
+            partial[i_partial] = accum;
+        }
+    }
+}
+
+// Second pass of a split reduction. The input is already accumulators, so
+// MapIn must not run again. Identity is handed a scratch offset rather than an
+// index into the input, which is why an impl that reads that argument — the
+// (min|max)_index and arg(min|max) pairs — must not be split.
+template <typename ReductionImpl>
+struct reduce_combine {
+    ReductionImpl impl;
+    using TypeReduce = decltype(ReductionImpl().Identity(0));
+    __device__ TypeReduce Identity(int64_t index) { return impl.Identity(index); }
+    __device__ TypeReduce MapIn(TypeReduce in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(TypeReduce next, TypeReduce& accum) { impl.Reduce(next, accum); }
+    template <typename... Args>
+    __device__ decltype(auto) MapOut(TypeReduce accum, Args... args) { return impl.MapOut(accum, args...); }
+};
+
+// Allocates the scratch and runs the first pass, then points arg2's input at
+// the partials so the caller can combine them with its own second pass. The
+// caller frees the returned buffer.
+template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
+TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, int64_t n_split, int64_t reduce_total_size, cumo_na_reduction_arg_t* arg2, ReductionImpl& impl) {
+    int64_t chunk = (reduce_total_size + n_split - 1) / n_split;
+    int64_t partial_total_size = arg.out_indexer.total_size * n_split;
+    TypeReduce* partial = reinterpret_cast<TypeReduce*>(cumo_cuda_runtime_malloc(sizeof(TypeReduce) * partial_total_size));
+
+    int64_t chunk_pow2 = round_up_to_power_of_2(std::max(int64_t{1}, chunk));
+    int64_t reduce_block_size = std::min(max_block_size, chunk_pow2);
+    int64_t out_block_size = max_block_size / reduce_block_size;
+    int64_t out_block_num = (partial_total_size + out_block_size - 1) / out_block_size;
+    int64_t grid_size = std::min(max_grid_size, out_block_num);
+    int64_t shared_mem_size = sizeof(TypeReduce) * max_block_size;
+
+    reduction_partial_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    cumo_cuda_runtime_check_kernel_launch();
+
+    arg2->in.ptr = reinterpret_cast<char*>(partial);
+    arg2->in.step[0] = sizeof(TypeReduce);
+    arg2->in_indexer.ndim = 1;
+    arg2->in_indexer.shape[0] = partial_total_size;
+    arg2->in_indexer.total_size = partial_total_size;
+    return partial;
+}
+
 }  // cumo_detail
 
 // TODO(sonots): Optimize indexer by squashing (or reducing) dimensions
@@ -231,6 +350,39 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     cumo_cuda_runtime_check_kernel_launch();
 }
 
+// Runs the reduce axis of one output across several blocks and combines their
+// accumulators in a second launch, for the shapes where cumo_reduce would give
+// the grid almost no blocks. Falls back to cumo_reduce when that is not the
+// case. Only for an impl whose Identity ignores its index argument — see
+// reduce_combine above.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+    cumo_na_indexer_t& in_indexer = arg.in_indexer;
+    cumo_na_indexer_t& out_indexer = arg.out_indexer;
+
+    if (out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size = in_indexer.total_size / out_indexer.total_size;
+    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(int64_t{1}, reduce_total_size));
+    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
+    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
+    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
+    if (n_split < 2) {
+        cumo_reduce<TypeIn, TypeOut, ReductionImpl>(arg, std::forward<ReductionImpl>(impl));
+        return;
+    }
+
+    cumo_na_reduction_arg_t arg2 = arg;
+    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, n_split, reduce_total_size, &arg2, impl);
+    cumo_reduce<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, cumo_detail::reduce_combine<ReductionImpl>{impl});
+    cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
+}
+
 // Variant of cumo_reduce writing two results per output element, for minmax.
 // See reduction_pair_kernel above. out2 has to describe the same shape as
 // arg.out, since the one out_indexer addresses both.
@@ -254,6 +406,35 @@ void cumo_reduce_pair(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, Reduct
 
     cumo_detail::reduction_pair_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out2, out_block_size, reduce_block_size, impl);
     cumo_cuda_runtime_check_kernel_launch();
+}
+
+// cumo_reduce_split for the two-output form. Same constraint on Identity.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_pair_split(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, ReductionImpl&& impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+    cumo_na_indexer_t& in_indexer = arg.in_indexer;
+    cumo_na_indexer_t& out_indexer = arg.out_indexer;
+
+    if (out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size = in_indexer.total_size / out_indexer.total_size;
+    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(int64_t{1}, reduce_total_size));
+    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
+    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
+    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
+    if (n_split < 2) {
+        cumo_reduce_pair<TypeIn, TypeOut, ReductionImpl>(arg, out2, std::forward<ReductionImpl>(impl));
+        return;
+    }
+
+    cumo_na_reduction_arg_t arg2 = arg;
+    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, n_split, reduce_total_size, &arg2, impl);
+    cumo_reduce_pair<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, out2, cumo_detail::reduce_combine<ReductionImpl>{impl});
+    cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }
 
 // Variant of cumo_reduce for arg-reductions (argmax/argmin), which returns

--- a/ext/cumo/include/cumo/template_kernel.h
+++ b/ext/cumo/include/cumo/template_kernel.h
@@ -80,5 +80,10 @@ cumo_get_block_dim(size_t n)
 // because raising needs ruby.h, which the .cu translation units do not include.
 void cumo_cuda_runtime_check_kernel_launch(void);
 
+// Scratch memory for a kernel that needs somewhere to put partial results.
+// Declared here rather than including cuda/memory_pool.h, which needs ruby.h.
+char* cumo_cuda_runtime_malloc(size_t size);
+void cumo_cuda_runtime_free(char *ptr);
+
 
 #endif /* ifndef CUMO_TEMPLATE_KERNEL_H */

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -67,12 +67,12 @@ extern "C" {
 
 void cumo_<%=type_name%>_sum_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, <%=dtype%>, cumo_<%=type_name%>_sum_impl>(*arg, cumo_<%=type_name%>_sum_impl{});
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_sum_impl>(*arg, cumo_<%=type_name%>_sum_impl{});
 }
 
 void cumo_<%=type_name%>_prod_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_impl>(*arg, cumo_<%=type_name%>_prod_impl{});
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_impl>(*arg, cumo_<%=type_name%>_prod_impl{});
 }
 
 void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -110,30 +110,30 @@ extern "C" {
 
 void cumo_<%=type_name%>_sum_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, <%=dtype%>, cumo_<%=type_name%>_sum_impl>(*arg, cumo_<%=type_name%>_sum_impl{});
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_sum_impl>(*arg, cumo_<%=type_name%>_sum_impl{});
 }
 
 void cumo_<%=type_name%>_prod_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_impl>(*arg, cumo_<%=type_name%>_prod_impl{});
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_impl>(*arg, cumo_<%=type_name%>_prod_impl{});
 }
 
 void cumo_<%=type_name%>_min_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, dtype, cumo_<%=type_name%>_min_impl>(*arg, cumo_<%=type_name%>_min_impl{});
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_min_impl>(*arg, cumo_<%=type_name%>_min_impl{});
 }
 
 void cumo_<%=type_name%>_max_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, dtype, cumo_<%=type_name%>_max_impl>(*arg, cumo_<%=type_name%>_max_impl{});
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_max_impl>(*arg, cumo_<%=type_name%>_max_impl{});
 }
 
 void cumo_<%=type_name%>_ptp_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, dtype, cumo_<%=type_name%>_ptp_impl>(*arg, cumo_<%=type_name%>_ptp_impl{});
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_ptp_impl>(*arg, cumo_<%=type_name%>_ptp_impl{});
 }
 
 void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2)
 {
-    cumo_reduce_pair<dtype, dtype, cumo_<%=type_name%>_minmax_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_impl{});
+    cumo_reduce_pair_split<dtype, dtype, cumo_<%=type_name%>_minmax_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_impl{});
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2428,4 +2428,43 @@ class NArrayTest < Test::Unit::TestCase
       assert_equal([1.0, 4.0], float_tags(a.max(axis: 1).to_a), dtype.to_s)
     end
   end
+
+  test "a reduction wide enough to be split across blocks" do
+    # a reduction gets one block per output, so a single output is split across
+    # a second launch; the answer has to be what one block would have said
+    n = (1 << 20) + 7 # not a multiple of the split count, so the tail counts
+    a = Cumo::DFloat.new(n).seq
+    assert_equal([549_762_629_653.0], reduction_to_a(a.sum))
+    assert_equal([0.0], reduction_to_a(a.min))
+    assert_equal([n - 1.0], reduction_to_a(a.max))
+    assert_equal([n - 1.0], reduction_to_a(a.ptp))
+    min, max = a.minmax
+    assert_equal([0.0], reduction_to_a(min))
+    assert_equal([n - 1.0], reduction_to_a(max))
+
+    # a handful of outputs leaves the grid nearly empty too
+    rows = 8
+    cols = 300_000
+    b = Cumo::Int32.new(rows * cols).seq.reshape(rows, cols)
+    assert_equal((0...rows).map { |r| r * cols }, b.min(axis: 1).to_a)
+    assert_equal((0...rows).map { |r| ((r + 1) * cols) - 1 }, b.max(axis: 1).to_a)
+  end
+
+  test "a split reduction keeps the NaN rules" do
+    n = 1 << 20
+    a = Cumo::DFloat.new(n).seq
+    a[n / 2] = Float::NAN
+    assert_equal([:nan], float_tags(reduction_to_a(a.sum)))
+    # min and max skip a NaN unless every element is one
+    assert_equal([0.0], reduction_to_a(a.min))
+    assert_equal([n - 1.0], reduction_to_a(a.max))
+
+    all_nan = Cumo::DFloat.new(n).fill(Float::NAN)
+    assert_equal([:nan], float_tags(reduction_to_a(all_nan.min)))
+    assert_equal([:nan], float_tags(reduction_to_a(all_nan.max)))
+    assert_equal([:nan], float_tags(reduction_to_a(all_nan.ptp)))
+    min, max = all_nan.minmax
+    assert_equal([:nan], float_tags(reduction_to_a(min)))
+    assert_equal([:nan], float_tags(reduction_to_a(max)))
+  end
 end


### PR DESCRIPTION
## Summary

`cumo_reduce` gives the grid one block per output element, so a reduction to a single value ran however many elements through one block of 512 threads: `out_indexer.total_size` is 1, which makes `out_block_num` 1, which makes `grid_size` 1. `sum` of `2**22` doubles was reading 32 MB at about 10 GB/s on a card that does 360 GB/s on an element-wise kernel.

`cumo_reduce_split` cuts the reduce axis into chunks, gives each a block, and combines the accumulators in a second launch. A reduction that already fills the grid takes the single pass as before.

Measured on an RTX 5070 Ti Laptop, `2**22` elements:

| method | before | after |
| --- | --- | --- |
| DFloat `sum` | 3.06 ms | 0.32 ms |
| DFloat `min` | 4.21 ms | 0.34 ms |
| DFloat `ptp` | 3.99 ms | 0.32 ms |
| DFloat `minmax` | 4.49 ms | 0.33 ms |
| Int32 `sum` | 3.24 ms | 0.28 ms |
| DFloat `min(axis: 1)` on `(8, 2**19)` | 0.69 ms | 0.32 ms |

## Problem

`min_index`, `max_index`, `argmin` and `argmax` keep the single pass. Their accumulator carries an index, and `Identity` is handed the index of the element a thread starts at; in a combine pass there are only scratch offsets to give it. Splitting those needs a different treatment of the identity, which is worth doing separately.

The first pass does not apply `MapOut` and the second does not apply `MapIn`, since the accumulator is what travels between them — `ptp` would otherwise hand the combine pass a difference instead of a min-max pair. `reduce_combine` is the wrapper that expresses that.

The scratch buffer is freed right after the second launch rather than after a synchronize, which is how `conv.c` treats its cuDNN workspace: everything here is on the default stream, so the pool cannot hand the block out to work that would overtake it.

Checked by forcing every reduction in the suite through the split path — `min_grid_size` to 2^30 and `min_split_chunk` to 4 — and running the whole suite plus 518 reductions cross-checked against numo. All pass, all identical. The new test uses a length of `(1 << 20) + 7` so the last chunk is short; dropping the tail rounding makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
