### PR TITLE
Warn about the synchronization in index parsing and inspect

### DIFF
--- a/ext/cumo/narray/gen/tmpl/inspect.c
+++ b/ext/cumo/narray/gen/tmpl/inspect.c
@@ -16,6 +16,7 @@ static VALUE
 static VALUE
 <%=c_func(0)%>(VALUE ary)
 {
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     return cumo_na_ndloop_inspect(ary, <%=c_iter%>, Qnil);
 }

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -179,6 +179,7 @@ cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_ar
     // is a String so the raise below cannot leak it.
     buf = rb_str_tmp_new((long)(sizeof(ssize_t)*n));
     host_idx = (ssize_t*)RSTRING_PTR(buf);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_parse_narray_index", "any");
     cumo_cuda_runtime_check_status(
         cudaMemcpy(host_idx,nidxp,sizeof(ssize_t)*n,cudaMemcpyDeviceToHost));
     for (k=0; k<n; k++) {


### PR DESCRIPTION
## Summary

- Indexing with an NArray (`a[idx]`, `a[idx, true]`) synchronizes and did not say so. `cumo_na_parse_narray_index` copies the indices back to the host with a blocking `cudaMemcpy` so it can range-check them and rewrite the negative ones, neither of which a kernel can do. The synchronization is deliberate; the silence was not.
- `inspect` calls `cudaDeviceSynchronize` with no warning either.
- Add `CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE` to both, so `CUMO_SHOW_WARNING=ON` accounts for every stall.

## How the gap was found

`bench/cumo_sync_probe.rb` queues device work, makes the call, and sees whether it waits. That answer owes nothing to the warnings, so comparing the two finds the calls that synchronize without saying so.

Measured with 60 queued 32MB stores, a backlog of 10.31 ms, three trials each:

| call | idle | behind the queue | |
|---|---|---|---|
| `a[idx, true]` | 25.5 us | 10.26 / 10.09 / 11.13 ms | synchronized, silent |
| `a[bit]` | 594.5 us | 11.36 / 10.68 / 11.02 ms | synchronized, warned |
| `a.to_a` | 1339.7 us | 12.47 / 12.18 / 12.39 ms | synchronized, warned |
| `a + 1.0` | 233.7 us | 0.01 / 0.01 / 0.01 ms | asynchronous |

Passing a Ruby Array instead, as `a[[3, 1, 2], true]`, stays asynchronous: there are no indices on the device to read back.

After this change the probe reports no silent synchronization at all.

## Not fixed here

Making the index path asynchronous would mean deferring the `IndexError` a bad index raises, which changes when the error reaches the caller. That is a larger decision than adding the warning, so the synchronization stays.

`rake test`: 1499 tests, 0 failures.
