### PR TITLE
Run the remaining elementwise kernels through the indexer loop

### DIFF
--- a/ext/cumo/narray/gen/tmpl/binary2.c
+++ b/ext/cumo/narray/gen/tmpl/binary2.c
@@ -1,21 +1,21 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* divzero);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t   n;
-    char    *p1, *p2, *p3, *p4;
-    ssize_t  s1, s2, s3, s4;
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_INIT_PTR(lp, 3, p4, s4);
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t   i, n;
+        char    *p1, *p2, *p3, *p4;
+        ssize_t  s1, s2, s3, s4;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
+        CUMO_INIT_PTR(lp, 3, p4, s4);
         for (i=n; i--;) {
             dtype    x, y, a, b;
             CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
@@ -34,15 +34,21 @@ static void
     }
     <% else %>
     {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_iarray_t a4 = cumo_na_make_iarray(&lp->args[3]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
         //<% if is_int and %w[divmod].include? name %>
         int *divzero = cumo_cuda_runtime_error_flag_new();
-        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,divzero);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&a4,&indexer,divzero);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         if (cumo_cuda_runtime_error_flag_get(divzero)) {
             lp->err_type = rb_eZeroDivError;
         }
         //<% else %>
-        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,0);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&a4,&indexer,0);
         //<% end %>
     }
     <% end %>
@@ -53,7 +59,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[2] = {{cT,0},{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 2, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 2, ain, aout };
+    <% end %>
 
     return cumo_na_ndloop(&ndf, 2, self, other);
 }

--- a/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary2_kernel.cu
@@ -10,19 +10,35 @@
 #define cumo_check_intdivzero(y) {}
 //<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_iarray_t a4, cumo_na_indexer_t indexer, int* divzero)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        cumo_check_intdivzero(*(dtype*)(p2+(i*s2)));
-        m_<%=name%>(*(dtype*)(p1+(i*s1)),*(dtype*)(p2+(i*s2)),*(dtype*)(p3+(i*s3)), *(dtype*)(p4+(i*s4)));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        char* p4 = cumo_na_iarray_at_dim<%=idim%>(&a4, &indexer);
+        cumo_check_intdivzero(*(dtype*)(p2));
+        m_<%=name%>(*(dtype*)(p1),*(dtype*)(p2),*(dtype*)(p3),*(dtype*)(p4));
     }
 }
+<% end %>
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* divzero)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* divzero)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n,divzero);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,divzero);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,divzero);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 #undef cumo_check_intdivzero

--- a/ext/cumo/narray/gen/tmpl/clip.c
+++ b/ext/cumo/narray/gen/tmpl/clip.c
@@ -1,24 +1,24 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid);
-void <%="cumo_#{c_iter}_min_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
-void <%="cumo_#{c_iter}_max_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid);
+void <%="cumo_#{c_iter}_min_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_max_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    char   *p1, *p2, *p3, *p4;
-    ssize_t s1, s2, s3, s4;
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-    CUMO_INIT_PTR(lp, 3, p4, s4);
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t  i, n;
+        char   *p1, *p2, *p3, *p4;
+        ssize_t s1, s2, s3, s4;
         dtype  x, min, max;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
+        CUMO_INIT_PTR(lp, 3, p4, s4);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
@@ -34,8 +34,14 @@ static void
     }
     <% else %>
     {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_iarray_t a4 = cumo_na_make_iarray(&lp->args[3]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
         int *invalid = cumo_cuda_runtime_error_flag_new();
-        <%="cumo_#{c_iter}_kernel_launch"%>(p1,p2,p3,p4,s1,s2,s3,s4,n,invalid);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&a4,&indexer,invalid);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         if (cumo_cuda_runtime_error_flag_get(invalid)) {
             rb_raise(cumo_na_eOperationError,"min is greater than max");
@@ -47,17 +53,17 @@ static void
 static void
 <%=c_iter%>_min(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    char   *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t  i, n;
+        char   *p1, *p2, *p3;
+        ssize_t s1, s2, s3;
         dtype  x, min;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_min", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
@@ -69,24 +75,31 @@ static void
         }
     }
     <% else %>
-    <%="cumo_#{c_iter}_min_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_min_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+    }
     <% end %>
 }
 
 static void
 <%=c_iter%>_max(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    char   *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t  i, n;
+        char   *p1, *p2, *p3;
+        ssize_t s1, s2, s3;
         dtype  x, max;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_max", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
@@ -98,7 +111,14 @@ static void
         }
     }
     <% else %>
-    <%="cumo_#{c_iter}_max_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_max_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+    }
     <% end %>
 }
 
@@ -137,9 +157,15 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[3] = {{Qnil,0},{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf_min = { <%=c_iter%>_min, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
     cumo_ndfunc_t ndf_max = { <%=c_iter%>_max, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
     cumo_ndfunc_t ndf_both = { <%=c_iter%>, CUMO_STRIDE_LOOP, 3, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf_min = { <%=c_iter%>_min, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+    cumo_ndfunc_t ndf_max = { <%=c_iter%>_max, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+    cumo_ndfunc_t ndf_both = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 3, 1, ain, aout };
+    <% end %>
 
     if (RTEST(min)) {
         if (RTEST(max)) {

--- a/ext/cumo/narray/gen/tmpl/clip_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/clip_kernel.cu
@@ -1,58 +1,90 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_kernel"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_iarray_t a4, cumo_na_indexer_t indexer, int* invalid)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
-        dtype min = *(dtype*)(p2+(i*s2));
-        dtype max = *(dtype*)(p3+(i*s3));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        dtype min = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype max = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
         // Leaving the element unwritten keeps a scalar min > max, where every
         // element takes this branch, from touching the output before it raises.
         if (m_gt(min,max)) { *invalid = 1; continue; }
         if (m_lt(x,min)) { x = min; }
         if (m_gt(x,max)) { x = max; }
-        *(dtype*)(p4+(i*s4)) = x;
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a4, &indexer) = x;
     }
 }
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, char *p4, ssize_t s1, ssize_t s2, ssize_t s3, ssize_t s4, uint64_t n, int* invalid)
+__global__ void <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,p4,s1,s2,s3,s4,n,invalid);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        dtype min = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer) = m_lt(x,min) ? min : x;
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        dtype max = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer) = m_gt(x,max) ? max : x;
+    }
+}
+<% end %>
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-__global__ void <%="cumo_#{c_iter}_min_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_min_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
-        dtype min = *(dtype*)(p2+(i*s2));
-        *(dtype*)(p3+(i*s3)) = m_lt(x,min) ? min : x;
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_min_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_min_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_min_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-__global__ void <%="cumo_#{c_iter}_max_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_max_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
-        dtype max = *(dtype*)(p2+(i*s2));
-        *(dtype*)(p3+(i*s3)) = m_gt(x,max) ? max : x;
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_max_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_max_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_max_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/ewcomp.c
+++ b/ext/cumo/narray/gen/tmpl/ewcomp.c
@@ -16,24 +16,23 @@
 <% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
 <% unless type_name == 'robject' %>
-void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(char *p1, char* p2, char* p3, ssize_t s1, ssize_t s2, ssize_t s3, size_t n);
+void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    size_t   n;
-    char    *p1, *p2, *p3;
-    ssize_t  s1, s2, s3;
-
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t   i, n;
+        char    *p1, *p2, *p3;
+        ssize_t  s1, s2, s3;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
+
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
         for (i=0; i<n; i++) {
             dtype x, y, z;
@@ -46,7 +45,12 @@ static void
     }
     <% else %>
     {
-        cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(p1,p2,p3,s1,s2,s3,n);
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(&a1,&a2,&a3,&indexer);
     }
     <% end %>
 }
@@ -59,7 +63,11 @@ static VALUE
     VALUE a2 = Qnil;
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP_NIP, 2, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+    <% end %>
 
     <% if is_float %>
     VALUE kw_hash = Qnil;

--- a/ext/cumo/narray/gen/tmpl/ewcomp_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/ewcomp_kernel.cu
@@ -1,18 +1,33 @@
 <% unless type_name == 'robject' %>
 <% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
-__global__ void <%="cumo_#{type_name}_#{name}#{nan}_kernel"%>(char* p1, char* p2, char* p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{type_name}_#{name}#{nan}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *((dtype*)(p3+(i*s3))) = f_<%=name%><%=nan%>(*((dtype*)(p1+(i*s1))), *((dtype*)(p2+(i*s2))));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        *(dtype*)(p3) = f_<%=name%><%=nan%>(*(dtype*)(p1), *(dtype*)(p2));
     }
 }
+<% end %>
 
-void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(char *p1, char *p2, char* p3, ssize_t s1, ssize_t s2, ssize_t s3, size_t n)
+void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{type_name}_#{name}#{nan}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{type_name}_#{name}#{nan}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{type_name}_#{name}#{nan}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/ext/cumo/narray/gen/tmpl/fill.c
+++ b/ext/cumo/narray/gen/tmpl/fill.c
@@ -1,36 +1,38 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *ptr, size_t *idx, dtype val, uint64_t n);
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *ptr, ssize_t step, dtype val, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_indexer_t* indexer, dtype val);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t   i;
-    char    *p1;
-    ssize_t  s1;
-    size_t  *idx1;
-    VALUE    x = lp->option;
-    dtype    y;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
-    y = m_num_to_data(x);
+    VALUE x = lp->option;
+    dtype y = m_num_to_data(x);
     <% if type_name == 'robject' %>
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    if (idx1) {
-        for (; i--;) {
-            CUMO_SET_DATA_INDEX(p1,idx1,dtype,y);
-        }
-    } else {
-        for (; i--;) {
-            CUMO_SET_DATA_STRIDE(p1,s1,dtype,y);
+    {
+        size_t   i;
+        char    *p1;
+        ssize_t  s1;
+        size_t  *idx1;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
+        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        if (idx1) {
+            for (; i--;) {
+                CUMO_SET_DATA_INDEX(p1,idx1,dtype,y);
+            }
+        } else {
+            for (; i--;) {
+                CUMO_SET_DATA_STRIDE(p1,s1,dtype,y);
+            }
         }
     }
     <% else %>
-    if (idx1) {
-        <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,idx1,y,i);
-    } else {
-        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,s1,y,i);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&indexer,y);
     }
     <% end %>
 }
@@ -45,7 +47,11 @@ static VALUE
 <%=c_func(1)%>(VALUE self, VALUE val)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{cumo_sym_option}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 2, 0, ain, 0 };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 0, ain, 0 };
+    <% end %>
 
     cumo_na_ndloop(&ndf, 2, self, val);
     return self;

--- a/ext/cumo/narray/gen/tmpl/fill_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/fill_kernel.cu
@@ -1,31 +1,28 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *ptr, size_t *idx, dtype val, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_indexer_t indexer, dtype val)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(ptr + idx[i]) = val;
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = val;
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char*ptr, ssize_t step, dtype val, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_indexer_t* indexer, dtype val)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(ptr + (i*step)) = val;
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*indexer,val);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*indexer,val);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *ptr, size_t *idx, dtype val, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(ptr,idx,val,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *ptr, ssize_t step, dtype val, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(ptr,step,val,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/frexp.c
+++ b/ext/cumo/narray/gen/tmpl/frexp.c
@@ -1,18 +1,14 @@
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t   n;
-    char    *p1, *p2, *p3;
-    ssize_t  s1, s2, s3;
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-
-    <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
 }
 
 /*
@@ -29,6 +25,6 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[2] = {{cT,0},{cumo_cInt32,0}};
-    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 1,2, ain,aout };
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1,2, ain,aout };
     return cumo_na_ndloop(&ndf, 1, a1);
 }

--- a/ext/cumo/narray/gen/tmpl/frexp_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/frexp_kernel.cu
@@ -1,18 +1,31 @@
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
         int y;
-        x = m_<%=name%>(x,&y);
-        *(dtype*)(p2+(i*s2)) = x;
-        *(int32_t*)(p3+(i*s3)) = y;
+        *(dtype*)(p2) = m_<%=name%>(*(dtype*)(p1),&y);
+        *(int32_t*)(p3) = y;
     }
 }
+<% end %>
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }

--- a/ext/cumo/narray/gen/tmpl/pow.c
+++ b/ext/cumo/narray/gen/tmpl/pow.c
@@ -1,21 +1,22 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
-void <%="cumo_#{c_iter}_int32_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char    *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
     <% if type_name == 'robject' %>
     {
+        size_t  i;
+        char    *p1, *p2, *p3;
+        ssize_t s1, s2, s3;
         dtype x, y;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         for (; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
@@ -25,24 +26,32 @@ static void
         }
     }
     <% else %>
-    <%="cumo_#{c_iter}_kernel_launch"%>(p1,p2,p3,s1,s2,s3,i);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+    }
     <% end %>
 }
 
 static void
 <%=c_iter%>_int32(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char   *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
     <% if type_name == 'robject' %>
     {
+        size_t  i;
+        char   *p1, *p2, *p3;
+        ssize_t s1, s2, s3;
         dtype   x;
         int32_t y;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_int32", "<%=type_name%>");
         for (; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
@@ -52,7 +61,14 @@ static void
         }
     }
     <% else %>
-    <%="cumo_#{c_iter}_int32_kernel_launch"%>(p1,p2,p3,s1,s2,s3,i);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_int32_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+    }
     <% end %>
 }
 
@@ -62,8 +78,13 @@ static VALUE
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_in_t ain_i[2] = {{cT,0},{cumo_cInt32,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
     cumo_ndfunc_t ndf_i = { <%=c_iter%>_int32, CUMO_STRIDE_LOOP, 2, 1, ain_i, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+    cumo_ndfunc_t ndf_i = { <%=c_iter%>_int32, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain_i, aout };
+    <% end %>
 
     // fixme : use na.integer?
     if (FIXNUM_P(other) || rb_obj_is_kind_of(other,cumo_cInt32)) {

--- a/ext/cumo/narray/gen/tmpl/pow_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/pow_kernel.cu
@@ -1,31 +1,59 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p3 + (i * s3)) = m_pow(*(dtype*)(p1 + (i * s1)), *(dtype*)(p2 + (i * s2)));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        *(dtype*)(p3) = m_pow(*(dtype*)(p1), *(dtype*)(p2));
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_int32_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+__global__ void <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p3 + (i * s3)) = m_pow_int(*(dtype*)(p1 + (i * s1)), *(int32_t*)(p2 + (i * s2)));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        *(dtype*)(p3) = m_pow_int(*(dtype*)(p1), *(int32_t*)(p2));
     }
 }
+<% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_int32_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_int32_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_int32_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/seq.c
+++ b/ext/cumo/narray/gen/tmpl/seq.c
@@ -17,30 +17,30 @@ typedef struct {
 } seq_opt_t;
 
 <% unless is_object %>
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t* idx1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n);
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_indexer_t* indexer, seq_data_t beg, seq_data_t step, seq_count_t c);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char   *p1;
-    ssize_t s1;
-    size_t *idx1;
     seq_data_t beg, step;
     seq_count_t c;
     seq_opt_t *g;
 
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     g = (seq_opt_t*)(lp->opt_ptr);
     beg  = g->beg;
     step = g->step;
     c    = g->count;
     <% if is_object %>
     {
+        size_t  i;
+        char   *p1;
+        ssize_t s1;
+        size_t *idx1;
         dtype x;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         if (idx1) {
             for (; i--;) {
@@ -59,13 +59,11 @@ static void
     }
     <% else %>
     {
-        size_t n = i;
-        if (idx1) {
-            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,idx1,beg,step,c,n);
-        } else {
-            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,s1,beg,step,c,n);
-        }
-        g->count += n;
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&indexer,beg,step,c);
+        g->count += indexer.total_size;
     }
     <% end %>
 }
@@ -93,7 +91,11 @@ static VALUE
     seq_opt_t *g;
     VALUE vbeg=Qnil, vstep=Qnil;
     cumo_ndfunc_arg_in_t ain[1] = {{CUMO_OVERWRITE,0}};
+    <% if is_object %>
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 1,0, ain,0};
+    <% else %>
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1,0, ain,0};
+    <% end %>
 
     g = ALLOCA_N(seq_opt_t,1);
     g->beg = m_zero;

--- a/ext/cumo/narray/gen/tmpl/seq_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/seq_kernel.cu
@@ -11,35 +11,30 @@ typedef double seq_count_t;
 <% end %>
 
 <% unless is_object %>
-__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *p1, size_t* idx1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_indexer_t indexer, seq_data_t beg, seq_data_t step, seq_count_t c)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = f_seq(beg,step,c+i);
-        *(dtype*)(p1+idx1[i]) = x;
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = f_seq(beg,step,c+i);
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, size_t s1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_indexer_t* indexer, seq_data_t beg, seq_data_t step, seq_count_t c)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = f_seq(beg,step,c+i);
-        *(dtype*)(p1+(i*s1)) = x;
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*indexer,beg,step,c);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*indexer,beg,step,c);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, size_t* idx1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,idx1,beg,step,c,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, ssize_t s1, seq_data_t beg, seq_data_t step, seq_count_t c, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,s1,beg,step,c,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/unary_ret2.c
+++ b/ext/cumo/narray/gen/tmpl/unary_ret2.c
@@ -1,18 +1,14 @@
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    char   *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-
-    <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
+    <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
 }
 
 /*
@@ -25,7 +21,7 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[2] = {{cT,0},{cT,0}};
-    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_STRIDE_LOOP, 1,2, ain,aout};
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1,2, ain,aout};
 
     return cumo_na_ndloop(&ndf, 1, self);
 }

--- a/ext/cumo/narray/gen/tmpl/unary_ret2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/unary_ret2_kernel.cu
@@ -1,18 +1,32 @@
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
         dtype y, z;
-        m_<%=name%>(x,y,z);
-        *(dtype*)(p2+(i*s2)) = y;
-        *(dtype*)(p3+(i*s3)) = z;
+        m_<%=name%>(*(dtype*)(p1),y,z);
+        *(dtype*)(p2) = y;
+        *(dtype*)(p3) = z;
     }
 }
+<% end %>
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3160,6 +3160,87 @@ class NArrayTest < Test::Unit::TestCase
                  b[[1, 0], true, true, true, true].copy.to_a.flatten)
   end
 
+  test "elementwise kernels reach every element of a view they cannot flatten" do
+    # pow, clip, divmod, maximum, frexp, modf, fill and seq each ran once per
+    # row of a view with more than one dimension left before the indexer loop.
+    # Each view is checked against a contiguous copy of the same elements, so
+    # only the walk is under test and not the operation's own semantics.
+    rows = 9
+    cols = 7
+    xs = Array.new(rows * cols) { |i| ((i * 3) % 13) + 1.0 }
+    src = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    idx = [5, 0, 3, 8, 1]
+
+    views = {
+      "column slice" => ->(a) { a[true, 1...(cols - 1)] },
+      "reversed" => ->(a) { a[true, (cols - 1).step(0, -1)] },
+      "row stride" => ->(a) { a[0.step(rows - 1, 2), true] },
+      "index view" => ->(a) { a[idx, true] },
+      "transpose" => ->(a) { a.transpose },
+    }
+
+    ops = {
+      "pow" => ->(a) { a**2.0 },
+      "pow_int32" => ->(a) { a**3 },
+      "clip" => ->(a) { a.clip(4.0, 9.0) },
+      "clip min" => ->(a) { a.clip(4.0, nil) },
+      "clip max" => ->(a) { a.clip(nil, 9.0) },
+      "clip array" => ->(a) { a.clip(a - 1.0, a + 1.0) },
+      "maximum" => ->(a) { Cumo::DFloat.maximum(a, 6.0) },
+      "minimum" => ->(a) { Cumo::DFloat.minimum(a, 6.0) },
+      "divmod" => ->(a) { a.divmod(4.0).map(&:to_a) },
+      "frexp" => ->(a) { Cumo::NMath.frexp(a).map(&:to_a) },
+      "modf" => ->(a) { a.modf.map(&:to_a) },
+    }
+
+    views.each do |what, take|
+      view = take.call(src)
+      flat = view.copy
+      assert_equal(flat.to_a, view.to_a, "#{what} itself")
+      ops.each do |op, f|
+        want = f.call(flat)
+        got = f.call(view)
+        assert_equal(want.is_a?(Array) ? want : want.to_a,
+                     got.is_a?(Array) ? got : got.to_a, "#{op} of #{what}")
+      end
+    end
+
+    # fill and seq write through the view, so the elements outside it must be
+    # left alone and the ones inside must all be reached
+    views.each do |what, take|
+      cells = take.call(Cumo::DFloat.cast((0...(rows * cols)).to_a).reshape(rows, cols))
+                  .to_a.flatten.map(&:to_i)
+
+      dst = Cumo::DFloat.zeros(rows, cols)
+      take.call(dst).fill(5.0)
+      want = Array.new(rows * cols) { |i| cells.include?(i) ? 5.0 : 0.0 }
+      assert_equal(want, dst.to_a.flatten, "fill #{what}")
+
+      dst = Cumo::DFloat.zeros(rows, cols)
+      take.call(dst).seq(2.0, 0.5)
+      seen = cells.each_with_index.to_h { |cell, i| [cell, 2.0 + (0.5 * i)] }
+      want = Array.new(rows * cols) { |i| seen.fetch(i, 0.0) }
+      assert_equal(want, dst.to_a.flatten, "seq #{what}")
+    end
+
+    # a 5-d shape runs past the dimension-specialised kernels
+    deep = [2, 2, 3, 2, 5]
+    n = deep.reduce(:*)
+    ys = Array.new(n) { |i| (i % 7) + 1.0 }
+    a = Cumo::DFloat.cast(ys).reshape(*deep)
+    assert_equal(ys.map { |x| x**2 }, (a**2.0).to_a.flatten)
+    assert_equal(ys.map { |x| x.clamp(2.0, 5.0) }, a.clip(2.0, 5.0).to_a.flatten)
+    assert_equal(a.transpose.copy.modf.map(&:to_a), a.transpose.modf.map(&:to_a))
+    d = Cumo::DFloat.zeros(*deep)
+    d.transpose.seq(1.0)
+    assert_equal((0...n).map { |i| 1.0 + i }, d.transpose.to_a.flatten)
+
+    # the error paths still fire from the kernel
+    assert_raise(Cumo::NArray::OperationError) { src[true, 1..-2].clip(9.0, 1.0) }
+    ints = Cumo::Int32.cast(xs.map(&:to_i)).reshape(rows, cols)
+    assert_raise(ZeroDivisionError) { ints[true, 1..-2].divmod(0) }
+  end
+
   test "copy of an RObject view stays on the host" do
     # RObject data is host memory, so it must not take the kernel path
     a = Cumo::RObject.cast([[1, 2, 3], [4, 5, 6], [7, 8, 9]])


### PR DESCRIPTION
# Run the remaining elementwise kernels through the indexer loop

`pow`, `clip`, `divmod`, `maximum`/`minimum`, `frexp`, `modf`, `fill` and `seq` handed ndloop one row at a time. A view with more than one dimension left after contraction — a column slice, a transpose, an index view — therefore cost one kernel launch per row and nothing else, the same shape [#245](https://github.com/sonots/cumo/pull/245) and [#246](https://github.com/sonots/cumo/pull/246) fixed for store and unary. This is the last of the elementwise group.

Measured on a 2048x2047 `DFloat` column slice (2048 rows), best of 5, on an RTX 5070 Ti Laptop. The "before" column takes the fastest of three separate baseline runs, so the ratios are conservative.

| | before | after |
|---|---|---|
| `a.divmod(3)` | 11.54 ms | 0.13 ms |
| `a.clip(min, max)` | 11.67 ms | 0.17 ms |
| `a ** 3` | 9.33 ms | 0.17 ms |
| `a ** b` | 10.61 ms | 1.76 ms |
| `a.seq` | 3.55 ms | 0.08 ms |
| `a.fill(1)` | 3.54 ms | 0.08 ms |
| `NMath.frexp(a)` | 3.41 ms | 0.24 ms |
| `a.modf` | 3.43 ms | 0.28 ms |
| `DFloat.maximum(a, b)` | 3.30 ms | 0.26 ms |
| `a.clip(nil, max)` | 3.34 ms | 0.17 ms |

`fill` and `seq` drop `CUMO_NDF_INDEX_LOOP` along the way, so an index-backed view is staged into contiguous memory in one launch and written back, which is what `store` has done since #245. `RObject` keeps the host loop, since the indexer addresses device memory with byte steps and cannot reach it.

Results are unchanged. 127 md5 digests covering five view shapes (contiguous, column slice, reversed, row stride, index view) and eight dtypes are identical before and after.

The new test compares each operation on a view against the same operation on a contiguous copy of the same elements, so it tests the walk rather than re-encoding each operation's semantics. It was verified by breaking the addressing in all nine kernels — reading the first input as if it were contiguous, which is right for a copy and wrong for any view — and confirming every one is caught.

`rake test` goes from 1503 tests / 19770 assertions to 1504 / 19846, with the same single pre-existing failure (`test_a_failing_free_from_the_gc_hook_does_not_raise`, which fails on master too when the whole suite runs and passes in isolation on both).
