### PR TITLE
Fix grid-stride kernels hanging from about 2**32 elements

### DIFF
--- a/ext/cumo/include/cumo/template_kernel.h
+++ b/ext/cumo/include/cumo/template_kernel.h
@@ -56,7 +56,11 @@
 // val -> val&1 ??
 
 #define CUMO_MAX_BLOCK_DIM 128
-#define CUMO_MAX_GRID_DIM 2147483647 // ref. http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
+// Grid-stride loops step by blockDim.x * gridDim.x, a product of two unsigned
+// ints, so the grid is capped where the product of the largest block and the
+// grid would reach 2^32 and the step would wrap to zero. The hardware grid
+// limit of 2^31-1 is far above this.
+#define CUMO_MAX_GRID_DIM (4294967295ul / CUMO_MAX_BLOCK_DIM)
 
 static inline size_t
 cumo_get_grid_dim(size_t n)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2687,4 +2687,14 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(seq.each_index.select { |i| seq[i] == 1 }, w1.to_a)
     assert_equal(seq.each_index.select { |i| seq[i] == 0 }, w0.to_a)
   end
+
+  test "a bit count over more than 2**32 bits" do
+    # in the window where a grid-stride step of blockDim * gridDim wraps past
+    # an unsigned int, an uncapped grid loops forever
+    n = 1 << 32
+    a = Cumo::Bit.new(n).fill(0)
+    ones = [0, n / 2, n - 1]
+    ones.each { |i| a[i] = 1 }
+    assert_equal(ones.size, a.count_true.to_i)
+  end
 end


### PR DESCRIPTION
## Summary

- Every elementwise kernel steps its grid-stride loop by `blockDim.x * gridDim.x`, a product of two unsigned ints. `cumo_get_grid_dim` capped the grid only at the hardware limit, so from about 2**32 elements the product wrapped: a step of zero hangs the kernel forever, and a small wrapped step degrades to quadratic work.
- Cap `CUMO_MAX_GRID_DIM` at `(2**32 - 1) / CUMO_MAX_BLOCK_DIM` so the step always fits in an unsigned int. The loops already index with `uint64_t`, so a smaller grid just means more strides.

## Verification

- Before: `Cumo::Bit.new(2**32 - 128).fill(0).count_true` hangs forever (step wraps to 0); `2**32` takes effectively forever (step wraps to 128). After: both answer in under 0.1s.
- Added a test counting three set bits in `2**32` bits; without the fix it hangs, with it the full suite passes (1484 tests, 0 failures).
