### PR TITLE
Read a flat reduction operand without the indexer

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -33,6 +33,19 @@ static inline int64_t round_up_to_power_of_2(int64_t x) {
     return x + 1;
 }
 
+// True when the flat index into the indexer is also the element offset from
+// ptr, which is what lets the kernels below drop the indexer entirely. An
+// indexer of no dimensions addresses one element at ptr, so it qualifies.
+template <typename Type>
+static bool iarray_is_flat(const cumo_na_iarray_t& iarray, const cumo_na_indexer_t& indexer) {
+    ssize_t expect = static_cast<ssize_t>(sizeof(Type));
+    for (int i = indexer.ndim; --i >= 0;) {
+        if (iarray.step[i] != expect) return false;
+        expect *= static_cast<ssize_t>(indexer.shape[i]);
+    }
+    return true;
+}
+
 // Reference: cupy reduction kernel
 // Note that reduction and out axis are inverse with cupy. Former axes are out axes, latters are reduce axes.
 
@@ -92,6 +105,61 @@ __global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, int out_blo
             TypeOut* out_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out_iarray, &out_indexer));
             *out_ptr = impl.MapOut(accum);
             //printf("threadId.x:%d blockIdx.x:%d blockDim.x:%d gridDim.x:%d accum:%d i_out:%ld out:%p(%d)\n", threadIdx.x, blockIdx.x, blockDim.x, gridDim.x, accum, i_out, out_ptr, *out_ptr);
+        }
+    }
+}
+
+// reduction_kernel for operands whose flat index is their element offset.
+//
+// Reading an element through cumo_na_indexer_set_dim and cumo_na_iarray_at_dim
+// costs far more than the reduction does: the indexer carries shape[] and
+// index[] for CUMO_NA_MAX_DIMENSION, so the copy the kernel writes into cannot
+// stay in registers and every element pays a local memory round trip. Measured
+// on an RTX 5070 Ti, a 2048x2048 sum along the last axis takes 1.89 ms through
+// the indexer and 0.02 ms through this. A runtime flag inside the one kernel
+// does not help; the indexer has to be absent for the addresses to fold away.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_flat_kernel(cumo_na_reduction_arg_t arg, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    TypeIn* in = reinterpret_cast<TypeIn*>(arg.in.ptr);
+    TypeOut* out = reinterpret_cast<TypeOut*>(arg.out.ptr);
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_indexer_total_size = arg.in_indexer.total_size / out_total_size;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
+        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
+        TypeReduce accum = impl.Identity(i_in);
+
+        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+            impl.Reduce(impl.MapIn(in[i_in], i_in), accum);
+        }
+
+        if (out_block_size <= max_block_size / 2) {
+            sdata[tid] = accum;
+            __syncthreads();
+            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
+                if (out_block_size <= stride) {
+                    if (tid < stride) {
+                        impl.Reduce(sdata[tid + stride], sdata[tid]);
+                    }
+                    __syncthreads();
+                }
+            }
+            accum = sdata[tid];
+            __syncthreads();
+        }
+        if (reduce_offset == 0 && i_out < out_total_size) {
+            out[i_out] = impl.MapOut(accum);
         }
     }
 }
@@ -283,6 +351,56 @@ __global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, Typ
     }
 }
 
+// reduction_partial_kernel without the indexer, for the same reason.
+template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
+__global__ static void reduction_partial_flat_kernel(cumo_na_reduction_arg_t arg, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    TypeIn* in = reinterpret_cast<TypeIn*>(arg.in.ptr);
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_indexer_total_size = arg.in_indexer.total_size / out_total_size;
+    int64_t partial_total_size = out_total_size * n_split;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_partial = out_base + out_offset; i_partial < partial_total_size; i_partial += out_stride) {
+        int64_t i_out = i_partial / n_split;
+        int64_t begin = (i_partial % n_split) * chunk;
+        int64_t end = begin + chunk;
+        if (end > reduce_indexer_total_size) end = reduce_indexer_total_size;
+        int64_t i_in = i_out * reduce_indexer_total_size + begin + reduce_offset;
+
+        TypeReduce accum = impl.Identity(i_in);
+
+        for (int64_t i_reduce = begin + reduce_offset; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+            impl.Reduce(impl.MapIn(in[i_in], i_in), accum);
+        }
+
+        if (out_block_size <= max_block_size / 2) {
+            sdata[tid] = accum;
+            __syncthreads();
+            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
+                if (out_block_size <= stride) {
+                    if (tid < stride) {
+                        impl.Reduce(sdata[tid + stride], sdata[tid]);
+                    }
+                    __syncthreads();
+                }
+            }
+            accum = sdata[tid];
+            __syncthreads();
+        }
+        if (reduce_offset == 0 && i_partial < partial_total_size) {
+            partial[i_partial] = accum;
+        }
+    }
+}
+
 // Second pass of a split reduction. The input is already accumulators, so
 // MapIn must not run again. Identity is handed a scratch offset rather than an
 // index into the input, which is why an impl that reads that argument — the
@@ -314,7 +432,11 @@ TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, int64_t n_split, in
     int64_t grid_size = std::min(max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(TypeReduce) * max_block_size;
 
-    reduction_partial_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    if (iarray_is_flat<TypeIn>(arg.in, arg.in_indexer)) {
+        reduction_partial_flat_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    } else {
+        reduction_partial_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    }
     cumo_cuda_runtime_check_kernel_launch();
 
     arg2->in.ptr = reinterpret_cast<char*>(partial);
@@ -346,7 +468,12 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
-    cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    if (cumo_detail::iarray_is_flat<TypeIn>(arg.in, arg.in_indexer) &&
+        cumo_detail::iarray_is_flat<TypeOut>(arg.out, arg.out_indexer)) {
+        cumo_detail::reduction_flat_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    } else {
+        cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3064,4 +3064,62 @@ class NArrayTest < Test::Unit::TestCase
     end
     assert_equal([[1, 0], [0, 0]], Cumo::Int32.cast([[1, 2], [3, 4]]).reciprocal.to_a)
   end
+
+  test "a reduction answers the same on a flat layout and a strided one" do
+    # the flat layout skips the indexer, so the two paths are different kernels
+    # and have to be compared against each other, not just against a literal
+    rows = 96
+    cols = 130
+    xs = Array.new(rows * cols) { |i| ((i * 37) % 101) - 50.0 }
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+
+    assert_equal(grid.map(&:sum), a.sum(axis: 1).to_a)
+    assert_equal(grid.transpose.map(&:sum), a.sum(axis: 0).to_a)
+    assert_equal(xs.sum, a.sum.to_f)
+    assert_equal(grid.map(&:min), a.min(axis: 1).to_a)
+    assert_equal(grid.map(&:max), a.max(axis: 1).to_a)
+    assert_equal(grid.map { |row| row.max - row.min }, a.ptp(axis: 1).to_a)
+
+    # a transpose leaves the input non-contiguous, which takes the indexer path
+    t = a.transpose
+    assert_equal(grid.transpose.map(&:sum), t.sum(axis: 1).to_a)
+    assert_equal(grid.map(&:sum), t.sum(axis: 0).to_a)
+    assert_equal(grid.transpose.map(&:max), t.max(axis: 1).to_a)
+
+    # so does a strided view
+    sel = (0...cols).step(3).to_a
+    v = a[true, (0...cols).step(3)]
+    assert_equal(grid.map { |row| sel.sum { |c| row[c] } }, v.sum(axis: 1).to_a)
+    want_min = grid.map { |row| sel.map { |c| row[c] } }
+    assert_equal(want_min.map(&:min), v.min(axis: 1).to_a)
+
+    # and a reduction over an axis that is neither first nor last
+    deep = [4, 5, 6]
+    ys = Array.new(deep.reduce(:*)) { |i| ((i * 13) % 29) - 14.0 }
+    b = Cumo::DFloat.cast(ys).reshape(*deep)
+    want =
+      (0...deep[0]).map do |i|
+        (0...deep[2]).map { |k| (0...deep[1]).sum { |j| ys[(i * 30) + (j * 6) + k] } }
+      end
+    assert_equal(want, b.sum(axis: 1).to_a)
+    assert_equal([deep[0], 1, deep[2]], b.sum(axis: 1, keepdims: true).shape)
+  end
+
+  test "a split reduction answers the same as an unsplit one" do
+    # one output over a long axis is the shape that goes through the two-pass
+    # split, and its first pass has a flat variant too
+    n = 300_000
+    xs = Array.new(n) { |i| ((i * 7) % 13) - 6.0 }
+    a = Cumo::DFloat.cast(xs)
+    assert_equal(xs.sum, a.sum.to_f)
+    assert_equal(xs.min, a.min.to_f)
+    assert_equal(xs.max, a.max.to_f)
+
+    # the same values reduced in rows, which is not split
+    rows = 300
+    b = Cumo::DFloat.cast(xs).reshape(rows, n / rows)
+    assert_equal(xs.sum, b.sum(axis: 1).to_a.sum)
+    assert_equal(xs.min, b.min(axis: 1).to_a.min)
+  end
 end


### PR DESCRIPTION
## Summary

- Every reduction read its input through `cumo_na_indexer_set_dim` and `cumo_na_iarray_at_dim`, once per element. The indexer carries `shape[]` and `index[]` for `CUMO_NA_MAX_DIMENSION`, so the copy the kernel writes into cannot stay in registers and each element pays a local memory round trip. It cost far more than the reduction itself.
- Add a variant of `reduction_kernel` and of `reduction_partial_kernel` that addresses the operands as `in[i]` and `out[i]`, and take it when the flat index into the indexer is also the element offset. That covers full reductions and reductions along the last axis, which is where the shape is already flat.

A runtime flag inside the one kernel does not work: leaving the indexer in the other branch keeps it in local memory and the addresses never fold away. Measured, a flag was 7.478 ms against 7.518 ms for the indexer, while a separate kernel on the same shape was 0.071 ms.

## Performance

RTX 5070 Ti Laptop, `SFloat`, 4194304 elements, `sum(axis: 1)`, best of 10 windows in a fresh process:

| outputs | reduce length | before | after |
|---|---|---|---|
| 16 | 262144 | 0.287 ms | 0.014 ms |
| 1024 | 4096 | 0.891 ms | 0.014 ms |
| 2048 | 2048 | 1.896 ms | 0.023 ms |
| 4096 | 1024 | 3.100 ms | 0.047 ms |
| 32768 | 128 | 6.167 ms | 0.083 ms |
| full `sum` of 2048x2048 | | 0.251 ms | 0.014 ms |

A reduction now costs what an elementwise pass over the same data costs: `a * 2.0` on that array is 0.023 ms.

`bench/transformer_bench.rb` on the GPU goes from 0.0632 to 0.0132 s per iteration, best of three runs each. Softmax was 55% of the block and is now 8%.

Reductions along an axis that is not the last one keep the indexer, since the input is not flat in that order; `sum(axis: 0)` of 2048x2048 is unchanged at 1.74 ms. Giving those the same treatment means specialising the kernel on the number of dimensions, as the elementwise kernels already are, and is left for a follow-up.

## Verification

- 1802 cross-checks against Numo: 8 dtypes, shapes of 1 to 5 dimensions, `sum`, `prod`, `min`, `max`, `ptp`, `mean`, `var`, `stddev`, `rms` over every axis and the whole array, plus keepdims, strided views, and the index reductions this does not touch. One `SFloat` `rms` differs from Numo by 0.3%, identically before and after this change: Numo's sequential float32 sum of a million squares is the inaccurate one, 3.3e-3 against 4.5e-8 from the exact value.
- Positive controls: making the flat predicate always true fails 402 checks, and dropping the reduce offset from the flat kernel's input index fails 1180.
- `rake test`: 1501 tests, 0 failures.
