### PR TITLE
Add bit reduction kernels for the tmpl_bit bit_reduce template

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -61,6 +61,11 @@
         }                                                    \
     }
 
+// A bit reduction along a short axis runs its loop once per output element, so
+// a launch per call costs more than walking the bits on the host. Measured on an
+// RTX 5070 Ti the two meet at about this many elements.
+#define CUMO_BIT_REDUCE_MIN_KERNEL_SIZE 8192
+
 #define CUMO_GET_DATA( ptr, type, val )                 \
     {                                              \
         val = *(type*)(ptr);                       \

--- a/ext/cumo/include/cumo/types/bit_kernel.h
+++ b/ext/cumo/include/cumo/types/bit_kernel.h
@@ -55,17 +55,25 @@ cumo_bit_gather_word(const CUMO_BIT_DIGIT *a, ssize_t o, uint64_t nw, uint64_t w
     return x;
 }
 
+// The bits of word w that belong to a loop covering bits [p, p+n). The words at
+// either end are shared with elements the loop must not read or write.
+__device__ static inline CUMO_BIT_DIGIT
+cumo_bit_word_mask(size_t p, uint64_t n, uint64_t w)
+{
+    size_t lb = (w == 0) ? p : 0;
+    size_t hb = ((w + 1) * CUMO_NB <= p + n) ? CUMO_NB : (p + n - w * CUMO_NB);
+    return CUMO_SLB(hb) & ~CUMO_SLB(lb);
+}
+
 // Stores z as word w of a loop covering bits [p, p+n) of a. Only one thread
 // owns a word, so the partial words at either end need no atomic.
 __device__ static inline void
 cumo_bit_store_word(CUMO_BIT_DIGIT *a, uint64_t w, CUMO_BIT_DIGIT z, size_t p, uint64_t n)
 {
-    size_t lb = (w == 0) ? p : 0;
-    size_t hb = ((w + 1) * CUMO_NB <= p + n) ? CUMO_NB : (p + n - w * CUMO_NB);
-    if (lb == 0 && hb == CUMO_NB) {
+    CUMO_BIT_DIGIT mask = cumo_bit_word_mask(p, n, w);
+    if (mask == CUMO_BALL) {
         a[w] = z;
     } else {
-        CUMO_BIT_DIGIT mask = CUMO_SLB(hb) & ~CUMO_SLB(lb);
         a[w] = (z & mask) | (a[w] & ~mask);
     }
 }

--- a/ext/cumo/narray/gen/tmpl_bit/bit_reduce.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_reduce.c
@@ -1,3 +1,7 @@
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, uint64_t n);
+void <%="cumo_#{c_iter}_reduce_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n);
+void <%="cumo_#{c_iter}_contiguous_reduce_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -8,13 +12,23 @@ static void
     size_t    *idx1, *idx2;
     CUMO_BIT_DIGIT  x=0, y=0;
 
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
     CUMO_INIT_PTR_BIT_IDX(lp, 1, a2, p2, s2, idx2);
+    if (i >= CUMO_BIT_REDUCE_MIN_KERNEL_SIZE) {
+        if (idx2 || s2) {
+            <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(a1,p1,s1,idx1,a2,p2,s2,idx2,i);
+        } else if (idx1 || s1 != 1) {
+            <%="cumo_#{c_iter}_reduce_kernel_launch"%>(a1,p1,s1,idx1,a2,p2,i);
+        } else {
+            <%="cumo_#{c_iter}_contiguous_reduce_kernel_launch"%>(a1,p1,a2,p2,i);
+        }
+        return;
+    }
+
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
     if (idx2) {
         if (idx1) {
             for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl_bit/bit_reduce_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_reduce_kernel.cu
@@ -1,0 +1,77 @@
+// The output starts out filled with <%=init_bit%> and an element can only ever
+// flip it to the other value, so a store is idempotent and the racing threads of
+// a launch need no ordering between them.
+
+__global__ void <%="cumo_#{c_iter}_elementwise_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        size_t q2 = cumo_bit_pos(p2,s2,idx2,i);
+        CUMO_BIT_DIGIT x, y;
+        CUMO_LOAD_BIT(a2, q2, y);
+        if (y == <%=init_bit%>) {
+            CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
+            if (x != <%=init_bit%>) {
+                CUMO_STORE_BIT(a2, q2, x);
+            }
+        }
+    }
+}
+
+// Every element answers the same output bit, so each block folds its threads
+// down to one flag and at most one of them reaches the bit.
+__device__ static void <%="cumo_#{c_iter}_store_flip"%>(int flip, CUMO_BIT_DIGIT *a2, size_t p2)
+{
+    if (__syncthreads_or(flip) && threadIdx.x == 0) {
+        CUMO_BIT_DIGIT y;
+        CUMO_LOAD_BIT(a2, p2, y);
+        if (y == <%=init_bit%>) {
+            CUMO_STORE_BIT(a2, p2, (CUMO_BIT_DIGIT)<%=1 - init_bit%>);
+        }
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_reduce_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n)
+{
+    int flip = 0;
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n && !flip; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x;
+        CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
+        flip = (x != <%=init_bit%>);
+    }
+    <%="cumo_#{c_iter}_store_flip"%>(flip, a2, p2);
+}
+
+__global__ void <%="cumo_#{c_iter}_contiguous_reduce_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n, uint64_t w1)
+{
+    const CUMO_BIT_DIGIT init_word = <%=init_bit%> ? CUMO_BALL : (CUMO_BIT_DIGIT)0;
+    int flip = 0;
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w1 && !flip; w += blockDim.x * gridDim.x) {
+        flip = ((a1[w] ^ init_word) & cumo_bit_word_mask(p1,n,w)) != 0;
+    }
+    <%="cumo_#{c_iter}_store_flip"%>(flip, a2, p2);
+}
+
+void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_elementwise_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a2,p2,s2,idx2,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_reduce_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_reduce_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a2,p2,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_reduce_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, uint64_t n)
+{
+    uint64_t w1 = (p1 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w1);
+    size_t block_dim = cumo_get_block_dim(w1);
+    <%="cumo_#{c_iter}_contiguous_reduce_kernel"%><<<grid_dim, block_dim>>>(a1,p1,a2,p2,n,w1);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/ext/cumo/narray/gen/tmpl_bit/extract.c
+++ b/ext/cumo/narray/gen/tmpl_bit/extract.c
@@ -22,7 +22,13 @@ static VALUE
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
-        val = ((*((ptr)+(pos)/CUMO_NB)) >> ((pos)%CUMO_NB)) & 1u;
+        {
+            // Reading through the managed pointer faults the whole page back from
+            // the device, which costs more than the kernel that wrote it.
+            CUMO_BIT_DIGIT word;
+            cumo_cuda_runtime_check_status(cudaMemcpy(&word, ptr+(pos)/CUMO_NB, sizeof(CUMO_BIT_DIGIT), cudaMemcpyDeviceToHost));
+            val = (word >> ((pos)%CUMO_NB)) & 1u;
+        }
         cumo_na_release_lock(self);
         return INT2FIX(val);
     }

--- a/ext/cumo/narray/gen/tmpl_bit/extract_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/extract_cpu.c
@@ -21,7 +21,13 @@ static VALUE
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
-        val = ((*((ptr)+(pos)/CUMO_NB)) >> ((pos)%CUMO_NB)) & 1u;
+        {
+            // Reading through the managed pointer faults the whole page back from
+            // the device, which costs more than the kernel that wrote it.
+            CUMO_BIT_DIGIT word;
+            cumo_cuda_runtime_check_status(cudaMemcpy(&word, ptr+(pos)/CUMO_NB, sizeof(CUMO_BIT_DIGIT), cudaMemcpyDeviceToHost));
+            val = (word >> ((pos)%CUMO_NB)) & 1u;
+        }
         cumo_na_release_lock(self);
         return INT2FIX(val);
     }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2590,4 +2590,60 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(Cumo::Bit.cast(grid.transpose.map { |col| col.any? { |x| x == 1 } ? 1 : 0 }),
                  rev.any?(axis: 0))
   end
+
+  test "bit reductions over long arrays and views" do
+    # long enough that the reduction runs on the device, and not a multiple of
+    # the bit-digit width so the words at either end are only partly in the view
+    n = 20_000
+    base = Array.new(n) { 1 }
+    picked = Array.new(n) { |i| ((i * 7) + 3) % n }
+    views = [
+      ["flat", (0...n).to_a, ->(v) { v }],
+      ["offset 13", (13...n).to_a, ->(v) { v[13...n] }],
+      ["offset 32", (32...n).to_a, ->(v) { v[32...n] }],
+      ["step 2", (0...n).step(2).to_a, ->(v) { v[(0...n).step(2)] }],
+      ["indexed", picked, ->(v) { v[picked] }],
+    ]
+
+    # the deciding element at the start, in the middle, at the end, and nowhere
+    [nil, 0, n / 2, n - 1].each do |zero_at|
+      xs = base.dup
+      xs[zero_at] = 0 if zero_at
+      a = Cumo::Bit.cast(xs)
+      b = ~a
+      views.each do |label, idxs, slice|
+        want_all = idxs.all? { |i| xs[i] == 1 }
+        lbl = "#{label} zero_at=#{zero_at.inspect}"
+        assert_equal(want_all, slice.call(a).all?, lbl)
+        assert_equal(!want_all, slice.call(b).any?, lbl)
+        assert_equal(want_all, slice.call(b).none?, lbl)
+      end
+    end
+  end
+
+  test "bit reductions along an axis" do
+    rows = 6
+    cols = 20_000
+    xs = Array.new(rows * cols) { |i| (i % 20_001).zero? ? 0 : 1 }
+    a = Cumo::Bit.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+
+    assert_equal(Cumo::Bit.cast(grid.map { |row| row.all? { |x| x == 1 } ? 1 : 0 }),
+                 a.all?(axis: 1))
+    assert_equal(Cumo::Bit.cast(grid.map { |row| row.any? { |x| x == 1 } ? 1 : 0 }),
+                 a.any?(axis: 1))
+    assert_equal(Cumo::Bit.cast(grid.transpose.map { |col| col.all? { |x| x == 1 } ? 1 : 0 }),
+                 a.all?(axis: 0))
+    assert_equal(Cumo::Bit.cast(grid.map { |row| row.all? { |x| x == 1 } ? 1 : 0 }).reshape(rows, 1),
+                 a.all?(axis: 1, keepdims: true))
+
+    # a strided view starts each row at a different bit offset
+    sel = (0...cols).step(2).to_a
+    v = a[true, (0...cols).step(2)]
+    want = grid.map { |row| sel.map { |c| row[c] } }
+    assert_equal(Cumo::Bit.cast(want.map { |row| row.all? { |x| x == 1 } ? 1 : 0 }),
+                 v.all?(axis: 1))
+    assert_equal(Cumo::Bit.cast(want.map { |row| row.none? { |x| x == 1 } ? 1 : 0 }),
+                 (~v).all?(axis: 1))
+  end
 end


### PR DESCRIPTION
## Summary

`all?`, `any?` and `none?` walked the bits on the host after a full device synchronize. Add kernels for the three loop shapes the template can see, and keep the host walk for short reduction axes, where a launch per output element costs more than the walk.

- `cumo_bit_word_mask` is split out of `cumo_bit_store_word` so the contiguous reduction can mask a word the same way
- `Cumo::Bit#extract` reads its word with `cudaMemcpy` instead of dereferencing the managed pointer, which faulted the page the reduction had just written back from the device

## Problem

The output starts filled with the initial bit and an element can only ever flip it to the other value, so the stores are idempotent and the blocks of a launch need no ordering. Each block folds its threads with `__syncthreads_or` and at most one thread reaches the output bit. A contiguous operand is read a word at a time, with the bits outside the loop masked off.

`CUMO_BIT_REDUCE_MIN_KERNEL_SIZE` picks the host walk when the reduction axis is short. Reducing a 4M-bit array along an axis of 1024 elements calls the loop 4096 times, and 4096 launches cost more than the whole host reduction.

## Numbers

2^22 bits on an RTX 5070 Ti, operand freshly computed on the device, best of three runs in separate processes:

| | before | after |
|---|---|---|
| `all?` -> true | 1.981 ms | 0.596 ms |
| `any?` -> false | 2.022 ms | 0.604 ms |
| `all?` -> false at the first element | 0.761 ms | 0.632 ms |
| `any?` -> true at the last element | 1.983 ms | 0.615 ms |
| `all?(axis: 1)` of 4x1048576 | 2.227 ms | 1.247 ms |
| `all?(axis: 1)` of 64x65536 | 2.140 ms | 1.154 ms |
| `all?(axis: 1)` of 1024x4096 (host walk) | 2.407 ms | 2.415 ms |
| `all?(axis: 1)` of 131072x32 (host walk) | 21.93 ms | 21.57 ms |
