### PR TITLE
Add the indexer loop to store

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_from.c
+++ b/ext/cumo/narray/gen/tmpl/store_from.c
@@ -1,13 +1,11 @@
 //<% unless c_iter.include? 'robject' %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer);
 //<% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    //<% if c_iter.include? 'robject' %>
     size_t  i, s1, s2;
     char   *p1, *p2;
     size_t *idx1, *idx2;
@@ -15,7 +13,6 @@ static void
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-    //<% if c_iter.include? 'robject' %>
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
     {
         <%=dtype%> x;
@@ -52,19 +49,11 @@ static void
     }
     //<% else %>
     {
-        if (idx2) {
-            if (idx1) {
-                <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,i);
-            } else {
-                <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,i);
-            }
-        } else {
-            if (idx1) {
-                <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,i);
-            } else {
-                <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,i);
-            }
-        }
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
     }
     //<% end %>
 }
@@ -74,7 +63,15 @@ static VALUE
 <%=c_func(:nodef)%>(VALUE self, VALUE obj)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{Qnil,0}};
+    //<% if c_iter.include? 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 2, 0, ain, 0 };
+    <% else %>
+    // Without INDEXER_LOOP ndloop walks the outer dimensions itself and the
+    // kernel runs once per row, which for a column slice costs one launch per
+    // row and nothing else. An index on either side is buffered into
+    // contiguous memory first, in one launch of its own.
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 0, ain, 0 };
+    <% end %>
 
     cumo_na_ndloop(&ndf, 2, self, obj);
     return self;

--- a/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
@@ -1,62 +1,30 @@
 <% unless c_iter.include? 'robject' %>
-__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p1 + idx1[i]) = <%=macro%>(*(<%=dtype%>*)(p2 + idx2[i]));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        *(dtype*)(p1) = <%=macro%>(*(<%=dtype%>*)(p2));
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p1 + (i * s1)) = <%=macro%>(*(<%=dtype%>*)(p2 + idx2[i]));
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
     }
-}
-
-__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p1 + idx1[i]) = <%=macro%>(*(<%=dtype%>*)(p2 + (i * s2)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p1 + (i * s1)) = <%=macro%>(*(<%=dtype%>*)(p2 + (i * s2)));
-    }
-}
-
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
-
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2981,4 +2981,42 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
   end
+
+  test "store into and out of views that ndloop cannot flatten" do
+    # a column slice, a transpose and an index view each leave more than one
+    # dimension for the kernel to walk; before the indexer loop the kernel ran
+    # once per row of them
+    rows = 40
+    cols = 12
+    xs = Array.new(rows * cols) { |i| (i % 11) + 1.0 }
+    src = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+
+    want = grid.map { |row| row[2...(cols - 1)] }
+    assert_equal(want, Cumo::DFloat.zeros(rows, cols - 3).store(src[true, 2...(cols - 1)]).to_a)
+
+    assert_equal(grid.transpose, Cumo::DFloat.zeros(cols, rows).store(src.transpose).to_a)
+
+    idx = Array.new(rows) { |i| ((i * 7) + 3) % rows }
+    assert_equal(idx.map { |i| grid[i] }, Cumo::DFloat.zeros(rows, cols).store(src[idx, true]).to_a)
+
+    # a store into a slice must leave the columns on either side alone
+    dst = Cumo::DFloat.zeros(rows, cols)
+    dst[true, 2...(cols - 1)] = src[true, 0...(cols - 3)]
+    assert_equal(grid.map { |row| [0.0, 0.0] + row[0...(cols - 3)] + [0.0] }, dst.to_a)
+
+    # a 5-d shape runs past the dimension-specialised kernels
+    deep = [2, 2, 3, 2, 5]
+    n = deep.reduce(:*)
+    ys = Array.new(n) { |i| (i % 7) + 1.0 }
+    a = Cumo::DFloat.cast(ys).reshape(*deep)
+    assert_equal(ys, Cumo::DFloat.zeros(*deep).store(a).to_a.flatten)
+    assert_equal(a.transpose.to_a.flatten,
+                 Cumo::DFloat.zeros(*deep.reverse).store(a.transpose).to_a.flatten)
+
+    # broadcast and dtype conversion still reach every element
+    assert_equal([[1.0, 2.0, 3.0]] * 4, Cumo::DFloat.zeros(4, 3).store(Cumo::Int32[1, 2, 3]).to_a)
+    assert_equal(grid.map { |row| row.map(&:to_i) },
+                 Cumo::Int32.zeros(rows, cols).store(src).to_a)
+  end
 end


### PR DESCRIPTION
## Summary

- `store` handed ndloop a one-dimensional kernel, so ndloop walked the outer dimensions itself and launched once per row. A column slice of a 512-row array therefore cost 512 launches and nothing else: the time was a flat 1.7 us per row whatever the row length.
- Give it `CUMO_NDF_INDEXER_LOOP` and an indexer kernel, the way `binary` already works, so the whole view goes in one launch. An index on either side is buffered into contiguous memory first, which ndloop already does in a single launch of its own.

## Performance

RTX 5070 Ti Laptop, `SFloat`, best of 10 windows in a fresh process. The source is a 512x1024 array and the slice is 512x128:

| case | before | after |
|---|---|---|
| store of a column slice | 0.9167 ms | 0.0025 ms |
| store of a transposed slice | 0.2082 ms | 0.0027 ms |
| `a[true, r] = b` | 0.8994 ms | 0.0026 ms |
| store of an index view | 3.0351 ms | 0.7972 ms |
| store of a whole array | 0.0032 ms | 0.0032 ms |
| `dup` | 0.0048 ms | 0.0047 ms |
| store with a dtype conversion | 0.0082 ms | 0.0080 ms |

Contiguous stores are untouched. `bench/transformer_bench.rb` on the GPU goes from 0.1764 to 0.0632 s per iteration, best of three runs each: splitting and merging the attention heads was 60% of the block and is now 4%.

## Verification

- 825 cross-checks against Numo: 7 dtypes in every convertible pair, shapes of 1 to 5 dimensions, and for each of those a column slice, a transpose, an index view and a store into a slice, plus broadcasts, a 0-dimensional store and an empty one.
- Positive controls: addressing the source with the destination's strides, and sending every rank to the rank-0 kernel, each fail the checks.
- `rake test`: 1497 tests, 0 failures.

An in-place store through an overlapping view still answers differently from Numo, whose host loop overwrites as it reads. That is unchanged by this: master and this branch give the same answer on `a.store(a[(n-1).step(0,-1)])`.
