### PR TITLE
Add where and where2 kernels for the tmpl_bit templates

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -66,6 +66,9 @@
 // RTX 5070 Ti the two meet at about this many elements.
 #define CUMO_BIT_REDUCE_MIN_KERNEL_SIZE 8192
 
+// Same trade for the three launches of a where compaction.
+#define CUMO_BIT_WHERE_MIN_KERNEL_SIZE 8192
+
 #define CUMO_GET_DATA( ptr, type, val )                 \
     {                                              \
         val = *(type*)(ptr);                       \

--- a/ext/cumo/include/cumo/types/bit_kernel.h
+++ b/ext/cumo/include/cumo/types/bit_kernel.h
@@ -78,4 +78,79 @@ cumo_bit_store_word(CUMO_BIT_DIGIT *a, uint64_t w, CUMO_BIT_DIGIT z, size_t p, u
     }
 }
 
+// Threads per block of the chunk scan below. The warp-shuffle scan is written
+// for a block that is a whole number of warps.
+#define CUMO_BIT_CHUNK_BLOCK 128
+
+// Exclusive prefix sum of v over the block, leaving the block total in *total.
+// Every thread of the block must reach it, and a caller that runs it more than
+// once has to put a barrier between the runs because the shared state is reused.
+__device__ static inline uint64_t
+cumo_bit_block_exscan(uint64_t v, uint64_t *total)
+{
+    __shared__ uint64_t warp_sum[CUMO_BIT_CHUNK_BLOCK / 32];
+    __shared__ uint64_t block_sum;
+    unsigned int lane = threadIdx.x & 31u;
+    unsigned int warp = threadIdx.x >> 5;
+    uint64_t x = v;
+
+    for (unsigned int d = 1; d < 32u; d <<= 1) {
+        uint64_t y = __shfl_up_sync(0xffffffffu, x, d);
+        if (lane >= d) x += y;
+    }
+    if (lane == 31u) warp_sum[warp] = x;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        uint64_t acc = 0;
+        for (unsigned int w = 0; w < CUMO_BIT_CHUNK_BLOCK / 32; ++w) {
+            uint64_t s = warp_sum[w];
+            warp_sum[w] = acc;
+            acc += s;
+        }
+        block_sum = acc;
+    }
+    __syncthreads();
+    *total = block_sum;
+    return warp_sum[warp] + x - v;
+}
+
+// Elements [c*CUMO_NB, c*CUMO_NB+CUMO_NB) of a loop over n elements, as one word
+// whose bit k is element c*CUMO_NB+k. A contiguous loop straddles two words of
+// the operand, which cumo_bit_gather_word recombines; any other loop gathers
+// its bits one element at a time. invert answers the complement, masked to the
+// elements the loop covers.
+__device__ static inline CUMO_BIT_DIGIT
+cumo_bit_chunk(const CUMO_BIT_DIGIT *a, size_t p, ssize_t s, const size_t *idx, uint64_t n, uint64_t nw, uint64_t c, int contiguous, int invert)
+{
+    uint64_t base = c * CUMO_NB;
+    uint64_t kend = (n - base < CUMO_NB) ? (n - base) : CUMO_NB;
+    CUMO_BIT_DIGIT z;
+
+    if (contiguous) {
+        z = cumo_bit_gather_word(a, (ssize_t)p, nw, c);
+    } else {
+        uint64_t k;
+        z = 0;
+        for (k = 0; k < kend; ++k) {
+            CUMO_BIT_DIGIT x;
+            CUMO_LOAD_BIT(a, cumo_bit_pos(p, s, idx, base + k), x);
+            z |= x << k;
+        }
+    }
+    if (invert) z = ~z;
+    return z & CUMO_SLB(kend);
+}
+
+// Stores the k-th index of a where result, whose element size the caller picked
+// from the size of the operand.
+__device__ static inline void
+cumo_bit_store_index(char *a, size_t elmsz, uint64_t k, size_t v)
+{
+    if (elmsz == sizeof(uint32_t)) {
+        ((uint32_t*)a)[k] = (uint32_t)v;
+    } else {
+        ((uint64_t*)a)[k] = (uint64_t)v;
+    }
+}
+
 #endif // CUMO_BIT_KERNEL_H

--- a/ext/cumo/narray/gen/tmpl_bit/where.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where.c
@@ -3,9 +3,32 @@ typedef struct {
     char  *idx0;
     char  *idx1;
     size_t elmsz;
+    char  *scratch;
 } where_opt_t;
 
 #define STORE_INT(ptr, esz, x) memcpy(ptr,&(x),esz)
+
+char *cumo_bit_where_scratch_new(void);
+void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t count, char *scratch);
+
+// The number of ones, read back with a copy of the count rather than through
+// the managed pointer, which would fault the whole page. The one sync it costs
+// sizes the output; the compaction itself never reads anything back.
+static size_t
+bit_where_count_true(VALUE self)
+{
+    VALUE v = <%=find_tmpl("count_true").c_func%>(0, NULL, self);
+    uint64_t count;
+    char *ptr;
+
+    if (RB_INTEGER_TYPE_P(v)) {
+        return NUM2SIZET(v);
+    }
+    ptr = cumo_na_get_pointer_for_read(v) + cumo_na_get_offset(v);
+    cumo_cuda_runtime_check_status(cudaMemcpy(&count, ptr, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    cumo_na_release_lock(v);
+    return (size_t)count;
+}
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
@@ -21,16 +44,23 @@ static void
     size_t  e;
     where_opt_t *g;
 
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
     g = (where_opt_t*)(lp->opt_ptr);
     count = g->count;
     idx1  = g->idx1;
     e     = g->elmsz;
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a, p, s, idx);
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        // idx1 stays put: the device-side cursor in the scratch orders the
+        // writes of successive calls instead.
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,count,g->scratch);
+        g->count = count + i;
+        return;
+    }
+
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
     if (idx) {
         for (; i--;) {
             CUMO_LOAD_BIT(a, p+*idx, x);
@@ -72,7 +102,7 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 0, ain, 0 };
 
     size = CUMO_RNARRAY_SIZE(self);
-    n_1 = NUM2SIZET(<%=find_tmpl("count_true_cpu").c_func%>(0, NULL, self));
+    n_1 = bit_where_count_true(self);
     g = ALLOCA_N(where_opt_t,1);
     g->count = 0;
     if (size>4294967295ul) {
@@ -84,7 +114,14 @@ static VALUE
     }
     g->idx1 = cumo_na_get_pointer_for_write(idx_1);
     g->idx0 = NULL;
+    g->scratch = NULL;
+    if (size >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        g->scratch = cumo_bit_where_scratch_new();
+    }
     cumo_na_ndloop3(&ndf, g, 1, self);
+    if (g->scratch) {
+        cumo_cuda_runtime_free(g->scratch);
+    }
     cumo_na_release_lock(idx_1);
     return idx_1;
 }

--- a/ext/cumo/narray/gen/tmpl_bit/where2.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where2.c
@@ -12,10 +12,6 @@ static void
     size_t  e;
     where_opt_t *g;
 
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
     g = (where_opt_t*)(lp->opt_ptr);
     count = g->count;
     idx0  = g->idx0;
@@ -23,6 +19,16 @@ static void
     e     = g->elmsz;
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a, p, s, idx);
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,count,g->scratch);
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,1,idx0,e,count,g->scratch);
+        g->count = count + i;
+        return;
+    }
+
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
     if (idx) {
         for (; i--;) {
             CUMO_LOAD_BIT(a, p+*idx, x);
@@ -73,7 +79,7 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 0, ain, 0 };
 
     size = CUMO_RNARRAY_SIZE(self);
-    n_1 = NUM2SIZET(<%=find_tmpl("count_true_cpu").c_func%>(0, NULL, self));
+    n_1 = bit_where_count_true(self);
     n_0 = size - n_1;
     g = ALLOCA_N(where_opt_t,1);
     g->count = 0;
@@ -88,7 +94,14 @@ static VALUE
     }
     g->idx1 = cumo_na_get_pointer_for_write(idx_1);
     g->idx0 = cumo_na_get_pointer_for_write(idx_0);
+    g->scratch = NULL;
+    if (size >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        g->scratch = cumo_bit_where_scratch_new();
+    }
     cumo_na_ndloop3(&ndf, g, 1, self);
+    if (g->scratch) {
+        cumo_cuda_runtime_free(g->scratch);
+    }
     cumo_na_release_lock(idx_0);
     cumo_na_release_lock(idx_1);
     return rb_assoc_new(idx_1,idx_0);

--- a/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
@@ -1,0 +1,107 @@
+// Compacts the indices of the one (or, inverted, zero) bits, in ascending
+// order: each block counts the hits of a contiguous range of chunks, one scan
+// block turns the counts into output positions, and each block scatters its
+// range from its position. *running carries the output cursor from one ndloop
+// iteration to the next entirely on the device, so no launch reads anything
+// back to the host.
+
+// The scan kernel is one block, so it bounds the scratch the caller allocates
+// and the sequential work it does itself.
+#define CUMO_BIT_WHERE_MAX_BLOCKS 1024
+
+__global__ void cumo_bit_where_partial_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, int invert, uint64_t nchunks, uint64_t cpb, uint64_t *block_sums)
+{
+    uint64_t start = blockIdx.x * cpb;
+    uint64_t end = (nchunks - start < cpb) ? nchunks : start + cpb;
+    uint64_t cnt = 0;
+    uint64_t c0, total;
+
+    if (start > nchunks) { start = end = nchunks; }
+    for (c0 = start; c0 < end; c0 += blockDim.x) {
+        uint64_t c = c0 + threadIdx.x;
+        if (c < end) {
+            cnt += (uint64_t)__popc(cumo_bit_chunk(a, p, s, idx, n, nw, c, contiguous, invert));
+        }
+    }
+    cumo_bit_block_exscan(cnt, &total);
+    if (threadIdx.x == 0) {
+        block_sums[blockIdx.x] = total;
+    }
+}
+
+__global__ void cumo_bit_where_scan_kernel(uint64_t *block_sums, uint64_t nblocks, uint64_t *running)
+{
+    uint64_t acc = *running;
+    uint64_t t0;
+
+    for (t0 = 0; t0 < nblocks; t0 += blockDim.x) {
+        uint64_t t = t0 + threadIdx.x;
+        uint64_t v = (t < nblocks) ? block_sums[t] : 0;
+        uint64_t total;
+        uint64_t pre = cumo_bit_block_exscan(v, &total);
+        if (t < nblocks) {
+            block_sums[t] = acc + pre;
+        }
+        acc += total;
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        *running = acc;
+    }
+}
+
+__global__ void cumo_bit_where_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, int invert, uint64_t nchunks, uint64_t cpb, char *out, size_t elmsz, uint64_t count, uint64_t *block_sums)
+{
+    uint64_t start = blockIdx.x * cpb;
+    uint64_t end = (nchunks - start < cpb) ? nchunks : start + cpb;
+    uint64_t off = block_sums[blockIdx.x];
+    uint64_t c0;
+
+    if (start > nchunks) { start = end = nchunks; }
+    for (c0 = start; c0 < end; c0 += blockDim.x) {
+        uint64_t c = c0 + threadIdx.x;
+        CUMO_BIT_DIGIT z = 0;
+        uint64_t total;
+        uint64_t pre;
+        uint64_t o;
+
+        if (c < end) {
+            z = cumo_bit_chunk(a, p, s, idx, n, nw, c, contiguous, invert);
+        }
+        pre = cumo_bit_block_exscan((uint64_t)__popc(z), &total);
+        o = off + pre;
+        while (z) {
+            int k = __ffs(z) - 1;
+            cumo_bit_store_index(out, elmsz, o++, count + c * CUMO_NB + k);
+            z &= z - 1;
+        }
+        off += total;
+        __syncthreads();
+    }
+}
+
+char *cumo_bit_where_scratch_new(void)
+{
+    char *scratch = cumo_cuda_runtime_malloc((2 + CUMO_BIT_WHERE_MAX_BLOCKS) * sizeof(uint64_t));
+    cudaMemsetAsync(scratch, 0, 2 * sizeof(uint64_t), 0);
+    cumo_cuda_runtime_check_kernel_launch();
+    return scratch;
+}
+
+void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t count, char *scratch)
+{
+    uint64_t nchunks = (n + CUMO_NB - 1) / CUMO_NB;
+    int contiguous = (idx == NULL && s == 1);
+    uint64_t nw = contiguous ? (p + n + CUMO_NB - 1) / CUMO_NB : 0;
+    uint64_t nblocks = (nchunks + CUMO_BIT_CHUNK_BLOCK - 1) / CUMO_BIT_CHUNK_BLOCK;
+    uint64_t *running = (uint64_t*)scratch + (invert ? 1 : 0);
+    uint64_t *block_sums = (uint64_t*)scratch + 2;
+    uint64_t cpb;
+
+    if (nblocks > CUMO_BIT_WHERE_MAX_BLOCKS) nblocks = CUMO_BIT_WHERE_MAX_BLOCKS;
+    cpb = (nchunks + nblocks - 1) / nblocks;
+    cumo_bit_where_partial_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,invert,nchunks,cpb,block_sums);
+    cumo_bit_where_scan_kernel<<<1, CUMO_BIT_CHUNK_BLOCK>>>(block_sums,nblocks,running);
+    cumo_bit_where_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,invert,nchunks,cpb,out,elmsz,count,block_sums);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2646,4 +2646,45 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(Cumo::Bit.cast(want.map { |row| row.none? { |x| x == 1 } ? 1 : 0 }),
                  (~v).all?(axis: 1))
   end
+
+  test "bit where and where2 over long arrays and views" do
+    n = 20_000
+    xs = Array.new(n) { |i| ((i * 2_654_435_761) >> 11) & 1 }
+    picked = Array.new(n) { |i| ((i * 7) + 3) % n }
+    views = [
+      ["flat", (0...n).to_a, ->(v) { v }],
+      ["offset 13", (13...n).to_a, ->(v) { v[13...n] }],
+      ["step 2", (0...n).step(2).to_a, ->(v) { v[(0...n).step(2)] }],
+      ["reversed", (n - 1).downto(0).to_a, ->(v) { v[(n - 1).step(0, -1)] }],
+      ["indexed", picked, ->(v) { v[picked] }],
+    ]
+
+    a = Cumo::Bit.cast(xs)
+    views.each do |label, idxs, slice|
+      seq = idxs.map { |i| xs[i] }
+      want_one = seq.each_index.select { |i| seq[i] == 1 }
+      want_zero = seq.each_index.select { |i| seq[i] == 0 }
+      v = slice.call(a)
+      assert_equal(want_one, v.where.to_a, label)
+      w1, w0 = v.where2
+      assert_equal(want_one, w1.to_a, label)
+      assert_equal(want_zero, w0.to_a, label)
+    end
+  end
+
+  test "bit where along the rows of a 2-d view" do
+    rows = 4
+    cols = 20_000
+    xs = Array.new(rows * cols) { |i| ((i * 40_503) >> 7) & 1 }
+    a = Cumo::Bit.cast(xs).reshape(rows, cols)
+
+    # each row is long enough to run on the device, and the view drops a
+    # column at either end so the rows stay separate calls
+    v = a[true, 1..-2]
+    seq = (0...rows).flat_map { |r| xs[r * cols + 1, cols - 2] }
+    assert_equal(seq.each_index.select { |i| seq[i] == 1 }, v.where.to_a)
+    w1, w0 = v.where2
+    assert_equal(seq.each_index.select { |i| seq[i] == 1 }, w1.to_a)
+    assert_equal(seq.each_index.select { |i| seq[i] == 0 }, w0.to_a)
+  end
 end


### PR DESCRIPTION
## Summary

- Add CUDA kernels for `Cumo::Bit#where` and `#where2`: each block counts the hits of a contiguous range of 32-element chunks, one scan block turns the counts into output positions, and each block scatters its indices, so the output stays in ascending order. A device-side cursor carries the output position across ndloop calls, and `where2` reuses the same three kernels with the chunk inverted.
- Size the output with the device `count_true` and a 4-byte copy instead of the host `count_true_cpu` loop, so nothing walks the bits on the host.
- Keep the host loop for calls under 8192 elements, where three launches per call cost more than walking the bits (same measured crossover as the `bit_reduce` threshold in #239).

## Performance

RTX 5070 Ti Laptop, 4194304 bits, best of 5 runs in a fresh process:

| case | before | after |
|---|---|---|
| `where`, half ones | 4.93 ms | 0.11 ms |
| `where`, 2% ones | 2.95 ms | 0.05 ms |
| `where`, all ones | 6.50 ms | 0.19 ms |
| `where2`, half ones | 7.35 ms | 0.17 ms |
| `where` on a sliced 2-d view | 3.55 ms | 0.43 ms |

Views whose rows fall under the threshold keep the host path and are unchanged.

## Verification

- 2510 cross-checks against Numo (sizes 0 to 100000, seven patterns, nine view shapes including negative steps and index views, plus multi-call 2-d views): 0 differences.
- Positive controls: off-by-one in the scatter and a dropped cursor carry each fail the checks; restoring the code passes them.
- `rake test`: 1485 tests, 0 failures. `CUMO_SHOW_WARNING=ON` no longer reports the fixme for `where`/`where2` on the device path.
