### PR TITLE
Add the indexer loop to the unary templates

### DIFF
--- a/ext/cumo/narray/gen/tmpl/unary.c
+++ b/ext/cumo/narray/gen/tmpl/unary.c
@@ -1,50 +1,12 @@
 <% if type_name == 'robject' || name == 'map' %>
 <% else %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero);
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* divzero);
-
-static void
-<%=c_iter%>_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, size_t n, int* divzero)
-{
-    if (idx1) {
-        if (idx2) {
-            <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,n,divzero);
-        } else {
-            <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,n,divzero);
-        }
-    } else {
-        if (idx2) {
-            <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,n,divzero);
-        } else {
-            //<% if need_align %>
-            if (cumo_is_aligned(p1,sizeof(dtype)) &&
-                cumo_is_aligned(p2,sizeof(dtype)) ) {
-                if (s1 == sizeof(dtype) &&
-                    s2 == sizeof(dtype) ) {
-                    <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(p1,p2,n,divzero);
-                    return;
-                }
-                if (cumo_is_aligned_step(s1,sizeof(dtype)) &&
-                    cumo_is_aligned_step(s2,sizeof(dtype)) ) {
-                    //<% end %>
-                    <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,divzero);
-                    return;
-                    //<% if need_align %>
-                }
-            }
-            <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,divzero);
-            //<% end %>
-        }
-    }
-}
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, int* divzero);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    <% if type_name == 'robject' || name == 'map' %>
     size_t  n;
     char   *p1, *p2;
     ssize_t s1, s2;
@@ -53,8 +15,6 @@ static void
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-
-    <% if type_name == 'robject' || name == 'map' %>
     {
         size_t i;
         dtype x;
@@ -114,15 +74,19 @@ static void
     }
     <% else %>
     {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
         //<% if is_int and name == 'reciprocal' %>
         int *divzero = cumo_cuda_runtime_error_flag_new();
-        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,divzero);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer,divzero);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         if (cumo_cuda_runtime_error_flag_get(divzero)) {
             lp->err_type = rb_eZeroDivError;
         }
         //<% else %>
-        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,0);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer,0);
         //<% end %>
     }
     <% end %>
@@ -138,7 +102,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    //<% if type_name == 'robject' || name == 'map' %>
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 1,1, ain,aout};
+    <% else %>
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1,1, ain,aout};
+    <% end %>
 
     <% if name == 'map' %>
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());

--- a/ext/cumo/narray/gen/tmpl/unary2.c
+++ b/ext/cumo/narray/gen/tmpl/unary2.c
@@ -1,50 +1,12 @@
 <% if type_name == 'robject' %>
 <% else %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* intmin);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* intmin);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* intmin);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* intmin);
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* intmin);
-
-static void
-<%=c_iter%>_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, size_t n, int* intmin)
-{
-    if (idx1) {
-        if (idx2) {
-            <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,n,intmin);
-        } else {
-            <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,n,intmin);
-        }
-    } else {
-        if (idx2) {
-            <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,n,intmin);
-        } else {
-            //<% if need_align %>
-            if (cumo_is_aligned(p1,sizeof(dtype)) &&
-                cumo_is_aligned(p2,sizeof(<%=dtype%>)) ) {
-                if (s1 == sizeof(dtype) &&
-                    s2 == sizeof(<%=dtype%>) ) {
-                    <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(p1,p2,n,intmin);
-                    return;
-                }
-                if (cumo_is_aligned_step(s1,sizeof(dtype)) &&
-                    cumo_is_aligned_step(s2,sizeof(<%=dtype%>)) ) {
-                    //<% end %>
-                    <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,intmin);
-                    return;
-                    //<% if need_align %>
-                }
-            }
-            <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,n,intmin);
-            //<% end %>
-        }
-    }
-}
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, int* intmin);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    <% if type_name == 'robject' %>
     size_t  n;
     char   *p1, *p2;
     ssize_t s1, s2;
@@ -53,8 +15,6 @@ static void
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-
-    <% if type_name == 'robject' %>
     {
         size_t i;
         dtype x;
@@ -93,15 +53,19 @@ static void
     }
     <% else %>
     {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
         //<% if is_int and !is_unsigned and name == 'abs' %>
         int *intmin = cumo_cuda_runtime_error_flag_new();
-        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,intmin);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer,intmin);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         if (cumo_cuda_runtime_error_flag_get(intmin)) {
             lp->err_type = cumo_na_eValueError;
         }
         //<% else %>
-        <%=c_iter%>_launch(p1,p2,s1,s2,idx1,idx2,n,0);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer,0);
         //<% end %>
     }
     <% end %>
@@ -118,7 +82,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{<%=result_class%>,0}};
+    //<% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain, aout };
+    <% end %>
 
     return cumo_na_ndloop(&ndf, 1, self);
 }

--- a/ext/cumo/narray/gen/tmpl/unary2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary2_kernel.cu
@@ -11,83 +11,33 @@
 #define cumo_check_intmin(x) {}
 //<% end %>
 
-__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* intmin)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, int* intmin)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intmin(*(dtype*)(p1 + idx1[i]));
-        *(<%=dtype%>*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        cumo_check_intmin(*(dtype*)(p1));
+        *(<%=dtype%>*)(p2) = m_<%=name%>(*(dtype*)(p1));
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* intmin)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, int* intmin)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intmin(*(dtype*)(p1 + idx1[i]));
-        *(<%=dtype%>*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,intmin);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,intmin);
+        break;
     }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* intmin)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intmin(*(dtype*)(p1 + (i * s1)));
-        *(<%=dtype%>*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* intmin)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intmin(*(dtype*)(p1 + (i * s1)));
-        *(<%=dtype%>*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(char *p1, char *p2, uint64_t n, int* intmin)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intmin(((dtype*)p1)[i]);
-        ((<%=dtype%>*)p2)[i] = m_<%=name%>(((dtype*)p1)[i]);
-    }
-}
-
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* intmin)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n,intmin);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* intmin)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n,intmin);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* intmin)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n,intmin);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* intmin)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n,intmin);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* intmin)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(p1,p2,n,intmin);
     cumo_cuda_runtime_check_kernel_launch();
 }
 #undef cumo_check_intmin

--- a/ext/cumo/narray/gen/tmpl/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_kernel.cu
@@ -11,83 +11,33 @@
 #define cumo_check_intdivzero(x) {}
 //<% end %>
 
-__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, int* divzero)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(*(dtype*)(p1 + idx1[i]));
-        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        cumo_check_intdivzero(*(dtype*)(p1));
+        *(dtype*)(p2) = m_<%=name%>(*(dtype*)(p1));
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, int* divzero)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(*(dtype*)(p1 + idx1[i]));
-        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,divzero);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,divzero);
+        break;
     }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(*(dtype*)(p1 + (i * s1)));
-        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(*(dtype*)(p1 + (i * s1)));
-        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(char *p1, char *p2, uint64_t n, int* divzero)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(((dtype*)p1)[i]);
-        ((dtype*)p2)[i] = m_<%=name%>(((dtype*)p1)[i]);
-    }
-}
-
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n, int* divzero)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n,divzero);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n, int* divzero)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n,divzero);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n, int* divzero)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n,divzero);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n, int* divzero)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n,divzero);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(char *p1, char *p2, uint64_t n, int* divzero)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(p1,p2,n,divzero);
     cumo_cuda_runtime_check_kernel_launch();
 }
 #undef cumo_check_intdivzero

--- a/ext/cumo/narray/gen/tmpl/unary_s.c
+++ b/ext/cumo/narray/gen/tmpl/unary_s.c
@@ -1,13 +1,11 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    <% if type_name == 'robject' %>
     size_t  i;
     char   *p1, *p2;
     ssize_t s1, s2;
@@ -15,8 +13,6 @@ static void
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-
-    <% if type_name == 'robject' %>
     {
         dtype x;
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
@@ -52,19 +48,11 @@ static void
     }
     <% else %>
     {
-        if (idx1) {
-            if (idx2) {
-                <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,idx1,idx2,i);
-            } else {
-                <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,idx1,s2,i);
-            }
-        } else {
-            if (idx2) {
-                <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,s1,idx2,i);
-            } else {
-                <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,s1,s2,i);
-            }
-        }
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
     }
     <% end %>
 }
@@ -80,7 +68,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    //<% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain, aout };
+    <% end %>
 
     return cumo_na_ndloop(&ndf, 1, a1);
 }

--- a/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_s_kernel.cu
@@ -1,62 +1,30 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_index_index_kernel"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        *(dtype*)(p2) = m_<%=name%>(*(dtype*)(p1));
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_index_stride_kernel"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + idx1[i]));
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
     }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_index_kernel"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p2 + idx2[i]) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-__global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p2 + (i * s2)) = m_<%=name%>(*(dtype*)(p1 + (i * s1)));
-    }
-}
-
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, char *p2, size_t *idx1, size_t *idx2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,idx2,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
-
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, char *p2, size_t *idx1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,idx1,s2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, char *p2, ssize_t s1, size_t *idx2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,idx2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, char *p2, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,s1,s2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3019,4 +3019,49 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(grid.map { |row| row.map(&:to_i) },
                  Cumo::Int32.zeros(rows, cols).store(src).to_a)
   end
+
+  test "unary operations on views that ndloop cannot flatten" do
+    # same shape of view the store tests use: before the indexer loop each of
+    # these ran one kernel per row of the view
+    rows = 40
+    cols = 12
+    xs = Array.new(rows * cols) { |i| ((i % 9) - 4).to_f }
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+    idx = Array.new(rows) { |i| ((i * 7) + 3) % rows }
+
+    views = [
+      [:flat, ->(m) { m }, grid],
+      [:colslice, ->(m) { m[true, 2...(cols - 1)] }, grid.map { |row| row[2...(cols - 1)] }],
+      [:transpose, :transpose.to_proc, grid.transpose],
+      [:idxview, ->(m) { m[idx, true] }, idx.map { |i| grid[i] }]
+    ]
+
+    views.each do |label, slice, want|
+      v = slice.call(a)
+      assert_equal(want.map { |row| row.map(&:-@) }, (-v).to_a, "minus #{label}")
+      assert_equal(want.map { |row| row.map { |x| x * x } }, v.square.to_a, "square #{label}")
+      assert_equal(want.map { |row| row.map(&:abs) }, v.abs.to_a, "abs #{label}")
+      got = Cumo::NMath.exp(v).to_a
+      want.each_with_index do |row, r|
+        row.each_with_index { |x, c| assert_in_delta(Math.exp(x), got[r][c], 1e-6, "exp #{label} #{r},#{c}") }
+      end
+    end
+
+    # a 5-d shape runs past the dimension-specialised kernels
+    deep = [2, 2, 3, 2, 5]
+    ys = Array.new(deep.reduce(:*)) { |i| ((i % 7) - 3).to_f }
+    b = Cumo::DFloat.cast(ys).reshape(*deep)
+    assert_equal(ys.map(&:-@), (-b).to_a.flatten)
+    assert_equal(b.transpose.to_a.flatten.map(&:abs), b.transpose.abs.to_a.flatten)
+  end
+
+  test "the unary error flags still fire from the indexer kernel" do
+    # the flag is read after the launch, so it has to survive the rewrite
+    assert_raise(ZeroDivisionError) { Cumo::Int32.cast([[1, 0], [2, 3]])[true, 0..1].reciprocal }
+    assert_raise(Cumo::NArray::ValueError) do
+      Cumo::Int32.cast([[-2_147_483_648, 1], [2, 3]])[true, 0..1].abs
+    end
+    assert_equal([[1, 0], [0, 0]], Cumo::Int32.cast([[1, 2], [3, 4]]).reciprocal.to_a)
+  end
 end


### PR DESCRIPTION
## Summary

- The unary templates handed ndloop a one-dimensional kernel, so ndloop walked the outer dimensions itself and launched once per row of a non-contiguous view. This covers `NMath.exp` and the rest of `unary_s`, `-@` / `reciprocal` / `square` / `sign` / `floor` and the rest of `unary`, and `abs` / `real` / `imag` / `arg` in `unary2`.
- Give all three `CUMO_NDF_INDEXER_LOOP` and an indexer kernel, the same shape `binary` and now `store` (#245) use. The error flags that `reciprocal` and `abs` raise from stay where they were, read after the launch.

Contiguous arrays were never affected: ndloop contracts them to one dimension, so the old kernel already saw the whole array.

## Performance

RTX 5070 Ti Laptop, `SFloat`, a 1024x2048 column slice of a 1024x4096 array, best of 5 windows in a fresh process:

| operation | before | after |
|---|---|---|
| `-v` | 1.8003 ms | 0.0195 ms |
| `v.square` | 1.7902 ms | 0.0195 ms |
| `v.reciprocal` | 1.7361 ms | 0.0211 ms |
| `v.abs` | 1.7722 ms | 0.0318 ms |
| `v.floor` | 1.8749 ms | 0.0196 ms |
| `Int32` `v.reciprocal` (with the divide-by-zero flag) | 5.9687 ms | 0.0345 ms |
| `NMath.exp(v)` | 1.8710 ms | 0.0212 ms |

Every one of them cost a flat 1.7 us per row before, which is what one launch costs; they are now bandwidth-bound at 500-860 GB/s. `bench/cumo_probe.rb` moves `exp colslice` and `sqrt colslice` from 9.7 GB/s to 630 GB/s.

`bench/transformer_bench.rb` on the GPU goes from 0.0632 to 0.0547 s per iteration, best of three runs each, on top of what #245 already took off.

## Verification

- 1243 cross-checks against Numo: 7 dtypes, shapes of 1 to 5 dimensions, and for each a column slice, a transpose and an index view, across `minus`, `square`, `reciprocal`, `sign`, `copy`, `floor`, `ceil`, `round`, `trunc`, `rint`, `abs`, `real`, `imag`, `arg`, and `NMath.exp`, `sqrt`, `log`, `sin`, `tanh`. Both error-flag paths still raise.
- Positive controls: writing to the input's address (1241 checks fail), sending every rank to the rank-0 kernel (328 fail), and dropping the `intmin` guard (1 fails).
- `rake test`: 1499 tests, 0 failures.

The comparison operators and `isnan` and friends have the same problem, but their output is a `Bit`, which `cumo_na_iarray_t` cannot address because a bit position is not a byte offset. They are left for a follow-up.
