### PR TITLE
Copy a view through the indexer loop

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -4,6 +4,7 @@
 #include "cumo/cuda/runtime.h"
 #include "cumo/narray.h"
 #include "cumo/template.h"
+#include "cumo/indexer.h"
 
 static ID cumo_id_mulsum;
 static ID cumo_id_store;
@@ -52,6 +53,7 @@ static ID cumo_id_swap_byte;
 }
 
 void cumo_iter_copy_bytes_kernel_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, size_t n, int elmsz);
+void cumo_iter_copy_bytes_indexer_kernel_launch(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, ssize_t elmsz);
 #define m_memcpy(src,dst) memcpy(dst,src,e)
 
 static void
@@ -79,6 +81,16 @@ iter_copy_bytes(cumo_na_loop_t *const lp)
     LOOP_UNARY_PTR(lp,m_memcpy);
 }
 
+static void
+iter_copy_bytes_indexer(cumo_na_loop_t *const lp)
+{
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    cumo_iter_copy_bytes_indexer_kernel_launch(&a1, &a2, &indexer, (ssize_t)lp->args[0].elmsz);
+}
+
 VALUE
 cumo_na_copy(VALUE self)
 {
@@ -86,6 +98,15 @@ cumo_na_copy(VALUE self)
     cumo_ndfunc_arg_in_t ain[1] = {{Qnil,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{INT2FIX(0),0}};
     cumo_ndfunc_t ndf = { iter_copy_bytes, CUMO_FULL_LOOP, 1, 1, ain, aout };
+
+    // Cumo::RObject data is host memory, which the kernel below must not touch.
+    // Everything else goes through the indexer so that ndloop hands the whole
+    // view over at once: walking the outer dimensions itself costs a
+    // synchronization per step when an operand carries an index array.
+    if (rb_obj_class(self) != cumo_cRObject) {
+        ndf.func = iter_copy_bytes_indexer;
+        ndf.flag = CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP;
+    }
 
     v = cumo_na_ndloop(&ndf, 1, self);
     return v;

--- a/ext/cumo/narray/data_kernel.cu
+++ b/ext/cumo/narray/data_kernel.cu
@@ -1,4 +1,5 @@
 #include "cumo/narray_kernel.h"
+#include "cumo/indexer.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -37,6 +38,97 @@ __global__ void cumo_na_diagonal_stride_index_kernel(size_t *idx, ssize_t s0, si
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
         idx[i] = s0*(i+k0) + idx1[i+k1];
     }
+}
+
+// Copying a whole view in one launch, so that ndloop does not have to walk the
+// outer dimensions itself. It synchronizes once per outer step when an operand
+// carries an index array, which for a gathered view costs far more than the
+// copy: 6250 rows took 37.6 ms that way and 0.2 ms through here.
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim0(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim0(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim0(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim0(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim1(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim1(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim1(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim1(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim2(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim2(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim2(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim2(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim3(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim3(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim3(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim3(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim4(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim4(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim4(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim4(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+__global__ void cumo_iter_copy_bytes_indexer_kernel_dim(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer, ssize_t elmsz)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim(&a2, &indexer);
+        memcpy(p2, p1, elmsz);
+    }
+}
+
+void cumo_iter_copy_bytes_indexer_kernel_launch(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer, ssize_t elmsz)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    case 0:
+        cumo_iter_copy_bytes_indexer_kernel_dim0<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    case 1:
+        cumo_iter_copy_bytes_indexer_kernel_dim1<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    case 2:
+        cumo_iter_copy_bytes_indexer_kernel_dim2<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    case 3:
+        cumo_iter_copy_bytes_indexer_kernel_dim3<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    case 4:
+        cumo_iter_copy_bytes_indexer_kernel_dim4<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    default:
+        cumo_iter_copy_bytes_indexer_kernel_dim<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void cumo_iter_copy_bytes_kernel_launch(char *p1, char *p2, ssize_t s1, ssize_t s2, size_t *idx1, size_t *idx2, uint64_t n, ssize_t elmsz)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3122,4 +3122,48 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(xs.sum, b.sum(axis: 1).to_a.sum)
     assert_equal(xs.min, b.min(axis: 1).to_a.min)
   end
+
+  test "copy of a view built from an index array" do
+    # ndloop used to walk the outer dimension itself here, and an index array
+    # made it synchronize once per row
+    rows = 50
+    cols = 9
+    xs = Array.new(rows * cols) { |i| ((i * 11) % 23) - 11.0 }
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+    idx = Array.new(rows) { |i| ((i * 7) + 3) % rows }
+
+    assert_equal(idx.map { |i| grid[i] }, a[idx, true].copy.to_a)
+    assert_equal(idx.map { |i| grid[i][2...(cols - 1)] }, a[idx, 2...(cols - 1)].copy.to_a)
+    assert_equal(grid, a.copy.to_a)
+    assert_equal(grid.transpose, a.transpose.copy.to_a)
+
+    # a reduction over such a view copies it first, so it must agree
+    assert_equal(idx.map { |i| grid[i].sum }, a[idx, true].sum(axis: 1).to_a)
+    assert_equal((0...cols).map { |c2| idx.sum { |i| grid[i][c2] } },
+                 a[idx, true].sum(axis: 0).to_a)
+
+    # the copy must not alias the source, so writing through the source after
+    # it was taken must leave it alone
+    mutable = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    taken = mutable[idx, true].copy
+    mutable[idx[0], 0] = 999.0
+    assert_equal(grid[idx[0]][0], taken[0, 0].to_f)
+
+    # 5-d runs past the dimension-specialised kernels
+    deep = [2, 2, 3, 2, 5]
+    ys = Array.new(deep.reduce(:*)) { |i| ((i * 13) % 29) - 14.0 }
+    b = Cumo::DFloat.cast(ys).reshape(*deep)
+    assert_equal(ys, b.copy.to_a.flatten)
+    assert_equal(b.transpose.to_a.flatten, b.transpose.copy.to_a.flatten)
+    assert_equal(b[[1, 0], true, true, true, true].to_a.flatten,
+                 b[[1, 0], true, true, true, true].copy.to_a.flatten)
+  end
+
+  test "copy of an RObject view stays on the host" do
+    # RObject data is host memory, so it must not take the kernel path
+    a = Cumo::RObject.cast([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert_equal([[7, 8, 9], [1, 2, 3]], a[[2, 0], true].copy.to_a)
+    assert_equal([[1, 4, 7], [2, 5, 8], [3, 6, 9]], a.transpose.copy.to_a)
+  end
 end


### PR DESCRIPTION
## Summary

- `cumo_na_copy` handed ndloop a one-dimensional kernel, so ndloop walked the outer dimensions itself. When an operand carries an index array that loop synchronizes and reads the index from managed memory on the host, once per outer step, which for a gathered view costs far more than the copy.
- Pass the whole view through an indexer kernel instead, the same way `store` does since #245. `RObject` keeps the old path: its data is host memory, which the kernel must not touch.

A reduction over an index-backed view copies it first (`accum.c` does so because the reduction cannot address an index), so this reaches those too.

## Performance

RTX 5070 Ti Laptop, a 6250x64 view gathered from a 100000x64 `SFloat`, best of 5 windows in a fresh process:

| | before | after |
|---|---|---|
| `view.copy` | 37.598 ms | 0.172 ms |
| `view.mean(axis: 0)` | 36.600 ms | 0.336 ms |
| `view.dup` (for scale) | 0.325 ms | 0.173 ms |
| `zeros.store(view)` (for scale) | 0.202 ms | 0.176 ms |

The warning the old path printed, `FIXME: Method "loop_narrayx" for dtype "any" synchronizes with CPU`, is gone: 6250 rows meant 6250 synchronizations.

A k-means benchmark over 100000 points in 64 dimensions with 16 clusters, whose centroid update gathers each cluster and averages it, goes from 12.0155 s to 0.2097 s for 20 iterations. Its inertia is identical to the last digit before and after, and stays monotonically decreasing.

## Verification

- 228 cross-checks against Numo: 8 dtypes including `RObject`, shapes of 1 to 5 dimensions, and for each a column slice, a transpose, an index view and an index view combined with a slice, comparing both the copy and a reduction over the view.
- A copy must not alias its source, which the added test checks by writing through the source afterwards.
- Positive controls: reading the destination instead of the source in the indexer kernel fails 191 checks. Letting `RObject` take the kernel path does not fail anything here, so the guard rests on the same reasoning the old code stated rather than on a measurement: that data is host memory and a kernel writing it is not ordered against the host reading it back.
- `rake test`: 1503 tests, 0 failures.
