### PR TITLE
Fix the accum reductions running in a single GPU thread

### DIFF
--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -1,4 +1,4 @@
-<% indexer_ops = %w[sum prod min max ptp] %>
+<% indexer_ops = %w[sum prod min max ptp var stddev mean rms] %>
 <% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
 <% unless type_name == 'robject' %>

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -19,44 +19,55 @@ struct cumo_<%=type_name%>_prod_impl {
     __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
 };
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_mean_kernel(Iterator1 p1_begin, Iterator1 p1_end, <%=dtype%>* p2, uint64_t n)
-{
-    dtype init = m_zero;
-    dtype sum = thrust::reduce(thrust::cuda::par, p1_begin, p1_end, init, cumo_thrust_plus());
-    *p2 = c_div_r(sum, n);
-}
+// Chan's parallel combination of a running count, mean and sum of squared
+// deviations, which is what the thrust functor these replace accumulated. The
+// mean stays complex and only the deviation collapses to a magnitude. The
+// guards are what make Identity neutral: combining two of them would divide
+// 0 by 0 and leave the accumulator NaN.
+struct cumo_<%=type_name%>_moments_impl {
+    struct Moments {
+        rtype n;
+        dtype mean;
+        rtype m2;
+    };
+    __device__ Moments Identity(int64_t /*index*/) { return {0, m_zero, 0}; }
+    __device__ Moments MapIn(dtype in, int64_t /*index*/) { return {1, in, 0}; }
+    __device__ void Reduce(Moments next, Moments& accum) {
+        if (next.n == 0) { return; }
+        if (accum.n == 0) { accum = next; return; }
+        rtype n = accum.n + next.n;
+        dtype delta = c_sub(next.mean, accum.mean);
+        accum.mean = c_add(accum.mean, c_mul_r(delta, next.n / n));
+        accum.m2 += next.m2 + c_abs_square(delta) * accum.n * next.n / n;
+        accum.n = n;
+    }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_var_kernel(Iterator1 p1_begin, Iterator1 p1_end, rtype* p2)
-{
-    cumo_thrust_complex_variance_unary_op<dtype, rtype>  unary_op;
-    cumo_thrust_complex_variance_binary_op<dtype, rtype> binary_op;
-    cumo_thrust_complex_variance_data<dtype, rtype> init = {};
-    cumo_thrust_complex_variance_data<dtype, rtype> result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, unary_op, init, binary_op);
-    *p2 = result.variance();
-}
+struct cumo_<%=type_name%>_var_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ rtype MapOut(Moments accum) { return accum.m2 / (accum.n - 1); }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_stddev_kernel(Iterator1 p1_begin, Iterator1 p1_end, rtype* p2)
-{
-    cumo_thrust_complex_variance_unary_op<dtype, rtype>  unary_op;
-    cumo_thrust_complex_variance_binary_op<dtype, rtype> binary_op;
-    cumo_thrust_complex_variance_data<dtype, rtype> init = {};
-    cumo_thrust_complex_variance_data<dtype, rtype> result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, unary_op, init, binary_op);
-    *p2 = r_sqrt(result.variance());
-}
+struct cumo_<%=type_name%>_stddev_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ rtype MapOut(Moments accum) { return r_sqrt(accum.m2 / (accum.n - 1)); }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_rms_kernel(Iterator1 p1_begin, Iterator1 p1_end, rtype* p2, uint64_t n)
-{
-    rtype init = 0;
-    rtype result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, cumo_thrust_square(), init, thrust::plus<rtype>());
-    *p2 = r_sqrt(result/n);
-}
+struct cumo_<%=type_name%>_mean_impl {
+    // The reduce axis is the same length for every output, so the divisor is a
+    // constant the launcher already knows rather than a count the tree carries.
+    rtype n;
+    __device__ dtype Identity(int64_t /*index*/) { return m_zero; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { accum = m_add(next, accum); }
+    __device__ dtype MapOut(dtype accum) { return c_div_r(accum, n); }
+};
+
+struct cumo_<%=type_name%>_rms_impl {
+    rtype n;
+    __device__ rtype Identity(int64_t /*index*/) { return 0; }
+    __device__ rtype MapIn(dtype in, int64_t /*index*/) { return c_abs_square(in); }
+    __device__ void Reduce(rtype next, rtype& accum) { accum += next; }
+    __device__ rtype MapOut(rtype accum) { return r_sqrt(accum / n); }
+};
 
 #if defined(__cplusplus)
 extern "C" {
@@ -75,63 +86,24 @@ void cumo_<%=type_name%>_prod_kernel_launch(cumo_na_reduction_arg_t* arg)
     cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_impl>(*arg, cumo_<%=type_name%>_prod_impl{});
 }
 
-void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_mean_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (dtype*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (dtype*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    rtype n = (rtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_mean_impl>(*arg, cumo_<%=type_name%>_mean_impl{n});
 }
 
-void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_var_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-    thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_var_impl>(*arg, cumo_<%=type_name%>_var_impl{});
 }
 
-void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_stddev_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_stddev_impl>(*arg, cumo_<%=type_name%>_stddev_impl{});
 }
 
-void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_rms_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (rtype*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (rtype*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    rtype n = (rtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_impl>(*arg, cumo_<%=type_name%>_rms_impl{n});
 }
-

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -7,44 +7,55 @@
 }  /* extern "C" { */
 #endif
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_mean_kernel(Iterator1 p1_begin, Iterator1 p1_end, <%=dtype%>* p2, uint64_t n)
-{
-    dtype init = m_zero;
-    *p2 = thrust::reduce(thrust::cuda::par, p1_begin, p1_end, init, thrust::plus<dtype>());
-    *p2 /= (dtype)n;
-}
+// Chan's parallel combination of a running count, mean and sum of squared
+// deviations, which is what the thrust functor these replace accumulated. numo
+// takes two passes with the exact mean instead, so the last digits can differ.
+// The guards are what make Identity neutral: combining two of them would
+// divide 0 by 0 and leave the accumulator NaN.
+struct cumo_<%=type_name%>_moments_impl {
+    struct Moments {
+        rtype n;
+        dtype mean;
+        rtype m2;
+    };
+    __device__ Moments Identity(int64_t /*index*/) { return {0, m_zero, 0}; }
+    __device__ Moments MapIn(dtype in, int64_t /*index*/) { return {1, in, 0}; }
+    __device__ void Reduce(Moments next, Moments& accum) {
+        if (next.n == 0) { return; }
+        if (accum.n == 0) { accum = next; return; }
+        rtype n = accum.n + next.n;
+        dtype delta = m_sub(next.mean, accum.mean);
+        accum.mean = m_add(accum.mean, delta * (next.n / n));
+        accum.m2 += next.m2 + delta * delta * accum.n * next.n / n;
+        accum.n = n;
+    }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_var_kernel(Iterator1 p1_begin, Iterator1 p1_end, <%=dtype%>* p2)
-{
-    cumo_thrust_variance_unary_op<dtype>  unary_op;
-    cumo_thrust_variance_binary_op<dtype> binary_op;
-    cumo_thrust_variance_data<dtype> init = {};
-    cumo_thrust_variance_data<dtype> result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, unary_op, init, binary_op);
-    *p2 = result.variance();
-}
+struct cumo_<%=type_name%>_var_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ rtype MapOut(Moments accum) { return accum.m2 / (accum.n - 1); }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_stddev_kernel(Iterator1 p1_begin, Iterator1 p1_end, <%=dtype%>* p2)
-{
-    cumo_thrust_variance_unary_op<dtype>  unary_op;
-    cumo_thrust_variance_binary_op<dtype> binary_op;
-    cumo_thrust_variance_data<dtype> init = {};
-    cumo_thrust_variance_data<dtype> result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, unary_op, init, binary_op);
-    *p2 = m_sqrt(result.variance());
-}
+struct cumo_<%=type_name%>_stddev_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ rtype MapOut(Moments accum) { return m_sqrt(accum.m2 / (accum.n - 1)); }
+};
 
-template<typename Iterator1>
-__global__ void cumo_<%=type_name%>_rms_kernel(Iterator1 p1_begin, Iterator1 p1_end, <%=dtype%>* p2, uint64_t n)
-{
-    dtype init = m_zero;
-    dtype result;
-    result = thrust::transform_reduce(thrust::cuda::par, p1_begin, p1_end, cumo_thrust_square(), init, thrust::plus<dtype>());
-    *p2 = m_sqrt(m_div(result,n));
-}
+struct cumo_<%=type_name%>_mean_impl {
+    // The reduce axis is the same length for every output, so the divisor is a
+    // constant the launcher already knows rather than a count the tree carries.
+    dtype n;
+    __device__ dtype Identity(int64_t /*index*/) { return m_zero; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { accum = m_add(next, accum); }
+    __device__ dtype MapOut(dtype accum) { return m_div(accum, n); }
+};
+
+struct cumo_<%=type_name%>_rms_impl {
+    rtype n;
+    __device__ rtype Identity(int64_t /*index*/) { return 0; }
+    __device__ rtype MapIn(dtype in, int64_t /*index*/) { return m_square(m_abs(in)); }
+    __device__ void Reduce(rtype next, rtype& accum) { accum += next; }
+    __device__ rtype MapOut(rtype accum) { return m_sqrt(accum / n); }
+};
 
 #if defined(__cplusplus)
 extern "C" {
@@ -53,62 +64,24 @@ extern "C" {
 #endif
 #endif
 
-void cumo_<%=type_name%>_mean_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_mean_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_mean_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    dtype n = (dtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_mean_impl>(*arg, cumo_<%=type_name%>_mean_impl{n});
 }
 
-void cumo_<%=type_name%>_var_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_var_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_var_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_var_impl>(*arg, cumo_<%=type_name%>_var_impl{});
 }
 
-void cumo_<%=type_name%>_stddev_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_stddev_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_stddev_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_stddev_impl>(*arg, cumo_<%=type_name%>_stddev_impl{});
 }
 
-void cumo_<%=type_name%>_rms_kernel_launch(uint64_t n, char *p1, ssize_t s1, char *p2)
+void cumo_<%=type_name%>_rms_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    ssize_t s1_idx = s1 / sizeof(dtype);
-    thrust::device_ptr<dtype> data_begin = thrust::device_pointer_cast((dtype*)p1);
-    if (s1_idx == 1 || n == 1) {
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(data_begin, data_begin + n, (<%=dtype%>*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    } else {
-        thrust::device_ptr<dtype> data_end = thrust::device_pointer_cast(((dtype*)p1) + n * s1_idx);
-        cumo_thrust_strided_range<thrust::device_vector<dtype>::iterator> range(data_begin, data_end, s1_idx);
-        cumo_<%=type_name%>_rms_kernel<<<1,1>>>(range.begin(), range.end(), (<%=dtype%>*)p2, n);
-        cumo_cuda_runtime_check_kernel_launch();
-    }
+    rtype n = (rtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_impl>(*arg, cumo_<%=type_name%>_rms_impl{n});
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -159,8 +159,8 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.sum == 29 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0 / 6 }
-          assert { a.var == 13.766666666666666 }
-          assert { a.stddev == 3.7103458958251676 }
+          assert { a.var == 13.76666666666667 }
+          assert { a.stddev == 3.710345895825168 }
           assert { a.rms == 5.901977069875258 }
         end
         assert { a.dup.fill(12) == [12] * 6 }
@@ -2795,6 +2795,108 @@ class NArrayTest < Test::Unit::TestCase
         assert(nan_eq(b.cumprod(nan: true).to_a, running_skip_nan(muls) { |x, y| x * y }),
                "cumprod nan:true #{lbl}")
       end
+    end
+  end
+
+  # the two-pass variance numo computes, in exact arithmetic
+  def exact_var(values)
+    mean = values.sum(0r, &:to_r) / values.size
+    (values.sum(0r) { |x| (x.to_r - mean)**2 } / (values.size - 1)).to_f
+  end
+
+  test "var and stddev over an axis long enough to split the reduction" do
+    # one output over a long axis is the shape cumo_reduce_split exists for, and
+    # the shifted data is where a one-pass accumulator loses digits if the
+    # running mean is not carried along with the deviations
+    rows = 5
+    cols = 40_000
+    xs = Array.new(rows * cols) { |i| 1000.0 + ((i * 7919) % 2003) / 1000.0 }
+
+    flat = Cumo::DFloat.cast(xs)
+    assert_in_delta(exact_var(xs), flat.var.to_f, exact_var(xs) * 1e-9)
+    assert_in_delta(Math.sqrt(exact_var(xs)), flat.stddev.to_f, Math.sqrt(exact_var(xs)) * 1e-9)
+
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    (0...rows).each do |r|
+      want = exact_var(xs[r * cols, cols])
+      assert_in_delta(want, a.var(axis: 1).to_a[r], want * 1e-9, "row #{r}")
+    end
+    assert_equal([rows, 1], a.var(axis: 1, keepdims: true).shape)
+
+    # a column reduction is the many-outputs shape, and a strided view starts
+    # each row at a different offset
+    down = (0...cols).map { |c| exact_var((0...rows).map { |r| xs[r * cols + c] }) }
+    got = a.var(axis: 0).to_a
+    [0, 1, cols / 2, cols - 1].each do |c|
+      assert_in_delta(down[c], got[c], down[c] * 1e-9, "col #{c}")
+    end
+
+    sel = (0...cols).step(3).to_a
+    want = exact_var(sel.map { |c| xs[c] })
+    assert_in_delta(want, a[true, (0...cols).step(3)].var(axis: 1).to_a[0], want * 1e-9)
+  end
+
+  test "mean and rms over an axis long enough to split the reduction" do
+    rows = 5
+    cols = 40_000
+    xs = Array.new(rows * cols) { |i| ((i * 7919) % 2003) / 100.0 - 10.0 }
+
+    flat = Cumo::DFloat.cast(xs)
+    want_mean = (xs.sum(0r, &:to_r) / xs.size).to_f
+    want_rms = Math.sqrt((xs.sum(0r) { |x| x.to_r**2 } / xs.size).to_f)
+    assert_in_delta(want_mean, flat.mean.to_f, want_mean.abs * 1e-9)
+    assert_in_delta(want_rms, flat.rms.to_f, want_rms * 1e-9)
+
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    got = a.mean(axis: 1).to_a
+    (0...rows).each do |r|
+      row = xs[r * cols, cols]
+      want = (row.sum(0r, &:to_r) / cols).to_f
+      assert_in_delta(want, got[r], want.abs * 1e-9, "row #{r}")
+    end
+
+    # the many-outputs shape, and a strided view starting each row elsewhere
+    down = (0...cols).map { |c| ((0...rows).sum(0r) { |r| xs[r * cols + c].to_r } / rows).to_f }
+    got = a.mean(axis: 0).to_a
+    [0, 1, cols / 2, cols - 1].each { |c| assert_in_delta(down[c], got[c], down[c].abs * 1e-9, "col #{c}") }
+
+    sel = (0...cols).step(3).to_a
+    want = (sel.sum(0r) { |c| xs[c].to_r } / sel.size).to_f
+    assert_in_delta(want, a[true, (0...cols).step(3)].mean(axis: 1).to_a[0], want.abs * 1e-9)
+  end
+
+  test "mean of nearly cancelling values stays close to the exact answer" do
+    # the mean is tiny next to the elements, so it carries whatever error the
+    # sum accumulated and a mis-combined accumulator shows up immediately
+    n = 100_000
+    xs = Array.new(n) { |i| Math.sin(i * 1.7) * 10 }
+    exact = (xs.sum(0r, &:to_r) / n).to_f
+    assert_in_delta(exact, Cumo::DFloat.cast(xs).mean.to_f, 1e-12)
+    assert_in_delta(exact, Cumo::SFloat.cast(xs).mean.to_f, 1e-4)
+
+    want_rms = Math.sqrt((xs.sum(0r) { |x| x.to_r**2 } / n).to_f)
+    assert_in_delta(want_rms, Cumo::DFloat.cast(xs).rms.to_f, want_rms * 1e-12)
+  end
+
+  test "var and stddev keep their corner answers" do
+    # a single element has no degrees of freedom left, and nan:true drops the
+    # nan rather than spreading it
+    assert(Cumo::DFloat[3.5].var.to_f.nan?)
+    assert(Cumo::DFloat[3.5].stddev.to_f.nan?)
+    assert_equal(0.0, Cumo::DFloat[3.5, 3.5].var.to_f)
+
+    n = 20_000
+    xs = Array.new(n) { |i| (i % 17) + 1.0 }
+    [0, n / 2, n - 1].each do |at|
+      ys = xs.dup
+      ys[at] = Float::NAN
+      a = Cumo::DFloat.cast(ys)
+      assert(a.var.to_f.nan?, "nan spreads at=#{at}")
+      assert(a.stddev.to_f.nan?, "nan spreads at=#{at}")
+
+      kept = xs.each_with_index.reject { |_, i| i == at }
+      want = exact_var(kept.map(&:first))
+      assert_in_delta(want, a.var(nan: true).to_f, want * 1e-9, "nan:true at=#{at}")
     end
   end
 end


### PR DESCRIPTION
## Summary

- `mean`, `var`, `stddev` and `rms` ran their whole reduction in **one GPU thread**. Their kernels call thrust with `thrust::cuda::par` from inside a `__global__` launched as `<<<1,1>>>`. That shape relied on dynamic parallelism, which thrust 2.x removed, so it compiles to the sequential fallback.
- Move all four onto `cumo_reduce_split`, the path `sum`, `min`, `max` and `ptp` already use: a moments accumulator for `var`/`stddev`, and a sum whose divisor the launcher passes in for `mean`/`rms`.
- `nan: true` still takes the host loop, unchanged.

## The single thread, four ways

- The build has no `-rdc=true` and the built `.so` contains no `cudaLaunchDevice`, so dynamic parallelism is not merely unused, it is impossible.
- `var` cost a flat 571.8 / 574.3 / 642.5 ns per element at 65536 / 262144 / 1048576 elements. A parallel reduction's per-element cost falls as the array grows; a single thread's does not.
- `sum` and `min`, which already go through `cumo_reduce`, cost 0.2-0.3 ns per element on the same data.
- The generated launches are literally `<<<1,1>>>`.

## Performance

RTX 5070 Ti Laptop, `DFloat`, 1048576 elements, operand freshly written by a kernel, best of 4 runs in a fresh process:

| method | before | after | numo on the CPU |
|---|---|---|---|
| `var` | 673.7 ms | 0.296 ms | 0.796 ms |
| `stddev` | 663.7 ms | 0.301 ms | — |
| `rms` | 32.7 ms | 0.264 ms | — |
| `mean` | 32.4 ms | 0.263 ms | 0.402 ms |
| `sum` (unchanged, for scale) | 0.264 ms | 0.264 ms | — |

All four now cost what `sum` costs. Before this the GPU lost to the CPU by 846x on `var`.

## Results move, and towards the exact answer

Summing in a tree rather than left to right changes the last digits.

`mean` gains accuracy where it matters most. Over 100000 values in [-10, 10] whose mean nearly cancels to -0.00128, measured against an exact rational mean of the same float32 inputs:

```
SFloat   tree 5.2e-07   sequential 4.6e-05    (88x closer)
DFloat   tree 8.0e-16   sequential 1.6e-14    (19x closer)
```

`var` is the same algorithm as before, only combined in a different order. Over 30 shapes it matched Numo bit for bit in 12 cases against 11 before, and the cases that differ by more than 1e-12 are the same 10 either way (large offsets, where Numo's two-pass and a one-pass accumulator genuinely part company).

Two assertions in the suite pinned the old association order for `var` and `stddev`. Both now hold the value Numo produces:

```
Cumo::DFloat[1,2,3,5,7,11].var     old 13.766666666666666  new 13.76666666666667   == Numo
Cumo::DFloat[1,2,3,5,7,11].stddev  old 3.7103458958251676  new 3.710345895825168   == Numo
```

## Verification

- 248 cross-checks against Numo (4 float dtypes, sizes 2 to 100000, both axes, keepdims, strided views, `nan:` both ways, NaN at three positions) agree within tolerance before and after.
- Positive controls: dividing by `n - 1` in `mean`, dropping the square in `rms`, dividing by `n` instead of `n - 1` in `var`, and dropping the cross term that makes the moments combinable each fail the checks and the tests. Removing the neutral-identity guards does not fail anything; `round_up_to_power_of_2` keeps the identity slots below half the tree, and an empty split chunk would need `n_split` above both `sqrt(reduce_size)` and `reduce_size / 1024`, which cannot both hold. The guards stay because every other impl in the file has a genuinely neutral identity.
- Adds tests for the split path, the many-outputs path, strided views, near-cancelling data and the NaN corners. `rake test`: 1493 tests, 0 failures.

`mulsum`, which is what a vector `dot` runs, has the same `<<<1,1>>>` shape. It reduces two inputs at once, which `cumo_reduce` has no form for, so it is left for a follow-up.
