### PR TITLE
Build the C++ and CUDA sources with optimization

### DIFF
--- a/ext/cumo/extconf.rb
+++ b/ext/cumo/extconf.rb
@@ -28,6 +28,9 @@ MakeMakefileCuda.install!(cxx: true)
 
 if ENV['DEBUG']
   $CFLAGS << " -g -O0 -Wall"
+  $CXXFLAGS << " -g -O0 -Wall"
+else
+  $CXXFLAGS << " #{RbConfig::CONFIG['optflags']}"
 end
 $CXXFLAGS << " -std=c++17"
 #$CFLAGS=" $(cflags) -O3 -m64 -msse2 -funroll-loops"


### PR DESCRIPTION
# Build the C++ and CUDA sources with optimization

`mkmf` puts `$(optflags)` into `CFLAGS` but not into `CXXFLAGS`, so every `.cpp` and the host half of every `.cu` was compiled at `-O0`. The memory pool, which is templated C++, was the visible cost.

Measured on an RTX 5070 Ti Laptop, CUDA 13.0, Ruby 4.0.6, best of several runs:

| | before | after |
|---|---|---|
| pool `Malloc`+`Free`, no Ruby in the loop | 620 ns | 122 ns |
| allocating an output array (`a + b` minus `a.inplace + b`) | 913 ns | 109 ns |
| `a + b` on 64 elements | 2.86 us | 2.00 us |
| conjugate gradient, scalars kept on the device | 84.8 us/iter | 62.1 us/iter |

The pool figure comes from a standalone C++ benchmark linking `memory_pool_impl.cpp` directly, compiled at each `-O` level, so it isolates the flag from everything else. Workloads dominated by large kernels are unchanged, as expected: the transformer benchmark is 91% cuBLAS and moves within run-to-run noise.

Device code is unaffected. `nvcc -O` applies to host code only, and the PTX emitted for `narray/types/sfloat_kernel.cu` is byte-identical with and without `-O3` (169652 lines, same md5), so no result changes. The conjugate gradient benchmark reports the same relative residual (2.617e-06) before and after.

`DEBUG=1` now sets `-g -O0` for C++ as it already did for C.

Clean build time goes from about 30 s to 37 s here. `rake test` is unchanged at 1503 tests / 19770 assertions, with the same single pre-existing failure (`test_a_failing_free_from_the_gc_hook_does_not_raise`, which fails on master too when the whole suite runs, and passes in isolation on both).
