### PR TITLE
Add cumsum and cumprod kernels for the cum template

### DIFF
--- a/ext/cumo/include/cumo/cuda/cumo_thrust.hpp
+++ b/ext/cumo/include/cumo/cuda/cumo_thrust.hpp
@@ -10,8 +10,24 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/reduce.h>
+#include <thrust/scan.h>
 #include <thrust/system/cuda/execution_policy.h>
+#include <thrust/system_error.h>
 #include <thrust/transform_reduce.h>
+
+// Scratch for an algorithm that needs it, taken from the same pool as array
+// data so that a loop calling one per row reuses a free-list entry instead of
+// going to cudaMalloc every time. Declared here rather than including
+// cuda/memory_pool.h, which needs ruby.h.
+extern "C" char* cumo_cuda_runtime_malloc(size_t size);
+extern "C" void cumo_cuda_runtime_free(char *ptr);
+
+struct cumo_thrust_pool_allocator
+{
+    typedef char value_type;
+    char *allocate(std::ptrdiff_t n) { return cumo_cuda_runtime_malloc((size_t)n); }
+    void deallocate(char *p, size_t) { cumo_cuda_runtime_free(p); }
+};
 
 // this example illustrates how to make strided access to a range of values
 // examples:

--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -69,6 +69,10 @@
 // Same trade for the three launches of a where compaction.
 #define CUMO_BIT_WHERE_MIN_KERNEL_SIZE 8192
 
+// A cumulative reduction along a short axis runs its scan once per row, and a
+// parallel scan needs scratch and several launches to start up.
+#define CUMO_CUM_MIN_KERNEL_SIZE 8192
+
 #define CUMO_GET_DATA( ptr, type, val )                 \
     {                                              \
         val = *(type*)(ptr);                       \

--- a/ext/cumo/include/cumo/types/xint_macro_kernel.h
+++ b/ext/cumo/include/cumo/types/xint_macro_kernel.h
@@ -43,8 +43,8 @@
 
 #define m_mulsum(x,y,z) {z += x*y;}
 #define m_mulsum_init 0
-//#define m_cumsum(x,y) {x += y;}
-//#define m_cumprod(x,y) {x *= y;}
+#define m_cumsum(x,y) {x += y;}
+#define m_cumprod(x,y) {x *= y;}
 
 __host__ __device__ static inline double f_seq(double x, double y, double c)
 {

--- a/ext/cumo/narray/gen/tmpl/cum.c
+++ b/ext/cumo/narray/gen/tmpl/cum.c
@@ -1,3 +1,9 @@
+<% unless type_name == 'robject' %>
+<% (is_float ? ["","_nan"] : [""]).each do |j| %>
+cudaError_t <%="cumo_#{type_name}_#{name}#{j}_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n);
+<% end %>
+<% end %>
+
 <% (is_float ? ["","_nan"] : [""]).each do |j| %>
 static void
 <%=c_iter%><%=j%>(cumo_na_loop_t *const lp)
@@ -11,6 +17,13 @@ static void
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     //printf("i=%lu p1=%lx s1=%lu p2=%lx s2=%lu\n",i,(size_t)p1,s1,(size_t)p2,s2);
+
+  <% unless type_name == 'robject' %>
+    if (i >= CUMO_CUM_MIN_KERNEL_SIZE) {
+        cumo_cuda_runtime_check_status(<%="cumo_#{type_name}_#{name}#{j}_kernel_launch"%>(p1,p2,s1,s2,i));
+        return;
+    }
+  <% end %>
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());

--- a/ext/cumo/narray/gen/tmpl/cum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cum_kernel.cu
@@ -1,0 +1,72 @@
+<% unless type_name == 'robject' %>
+<% (is_float ? ["","_nan"] : [""]).each do |j| %>
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+
+// Reusing the macro keeps the operator identical to the host loop, including
+// how it carries a NaN. What does change is the association: a parallel scan
+// does not add strictly left to right, so a float result can differ in the
+// last ulp, the same way sum already does.
+struct <%="cumo_thrust_#{name}#{j}"%>
+{
+    using first_argument_type  = dtype;
+    using second_argument_type = dtype;
+    using result_type          = dtype;
+    __host__ __device__ dtype operator()(dtype x, dtype y) const { m_<%=name%><%=j%>(x,y); return x; }
+};
+
+// Nothing may reach the C caller: it has no handler, so an escaping exception
+// is std::terminate. The status goes back instead and the caller raises.
+template<typename Iterator1, typename Iterator2>
+static cudaError_t <%="cumo_#{type_name}_#{name}#{j}_scan"%>(Iterator1 first, Iterator1 last, Iterator2 result)
+{
+    cumo_thrust_pool_allocator alloc;
+    try {
+        thrust::inclusive_scan(thrust::cuda::par(alloc), first, last, result, <%="cumo_thrust_#{name}#{j}"%>());
+    } catch (const thrust::system_error& e) {
+        return (cudaError_t)e.code().value();
+    } catch (const std::bad_alloc&) {
+        return cudaErrorMemoryAllocation;
+    } catch (...) {
+        return cudaErrorUnknown;
+    }
+    return cudaSuccess;
+}
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+cudaError_t <%="cumo_#{type_name}_#{name}#{j}_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
+{
+    ssize_t s1_idx = s1 / (ssize_t)sizeof(dtype);
+    ssize_t s2_idx = s2 / (ssize_t)sizeof(dtype);
+    thrust::device_ptr<dtype> p1_begin = thrust::device_pointer_cast((dtype*)p1);
+    thrust::device_ptr<dtype> p2_begin = thrust::device_pointer_cast((dtype*)p2);
+    cudaError_t status;
+
+    // A broadcast operand has stride 0 and a reversed view a negative one, so
+    // anything but 1 has to go through the strided range.
+    if (s1_idx == 1 && s2_idx == 1) {
+        status = <%="cumo_#{type_name}_#{name}#{j}_scan"%>(p1_begin, p1_begin + n, p2_begin);
+    } else {
+        typedef cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range_t;
+        range_t r1(p1_begin, (range_t::difference_type)s1_idx, (range_t::difference_type)n);
+        range_t r2(p2_begin, (range_t::difference_type)s2_idx, (range_t::difference_type)n);
+        status = <%="cumo_#{type_name}_#{name}#{j}_scan"%>(r1.begin(), r1.end(), r2.begin());
+    }
+    if (status != cudaSuccess) {
+        return status;
+    }
+    return cudaGetLastError();
+}
+<% end %>
+<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2697,4 +2697,104 @@ class NArrayTest < Test::Unit::TestCase
     ones.each { |i| a[i] = 1 }
     assert_equal(ones.size, a.count_true.to_i)
   end
+
+  # cumsum and cumprod had no tests at all before the scan was moved to the device
+  def running(values)
+    acc = nil
+    values.map { |x| acc = acc.nil? ? x : yield(acc, x) }
+  end
+
+  # what the host loop does with nan:true: the first element is copied through,
+  # and a nan in the accumulator is replaced by the next value rather than spread
+  def running_skip_nan(values)
+    acc = values[0]
+    out = [acc]
+    values[1..-1].each do |y|
+      if acc.nan?
+        acc = y
+      elsif !y.nan?
+        acc = yield(acc, y)
+      end
+      out << acc
+    end
+    out
+  end
+
+  def nan_eq(got, want)
+    got.size == want.size &&
+      got.each_index.all? { |i| (got[i].nan? && want[i].nan?) || got[i] == want[i] }
+  end
+
+  test "cumsum and cumprod over long arrays and views" do
+    # long enough that the scan runs on the device, with values that keep every
+    # partial result exactly representable, so the answer cannot depend on the
+    # order a parallel scan associates in
+    n = 20_000
+    adds = Array.new(n) { |i| (i % 3) + 1 }
+    muls = Array.new(n) { |i| i % 4 < 2 ? 2 : 0.5 }
+    views = [
+      ["flat", (0...n).to_a, ->(v) { v }],
+      ["offset 13", (13...n).to_a, ->(v) { v[13...n] }],
+      ["step 2", (0...n).step(2).to_a, ->(v) { v[(0...n).step(2)] }],
+      ["reversed", (n - 1).downto(0).to_a, ->(v) { v[(n - 1).step(0, -1)] }],
+    ]
+
+    [Cumo::Int32, Cumo::DFloat, Cumo::SFloat].each do |klass|
+      a = klass.cast(adds)
+      views.each do |label, idxs, slice|
+        want = running(idxs.map { |i| adds[i] }) { |x, y| x + y }
+        assert_equal(want, slice.call(a).cumsum.to_a, "#{klass} cumsum #{label}")
+      end
+    end
+
+    [Cumo::DFloat, Cumo::SFloat].each do |klass|
+      a = klass.cast(muls)
+      views.each do |label, idxs, slice|
+        want = running(idxs.map { |i| muls[i] }) { |x, y| x * y }
+        assert_equal(want, slice.call(a).cumprod.to_a, "#{klass} cumprod #{label}")
+      end
+    end
+  end
+
+  test "cumsum and cumprod along an axis" do
+    rows = 6
+    cols = 20_000
+    adds = Array.new(rows * cols) { |i| (i % 3) + 1 }
+    muls = Array.new(rows * cols) { |i| i % 4 < 2 ? 2 : 0.5 }
+
+    a = Cumo::DFloat.cast(adds).reshape(rows, cols)
+    rowwise = (0...rows).map { |r| running(adds[r * cols, cols]) { |x, y| x + y } }
+    assert_equal(rowwise, a.cumsum(axis: 1).to_a)
+
+    down = (0...cols).map { |c| running((0...rows).map { |r| adds[r * cols + c] }) { |x, y| x + y } }
+    assert_equal((0...rows).map { |r| (0...cols).map { |c| down[c][r] } },
+                 a.cumsum(axis: 0).to_a)
+
+    b = Cumo::DFloat.cast(muls).reshape(rows, cols)
+    assert_equal((0...rows).map { |r| running(muls[r * cols, cols]) { |x, y| x * y } },
+                 b.cumprod(axis: 1).to_a)
+  end
+
+  test "cumsum and cumprod carry a nan the same way on either path" do
+    # one size below the threshold that keeps the host loop and one above it
+    [64, 20_000].each do |n|
+      [0, 1, n / 2, n - 1].each do |at|
+        adds = Array.new(n) { |i| (i % 3) + 1.0 }
+        muls = Array.new(n) { |i| i % 4 < 2 ? 2.0 : 0.5 }
+        adds[at] = Float::NAN
+        muls[at] = Float::NAN
+        lbl = "n=#{n} at=#{at}"
+
+        a = Cumo::DFloat.cast(adds)
+        assert(nan_eq(a.cumsum.to_a, running(adds) { |x, y| x + y }), "cumsum #{lbl}")
+        assert(nan_eq(a.cumsum(nan: true).to_a, running_skip_nan(adds) { |x, y| x + y }),
+               "cumsum nan:true #{lbl}")
+
+        b = Cumo::DFloat.cast(muls)
+        assert(nan_eq(b.cumprod.to_a, running(muls) { |x, y| x * y }), "cumprod #{lbl}")
+        assert(nan_eq(b.cumprod(nan: true).to_a, running_skip_nan(muls) { |x, y| x * y }),
+               "cumprod nan:true #{lbl}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Run `cumsum` and `cumprod` on the device with `thrust::inclusive_scan`. The binary operator reuses the same `m_cumsum`/`m_cumprod` macro the host loop used, so how a NaN is carried is unchanged, and `nan:true` keeps its own variant.
- Give thrust a temporary allocator backed by cumo's memory pool. Its default one goes to `cudaMalloc`/`cudaFree` on every call, which costs more than the scan itself.
- Keep the host loop for calls under 8192 elements, where a per-row scan does not pay for its startup (same measured crossover as #239 and #241).
- `m_cumsum`/`m_cumprod` were commented out in `xint_macro_kernel.h`; uncomment them so integer types get the same operator.

## Performance

RTX 5070 Ti Laptop, `DFloat`, operand freshly written by a kernel, best of 5 runs in a fresh process:

| case | before | after |
|---|---|---|
| `cumsum`, 4194304 elements | 9.36 ms | 0.18 ms |
| `cumprod`, 4194304 elements | 8.80 ms | 0.18 ms |
| `cumsum(nan: true)`, 4194304 elements | 9.95 ms | 0.25 ms |
| `cumsum(axis: 1)`, 64 x 65536 | 3.74 ms | 1.56 ms |
| `cumsum(axis: 1)`, 512 x 8192 | 12.92 ms | 5.29 ms |

The pool allocator is most of the multi-row win: 512 rows of 8192 take 35.8 ms with thrust's default allocator and 6.2 ms with the pool.

## Float results move, and towards the exact answer

A parallel scan does not accumulate strictly left to right, so float results can differ from Numo in the last ulp, exactly as `sum` and `prod` already do. Measured against an exact rational running sum over 100000 random values, the scan is the more accurate of the two: relative error 7.4e-10 against Numo's 8.7e-9.

Overflowed `cumprod` values can also differ in kind rather than degree (`Infinity+0.0i` where Numo has `NaN+NaN*i`), because complex multiplication mixes the components. `Cumo::DComplex#prod` already answers differently from Numo for the same reason, so this makes `cumprod` agree with `prod`.

## Verification

- 788 cross-checks against Numo (12 dtypes, sizes 1 to 20000, four view shapes including negative steps, both axes of three 2-d shapes, and a NaN at four positions with `nan:` both ways): integer types match exactly, float types within tolerance.
- Positive controls: an exclusive scan, a dropped input stride, and the `nan` variant falling back to the plain operator each fail the checks and the new tests.
- Adds the first tests `cumsum`/`cumprod` have had. `rake test`: 1489 tests, 0 failures.
