### PR TITLE
Add bit operator kernels for the tmpl_bit binary and unary templates

### DIFF
--- a/ext/cumo/include/cumo/types/bit_kernel.h
+++ b/ext/cumo/include/cumo/types/bit_kernel.h
@@ -31,4 +31,43 @@ typedef CUMO_BIT_DIGIT rtype;
 #define m_count_false(x) ((x)==0)
 #define m_count_false_cpu(x) m_count_false(x)
 
+// Bit position of element i of an operand that is either indexed or strided.
+__device__ static inline size_t
+cumo_bit_pos(size_t p, ssize_t s, const size_t *idx, uint64_t i)
+{
+    return idx ? (p + idx[i]) : (p + i * s);
+}
+
+// The CUMO_NB bits starting o bits after word w of a, so a contiguous bit loop
+// can give a whole word to each thread. nw bounds the operand, and a shift that
+// would reach past it yields zeroes; those bits are outside the store mask.
+__device__ static inline CUMO_BIT_DIGIT
+cumo_bit_gather_word(const CUMO_BIT_DIGIT *a, ssize_t o, uint64_t nw, uint64_t w)
+{
+    CUMO_BIT_DIGIT x = 0;
+    if (o >= 0) {
+        if (w < nw)               x  = a[w] >> o;
+        if (o > 0 && w + 1 < nw)  x |= a[w+1] << (CUMO_NB - o);
+    } else {
+        if (w < nw)               x  = a[w] << -o;
+        if (w > 0)                x |= a[w-1] >> (CUMO_NB + o);
+    }
+    return x;
+}
+
+// Stores z as word w of a loop covering bits [p, p+n) of a. Only one thread
+// owns a word, so the partial words at either end need no atomic.
+__device__ static inline void
+cumo_bit_store_word(CUMO_BIT_DIGIT *a, uint64_t w, CUMO_BIT_DIGIT z, size_t p, uint64_t n)
+{
+    size_t lb = (w == 0) ? p : 0;
+    size_t hb = ((w + 1) * CUMO_NB <= p + n) ? CUMO_NB : (p + n - w * CUMO_NB);
+    if (lb == 0 && hb == CUMO_NB) {
+        a[w] = z;
+    } else {
+        CUMO_BIT_DIGIT mask = CUMO_SLB(hb) & ~CUMO_SLB(lb);
+        a[w] = (z & mask) | (a[w] & ~mask);
+    }
+}
+
 #endif // CUMO_BIT_KERNEL_H

--- a/ext/cumo/narray/gen/tmpl_bit/binary.c
+++ b/ext/cumo/narray/gen/tmpl_bit/binary.c
@@ -1,3 +1,6 @@
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -5,113 +8,16 @@ static void
     size_t  p1, p2, p3;
     ssize_t s1, s2, s3;
     size_t *idx1, *idx2, *idx3;
-    int     o1, o2, l1, l2, r1, r2, len;
     CUMO_BIT_DIGIT *a1, *a2, *a3;
-    CUMO_BIT_DIGIT  x, y;
-
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
     CUMO_INIT_PTR_BIT_IDX(lp, 1, a2, p2, s2, idx2);
     CUMO_INIT_PTR_BIT_IDX(lp, 2, a3, p3, s3, idx3);
     if (s1!=1 || s2!=1 || s3!=1 || idx1 || idx2 || idx3) {
-        for (; n--;) {
-            CUMO_LOAD_BIT_STEP(a1, p1, s1, idx1, x);
-            CUMO_LOAD_BIT_STEP(a2, p2, s2, idx2, y);
-            x = m_<%=name%>(x,y);
-            CUMO_STORE_BIT_STEP(a3, p3, s3, idx3, x);
-        }
+        <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(a1,p1,s1,idx1,a2,p2,s2,idx2,a3,p3,s3,idx3,n);
     } else {
-        a1 += p1/CUMO_NB;
-        p1 %= CUMO_NB;
-        a2 += p2/CUMO_NB;
-        p2 %= CUMO_NB;
-        a3 += p3/CUMO_NB;
-        p3 %= CUMO_NB;
-        o1 =  p1-p3;
-        o2 =  p2-p3;
-        l1 =  CUMO_NB+o1;
-        r1 =  CUMO_NB-o1;
-        l2 =  CUMO_NB+o2;
-        r2 =  CUMO_NB-o2;
-        if (p3>0 || n<CUMO_NB) {
-            len = CUMO_NB - p3;
-            if ((int)n<len) len=n;
-            if (o1>=0) x = *a1>>o1;
-            else       x = *a1<<-o1;
-            if (p1+len>CUMO_NB)  x |= *(a1+1)<<r1;
-            a1++;
-            if (o2>=0) y = *a2>>o2;
-            else       y = *a2<<-o2;
-            if (p2+len>CUMO_NB)  y |= *(a2+1)<<r2;
-            a2++;
-            x = m_<%=name%>(x,y);
-            *a3 = (x & (CUMO_SLB(len)<<p3)) | (*a3 & ~(CUMO_SLB(len)<<p3));
-            a3++;
-            n -= len;
-        }
-        if (o1==0 && o2==0) {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                x = *(a1++);
-                y = *(a2++);
-                x = m_<%=name%>(x,y);
-                *(a3++) = x;
-            }
-        } else {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                if (o1==0) {
-                    x = *a1;
-                } else if (o1>0) {
-                    x = *a1>>o1  | *(a1+1)<<r1;
-                } else {
-                    x = *a1<<-o1 | *(a1-1)>>l1;
-                }
-                a1++;
-                if (o2==0) {
-                    y = *a2;
-                } else if (o2>0) {
-                    y = *a2>>o2  | *(a2+1)<<r2;
-                } else {
-                    y = *a2<<-o2 | *(a2-1)>>l2;
-                }
-                a2++;
-                x = m_<%=name%>(x,y);
-                *(a3++) = x;
-            }
-        }
-        if (n>0) {
-            if (o1==0) {
-                x = *a1;
-            } else if (o1>0) {
-                x = *a1>>o1;
-                if ((int)n>r1) {
-                    x |= *(a1+1)<<r1;
-                }
-            } else {
-                x = *(a1-1)>>l1;
-                if ((int)n>-o1) {
-                    x |= *a1<<-o1;
-                }
-            }
-            if (o2==0) {
-                y = *a2;
-            } else if (o2>0) {
-                y = *a2>>o2;
-                if ((int)n>r2) {
-                    y |= *(a2+1)<<r2;
-                }
-            } else {
-                y = *(a2-1)>>l2;
-                if ((int)n>-o2) {
-                    y |= *a2<<-o2;
-                }
-            }
-            x = m_<%=name%>(x,y);
-            *a3 = (x & CUMO_SLB(n)) | (*a3 & CUMO_BALL<<n);
-        }
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(a1,p1,a2,p2,a3,p3,n);
     }
 }
 

--- a/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
@@ -1,0 +1,40 @@
+__global__ void <%="cumo_#{c_iter}_elementwise_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x, y;
+        CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
+        CUMO_LOAD_BIT(a2, cumo_bit_pos(p2,s2,idx2,i), y);
+        CUMO_BIT_DIGIT z = m_<%=name%>(x,y) & 1u;
+        CUMO_STORE_BIT(a3, cumo_bit_pos(p3,s3,idx3,i), z);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a2, ssize_t o2, uint64_t w2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_gather_word(a1,o1,w1,w);
+        CUMO_BIT_DIGIT y = cumo_bit_gather_word(a2,o2,w2,w);
+        cumo_bit_store_word(a3, w, m_<%=name%>(x,y), p3, n);
+    }
+}
+
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_elementwise_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a2,p2,s2,idx2,a3,p3,s3,idx3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n)
+{
+    ssize_t o1 = (ssize_t)p1 - (ssize_t)p3;
+    ssize_t o2 = (ssize_t)p2 - (ssize_t)p3;
+    uint64_t w1 = (p1 + n + CUMO_NB - 1) / CUMO_NB;
+    uint64_t w2 = (p2 + n + CUMO_NB - 1) / CUMO_NB;
+    uint64_t w3 = (p3 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w3);
+    size_t block_dim = cumo_get_block_dim(w3);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(a1,o1,w1,a2,o2,w2,a3,p3,n,w3);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/ext/cumo/narray/gen/tmpl_bit/unary.c
+++ b/ext/cumo/narray/gen/tmpl_bit/unary.c
@@ -1,3 +1,6 @@
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -5,81 +8,15 @@ static void
     size_t  p1, p3;
     ssize_t s1, s3;
     size_t *idx1, *idx3;
-    int     o1, l1, r1, len;
     CUMO_BIT_DIGIT *a1, *a3;
-    CUMO_BIT_DIGIT  x;
-    CUMO_BIT_DIGIT  y;
-
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
     CUMO_INIT_PTR_BIT_IDX(lp, 1, a3, p3, s3, idx3);
     if (s1!=1 || s3!=1 || idx1 || idx3) {
-        for (; n--;) {
-            CUMO_LOAD_BIT_STEP(a1, p1, s1, idx1, x);
-            y = m_<%=name%>(x);
-            CUMO_STORE_BIT_STEP(a3, p3, s3, idx3, y);
-        }
+        <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(a1,p1,s1,idx1,a3,p3,s3,idx3,n);
     } else {
-        a1 += p1/CUMO_NB;
-        p1 %= CUMO_NB;
-        a3 += p3/CUMO_NB;
-        p3 %= CUMO_NB;
-        o1 =  p1-p3;
-        l1 =  CUMO_NB+o1;
-        r1 =  CUMO_NB-o1;
-        if (p3>0 || n<CUMO_NB) {
-            len = CUMO_NB - p3;
-            if ((int)n<len) len=n;
-            if (o1>=0) x = *a1>>o1;
-            else       x = *a1<<-o1;
-            if (p1+len>CUMO_NB)  x |= *(a1+1)<<r1;
-            a1++;
-            y = m_<%=name%>(x);
-            *a3 = (y & (CUMO_SLB(len)<<p3)) | (*a3 & ~(CUMO_SLB(len)<<p3));
-            a3++;
-            n -= len;
-        }
-        if (o1==0) {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                x = *(a1++);
-                y = m_<%=name%>(x);
-                *(a3++) = y;
-            }
-        } else {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                if (o1==0) {
-                    x = *a1;
-                } else if (o1>0) {
-                    x = *a1>>o1  | *(a1+1)<<r1;
-                } else {
-                    x = *a1<<-o1 | *(a1-1)>>l1;
-                }
-                a1++;
-                y = m_<%=name%>(x);
-                *(a3++) = y;
-            }
-        }
-        if (n>0) {
-            if (o1==0) {
-                x = *a1;
-            } else if (o1>0) {
-                x = *a1>>o1;
-                if ((int)n>r1) {
-                    x |= *(a1+1)<<r1;
-                }
-            } else {
-                x = *(a1-1)>>l1;
-                if ((int)n>-o1) {
-                    x |= *a1<<-o1;
-                }
-            }
-            y = m_<%=name%>(x);
-            *a3 = (y & CUMO_SLB(n)) | (*a3 & CUMO_BALL<<n);
-        }
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(a1,p1,a3,p3,n);
     }
 }
 

--- a/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
@@ -1,0 +1,36 @@
+__global__ void <%="cumo_#{c_iter}_elementwise_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x;
+        CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
+        CUMO_BIT_DIGIT y = m_<%=name%>(x) & 1u;
+        CUMO_STORE_BIT(a3, cumo_bit_pos(p3,s3,idx3,i), y);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_gather_word(a1,o1,w1,w);
+        cumo_bit_store_word(a3, w, m_<%=name%>(x), p3, n);
+    }
+}
+
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_elementwise_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a3,p3,s3,idx3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n)
+{
+    ssize_t o1 = (ssize_t)p1 - (ssize_t)p3;
+    uint64_t w1 = (p1 + n + CUMO_NB - 1) / CUMO_NB;
+    uint64_t w3 = (p3 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w3);
+    size_t block_dim = cumo_get_block_dim(w3);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(a1,o1,w1,a3,p3,n,w3);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2496,4 +2496,63 @@ class NArrayTest < Test::Unit::TestCase
       assert_equal([2, 0, 1, 2], grid.argmax(axis: 1).to_a, dtype.to_s)
     end
   end
+
+  test "bit operators over long arrays and views" do
+    n = 200
+    xs = Array.new(n) { |i| (i % 3).zero? ? 1 : 0 }
+    ys = Array.new(n) { |i| (i % 5) < 2 ? 1 : 0 }
+    a = Cumo::Bit.cast(xs)
+    b = Cumo::Bit.cast(ys)
+    picked = Array.new(n) { |i| ((i * 7) + 3) % n }
+    # an offset that is not a multiple of the bit-digit width has to shift every
+    # word into place, and a strided or indexed view drops to a bit at a time
+    views = [
+      ["flat", (0...n).to_a, ->(v) { v }],
+      ["offset 13", (13...n).to_a, ->(v) { v[13...n] }],
+      ["offset 33", (33...n).to_a, ->(v) { v[33...n] }],
+      ["step 2", (0...n).step(2).to_a, ->(v) { v[(0...n).step(2)] }],
+      ["indexed", picked, ->(v) { v[picked] }],
+    ]
+
+    views.each do |label, idxs, slice|
+      va = slice.call(a)
+      vb = slice.call(b)
+      assert_equal(Cumo::Bit.cast(idxs.map { |i| 1 - xs[i] }), ~va, label)
+      [:&, :|, :^].each do |op|
+        want = Cumo::Bit.cast(idxs.map { |i| xs[i].public_send(op, ys[i]) })
+        assert_equal(want, va.public_send(op, vb), "#{label} #{op}")
+      end
+    end
+
+    # a strided 2-d view runs the loop once per row, so each row starts at a
+    # different bit offset
+    cols = (0...25).step(2).to_a
+    grid = (0...8).flat_map { |r| cols.map { |c| (r * 25) + c } }
+    ga = a.reshape(8, 25)[true, (0...25).step(2)]
+    gb = b.reshape(8, 25)[true, (0...25).step(2)]
+    assert_equal(Cumo::Bit.cast(grid.map { |i| 1 - xs[i] }).reshape(8, cols.size), ~ga)
+    [:&, :|, :^].each do |op|
+      want = Cumo::Bit.cast(grid.map { |i| xs[i].public_send(op, ys[i]) }).reshape(8, cols.size)
+      assert_equal(want, ga.public_send(op, gb), op.to_s)
+    end
+  end
+
+  test "a bit operator in place leaves the bits outside the view alone" do
+    n = 200
+    xs = Array.new(n) { |i| (i % 3).zero? ? 1 : 0 }
+    ys = Array.new(n) { |i| (i % 5) < 2 ? 1 : 0 }
+    # the view starts and ends inside a word it shares with elements it must not
+    # touch
+    view = (10...100)
+
+    a = Cumo::Bit.cast(xs)
+    a[view].inplace & Cumo::Bit.cast(ys[view])
+    want = xs.each_with_index.map { |x, i| view.cover?(i) ? (x & ys[i]) : x }
+    assert_equal(Cumo::Bit.cast(want), a)
+
+    a = Cumo::Bit.cast(xs)
+    a[view].inplace.~
+    want = xs.each_with_index.map { |x, i| view.cover?(i) ? (1 - x) : x }
+    assert_equal(Cumo::Bit.cast(want), a)
+  end
 end


### PR DESCRIPTION
## Summary

* `Cumo::Bit`'s `&`, `|`, `^` and `~` ran their loop on the CPU behind `cudaDeviceSynchronize`. They now run on the GPU.
* The contiguous path gives one bit-digit word to each thread, so 32 elements move per thread and no atomic is involved. Operands whose bit offsets differ are realigned per word, the same shifting the host loop walked.
* The strided and indexed path stores one bit at a time and normalises the result to 0 or 1, because the device `CUMO_STORE_BIT` tests the whole value rather than its low bit — `m_not` and `m_eq` return `~x`.

## Problem

`tmpl_bit/binary.c` and `tmpl_bit/unary.c` were the last pure element-wise loops left on the host, so every bit operation pulled its operands back to the CPU and left them there. Over 2^22 elements `&` took 0.014 ms and `~` 0.011 ms with the operands already resident on the host, and 2.68 ms / 2.39 ms over a strided view. They are now 0.004 ms and 0.10 ms. A pipeline that produces the operands on the device and then combines them went from 9.2 ms to 0.45 ms.

Checked against `Numo::NArray` over 476 combinations of operand shape — flat, bit offsets 1/13/32/33, strided, reversed, indexed, 2-d strided and 3-d strided views, plus scalar operands and in-place — with no differences. `rake test` passes.
