### PR TITLE
Fix bit views with a negative step reading out of bounds

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -34,21 +34,31 @@
         es = ((lp)->args[i]).elmsz;                             \
     }
 
+// pos is the first position in iteration order, so a step below zero walks down
+// from there and rebasing the pointer onto pos would underflow the position of
+// every element past the first word. A step of zero comes with an index, whose
+// entries only ever move forward.
 #define CUMO_INIT_PTR_BIT( lp, i, ad, ps, st )               \
     {                                                   \
         ps = ((lp)->args[i].iter[0]).pos;                       \
-        ad = (CUMO_BIT_DIGIT*)(((lp)->args[i]).ptr) + ps/CUMO_NB; \
-        ps %= CUMO_NB;                                       \
         st = ((lp)->args[i].iter[0]).step;                      \
+        ad = (CUMO_BIT_DIGIT*)(((lp)->args[i]).ptr);            \
+        if (st >= 0) {                                       \
+            ad += ps/CUMO_NB;                                \
+            ps %= CUMO_NB;                                   \
+        }                                                    \
     }
 
 #define CUMO_INIT_PTR_BIT_IDX( lp, i, ad, ps, st, id )       \
     {                                                   \
         ps = ((lp)->args[i].iter[0]).pos;                       \
-        ad = (CUMO_BIT_DIGIT*)(((lp)->args[i]).ptr) + ps/CUMO_NB; \
-        ps %= CUMO_NB;                                       \
         st = ((lp)->args[i].iter[0]).step;                      \
         id = ((lp)->args[i].iter[0]).idx;                       \
+        ad = (CUMO_BIT_DIGIT*)(((lp)->args[i]).ptr);            \
+        if (st >= 0) {                                       \
+            ad += ps/CUMO_NB;                                \
+            ps %= CUMO_NB;                                   \
+        }                                                    \
     }
 
 #define CUMO_GET_DATA( ptr, type, val )                 \

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2555,4 +2555,39 @@ class NArrayTest < Test::Unit::TestCase
     want = xs.each_with_index.map { |x, i| view.cover?(i) ? (1 - x) : x }
     assert_equal(Cumo::Bit.cast(want), a)
   end
+  test "a bit view with a negative step reads the elements below its first one" do
+    # the view starts at the last element, so every element after it sits in a
+    # lower word than the one the loop starts in
+    [8, 32, 33, 64, 65, 200].each do |n|
+      xs = Array.new(n) { |i| (i % 3).zero? ? 1 : 0 }
+      a = Cumo::Bit.cast(xs)
+      rev = a[(n - 1).step(0, -1)]
+      assert_equal(xs.reverse, rev.to_a, "n=#{n}")
+      assert_equal(Cumo::Bit.cast(xs.reverse.map { |x| 1 - x }), ~rev, "n=#{n}")
+      ones = xs.reverse.each_index.select { |i| xs.reverse[i] == 1 }
+      assert_equal(ones, rev.where.to_a, "n=#{n}")
+      assert_equal(false, rev.all?, "n=#{n}")
+      assert_equal(true, rev.any?, "n=#{n}")
+      assert_equal(xs.count(1), rev.count_true.to_i, "n=#{n}")
+
+      # and as the destination of a store
+      dst = Cumo::Bit.zeros(n)
+      dst[(n - 1).step(0, -1)].store(a)
+      assert_equal(Cumo::Bit.cast(xs.reverse), dst, "n=#{n}")
+    end
+  end
+
+  test "a bit reduction along an axis of a reversed 2-d view" do
+    rows = 7
+    cols = 33
+    xs = Array.new(rows * cols) { |i| (i % 3).zero? ? 1 : 0 }
+    a = Cumo::Bit.cast(xs).reshape(rows, cols)
+    rev = a[true, (cols - 1).step(0, -1)]
+    grid = (0...rows).map { |r| (0...cols).map { |c| xs[(r * cols) + (cols - 1 - c)] } }
+    assert_equal(grid, rev.to_a)
+    assert_equal(Cumo::Bit.cast(grid.map { |row| row.all? { |x| x == 1 } ? 1 : 0 }),
+                 rev.all?(axis: 1))
+    assert_equal(Cumo::Bit.cast(grid.transpose.map { |col| col.any? { |x| x == 1 } ? 1 : 0 }),
+                 rev.any?(axis: 0))
+  end
 end


### PR DESCRIPTION
## Summary

`CUMO_INIT_PTR_BIT` and `CUMO_INIT_PTR_BIT_IDX` rebase the word pointer onto the loop's start position and keep only the remainder in the position, which numo does not do. That is only valid while the loop walks forward. Skip the rebase when the step is negative.

## Problem

A view built with a negative step starts at its last element, so the loop walks down from there. After the rebase the position is `pos % 32`, and element `i` is at `pos % 32 - i`, which underflows `size_t` as soon as `i` passes the first word. Every bit method reading such a view then indexes ~2^59 words past the pointer.

```ruby
a = Cumo::Bit.cast(Array.new(33) { 1 })
a[32.step(0, -1)].to_a   #=> segmentation fault
a[32.step(0, -1)].all?   #=> illegal memory access (error=700)
```

`to_a`, `where`, `count_true`, `~`, `&`, `all?`, `any?` and storing into such a view all crash; it survives only while the view fits in one word (`n <= 32`). numo answers all of them correctly.
