### PR TITLE
Address Bit operands with an indexer of their own

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -30,10 +30,35 @@ typedef struct {
     ssize_t step[CUMO_NA_MAX_DIMENSION]; // or strides
 } cumo_na_iarray_t;
 
+/* A structure to get a Bit element's position with indexer.
+ *
+ * An element of a Bit array is one bit, so neither the offset of the first
+ * element nor the steps are byte counts and cumo_na_iarray_t cannot hold them.
+ * The position stays absolute rather than being split into a word pointer and
+ * an offset within it, which a negative step would take out of the array.
+ */
+typedef struct {
+    CUMO_BIT_DIGIT* ptr;
+    size_t pos;
+    ssize_t step[CUMO_NA_MAX_DIMENSION];
+} cumo_na_bit_iarray_t;
+
 typedef struct {
     char* ptr;
     cumo_stridx_t stridx[CUMO_NA_MAX_DIMENSION];
 } cumo_na_iarray_stridx_t;
+
+/* The same for a Bit operand that may be backed by an index array.
+ *
+ * ndloop cannot stage a Bit operand into a buffer for us: a buffer copy moves
+ * whole bytes, and a Bit element is one bit. So a Bit loop has to address its
+ * own index arrays.
+ */
+typedef struct {
+    CUMO_BIT_DIGIT* ptr;
+    size_t pos;
+    cumo_stridx_t stridx[CUMO_NA_MAX_DIMENSION];
+} cumo_na_bit_iarray_stridx_t;
 
 typedef struct {
     cumo_na_iarray_t in;
@@ -114,6 +139,34 @@ static cumo_na_iarray_t
 cumo_na_make_iarray(cumo_na_loop_args_t* arg)
 {
     return cumo_na_make_iarray_given_ndim(arg, arg->ndim);
+}
+
+static cumo_na_bit_iarray_stridx_t
+cumo_na_make_bit_iarray_stridx(cumo_na_loop_args_t* arg)
+{
+    cumo_na_bit_iarray_stridx_t iarray;
+    iarray.ptr = (CUMO_BIT_DIGIT*)(arg->ptr);
+    iarray.pos = arg->iter[0].pos;
+    for (int idim = 0; idim < arg->ndim; ++idim) {
+        if (arg->iter[idim].idx) {
+            CUMO_SDX_SET_INDEX(iarray.stridx[idim], arg->iter[idim].idx);
+        } else {
+            CUMO_SDX_SET_STRIDE(iarray.stridx[idim], arg->iter[idim].step);
+        }
+    }
+    return iarray;
+}
+
+static cumo_na_bit_iarray_t
+cumo_na_make_bit_iarray(cumo_na_loop_args_t* arg)
+{
+    cumo_na_bit_iarray_t iarray;
+    iarray.ptr = (CUMO_BIT_DIGIT*)(arg->ptr);
+    iarray.pos = arg->iter[0].pos;
+    for (int idim = arg->ndim; --idim >= 0;) {
+        iarray.step[idim] = arg->iter[idim].step;
+    }
+    return iarray;
 }
 
 // out_arg names the loop argument to reduce into. It is 1 for a reduction with
@@ -221,6 +274,86 @@ __host__ __device__
 static inline char*
 cumo_na_iarray_at_dim1(cumo_na_iarray_t* iarray, cumo_na_indexer_t* indexer) {
     return iarray->ptr + iarray->step[0] * indexer->raw_index;
+}
+
+__host__ __device__
+static inline size_t
+cumo_na_bit_iarray_at_dim(cumo_na_bit_iarray_t* iarray, cumo_na_indexer_t* indexer) {
+    size_t pos = iarray->pos;
+    for (int idim = 0; idim < indexer->ndim; ++idim) {
+        pos += iarray->step[idim] * indexer->index[idim];
+    }
+    return pos;
+}
+
+// Let compiler optimize
+#define CUMO_NA_BIT_IARRAY_AT(NDIM) \
+__host__ __device__ \
+static inline size_t \
+cumo_na_bit_iarray_at_dim##NDIM(cumo_na_bit_iarray_t* iarray, cumo_na_indexer_t* indexer) { \
+    size_t pos = iarray->pos; \
+    for (int idim = 0; idim < NDIM; ++idim) { \
+        pos += iarray->step[idim] * indexer->index[idim]; \
+    } \
+    return pos; \
+}
+
+CUMO_NA_BIT_IARRAY_AT(4)
+CUMO_NA_BIT_IARRAY_AT(3)
+CUMO_NA_BIT_IARRAY_AT(2)
+CUMO_NA_BIT_IARRAY_AT(0)
+
+__host__ __device__
+static inline size_t
+cumo_na_bit_iarray_at_dim1(cumo_na_bit_iarray_t* iarray, cumo_na_indexer_t* indexer) {
+    return iarray->pos + iarray->step[0] * indexer->raw_index;
+}
+
+__host__ __device__
+static inline size_t
+cumo_na_bit_iarray_stridx_at_dim(cumo_na_bit_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer) {
+    size_t pos = iarray->pos;
+    for (int idim = 0; idim < indexer->ndim; ++idim) {
+        if (CUMO_SDX_IS_INDEX(iarray->stridx[idim])) {
+            pos += CUMO_SDX_GET_INDEX(iarray->stridx[idim])[indexer->index[idim]];
+        } else {
+            pos += CUMO_SDX_GET_STRIDE(iarray->stridx[idim]) * indexer->index[idim];
+        }
+    }
+    return pos;
+}
+
+// Let compiler optimize
+#define CUMO_NA_BIT_IARRAY_STRIDX_AT(NDIM) \
+__host__ __device__ \
+static inline size_t \
+cumo_na_bit_iarray_stridx_at_dim##NDIM(cumo_na_bit_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer) { \
+    size_t pos = iarray->pos; \
+    for (int idim = 0; idim < NDIM; ++idim) { \
+        if (CUMO_SDX_IS_INDEX(iarray->stridx[idim])) { \
+            pos += CUMO_SDX_GET_INDEX(iarray->stridx[idim])[indexer->index[idim]]; \
+        } else { \
+            pos += CUMO_SDX_GET_STRIDE(iarray->stridx[idim]) * indexer->index[idim]; \
+        } \
+    } \
+    return pos; \
+}
+
+CUMO_NA_BIT_IARRAY_STRIDX_AT(4)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(3)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(2)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(0)
+
+// cumo_na_indexer_set_dim1 leaves index[] alone, so one dimension has to be
+// addressed through raw_index
+__host__ __device__
+static inline size_t
+cumo_na_bit_iarray_stridx_at_dim1(cumo_na_bit_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer) {
+    if (CUMO_SDX_IS_INDEX(iarray->stridx[0])) {
+        return iarray->pos + CUMO_SDX_GET_INDEX(iarray->stridx[0])[indexer->raw_index];
+    } else {
+        return iarray->pos + CUMO_SDX_GET_STRIDE(iarray->stridx[0]) * indexer->raw_index;
+    }
 }
 
 __host__ __device__

--- a/ext/cumo/narray/gen/tmpl/cond_binary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_binary.c
@@ -1,23 +1,24 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char   *p1, *p2;
-    CUMO_BIT_DIGIT *a3;
-    size_t  p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR_BIT(lp, 2, a3, p3, s3);
     <% if type_name == 'robject' %>
     {
+        size_t  i;
+        char   *p1, *p2;
+        CUMO_BIT_DIGIT *a3;
+        size_t  p3;
+        ssize_t s1, s2, s3;
         dtype x, y;
         CUMO_BIT_DIGIT b;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR_BIT(lp, 2, a3, p3, s3);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         for (; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
@@ -29,7 +30,12 @@ static void
     }
     <% else %>
     {
-        <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,a3,p3,s1,s2,s3,i);
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_bit_iarray_t a3 = cumo_na_make_bit_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
     }
     <% end %>
 }
@@ -39,7 +45,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cumo_cBit,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+    <% end %>
 
     return cumo_na_ndloop(&ndf, 2, self, other);
 }

--- a/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
@@ -1,19 +1,31 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
-        dtype y = *(dtype*)(p2+(i*s2));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        dtype y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         CUMO_BIT_DIGIT b = (m_<%=name%>(x,y)) ? 1:0;
-        CUMO_STORE_BIT(a3,p3+(i*s3),b);
+        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a3, &indexer), b);
     }
 }
+<% end %>
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a3,p3,s1,s2,s3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/cond_unary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_unary.c
@@ -1,27 +1,24 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_bit_iarray_t* a2, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t    n;
-    char     *p1;
-    CUMO_BIT_DIGIT *a2;
-    size_t    p2;
-    ssize_t   s1, s2;
-    size_t   *idx1;
-
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
-    CUMO_INIT_PTR_BIT(lp, 1, a2, p2, s2);
-
     <% if type_name == 'robject' %>
     {
-        size_t i;
+        size_t    i, n;
+        char     *p1;
+        CUMO_BIT_DIGIT *a2;
+        size_t    p2;
+        ssize_t   s1, s2;
+        size_t   *idx1;
         dtype x;
         CUMO_BIT_DIGIT b;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
+        CUMO_INIT_PTR_BIT(lp, 1, a2, p2, s2);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         if (idx1) {
@@ -42,11 +39,11 @@ static void
     }
     <% else %>
     {
-        if (idx1) {
-            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,a2,p2,idx1,s2,n);
-        } else {
-            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,a2,p2,s1,s2,n);
-        }
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_bit_iarray_t a2 = cumo_na_make_bit_iarray(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
     }
     <% end %>
 }
@@ -61,7 +58,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cumo_cBit,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 1, ain, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain, aout };
+    <% end %>
 
     return cumo_na_ndloop(&ndf, 1, self);
 }

--- a/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
@@ -1,35 +1,30 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_index_kernel"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_bit_iarray_t a2, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1 + idx1[i]);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         CUMO_BIT_DIGIT b = (m_<%=name%>(x)) ? 1:0;
-        CUMO_STORE_BIT(a2,p2+(i*s2),b);
+        CUMO_STORE_BIT(a2.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a2, &indexer), b);
     }
 }
+<% end %>
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_bit_iarray_t* a2, cumo_na_indexer_t* indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
-        CUMO_BIT_DIGIT b = (m_<%=name%>(x)) ? 1:0;
-        CUMO_STORE_BIT(a2,p2+(i*s2),b);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
     }
-}
-
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, size_t *idx1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,a2,p2,idx1,s2,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,a2,p2,s1,s2,n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl_bit/binary.c
+++ b/ext/cumo/narray/gen/tmpl_bit/binary.c
@@ -1,23 +1,32 @@
-void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a2, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a2, size_t p2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n);
+
+static int
+<%=c_iter%>_is_flat(cumo_na_bit_iarray_stridx_t* a, cumo_na_indexer_t* indexer)
+{
+    return indexer->ndim == 1 &&
+        CUMO_SDX_IS_STRIDE(a->stridx[0]) && CUMO_SDX_GET_STRIDE(a->stridx[0]) == 1;
+}
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    size_t  p1, p2, p3;
-    ssize_t s1, s2, s3;
-    size_t *idx1, *idx2, *idx3;
-    CUMO_BIT_DIGIT *a1, *a2, *a3;
+    cumo_na_bit_iarray_stridx_t a1 = cumo_na_make_bit_iarray_stridx(&lp->args[0]);
+    cumo_na_bit_iarray_stridx_t a2 = cumo_na_make_bit_iarray_stridx(&lp->args[1]);
+    cumo_na_bit_iarray_stridx_t a3 = cumo_na_make_bit_iarray_stridx(&lp->args[2]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
-    CUMO_INIT_PTR_BIT_IDX(lp, 1, a2, p2, s2, idx2);
-    CUMO_INIT_PTR_BIT_IDX(lp, 2, a3, p3, s3, idx3);
-    if (s1!=1 || s2!=1 || s3!=1 || idx1 || idx2 || idx3) {
-        <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(a1,p1,s1,idx1,a2,p2,s2,idx2,a3,p3,s3,idx3,n);
+    // A word at a time is worth a separate kernel, but it needs every operand
+    // laid out end to end, which after the loop is contracted means one
+    // dimension of step one.
+    if (<%=c_iter%>_is_flat(&a1,&indexer) && <%=c_iter%>_is_flat(&a2,&indexer) && <%=c_iter%>_is_flat(&a3,&indexer)) {
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(
+            a1.ptr + a1.pos / CUMO_NB, a1.pos % CUMO_NB,
+            a2.ptr + a2.pos / CUMO_NB, a2.pos % CUMO_NB,
+            a3.ptr + a3.pos / CUMO_NB, a3.pos % CUMO_NB,
+            indexer.total_size);
     } else {
-        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(a1,p1,a2,p2,a3,p3,n);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
     }
 }
 
@@ -32,7 +41,7 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
-    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 2, 1, ain, aout };
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
 
     return cumo_na_ndloop(&ndf, 2, self, other);
 }

--- a/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
@@ -1,13 +1,16 @@
-__global__ void <%="cumo_#{c_iter}_elementwise_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a2, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         CUMO_BIT_DIGIT x, y;
-        CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
-        CUMO_LOAD_BIT(a2, cumo_bit_pos(p2,s2,idx2,i), y);
+        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
+        CUMO_LOAD_BIT(a2.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a2, &indexer), y);
         CUMO_BIT_DIGIT z = m_<%=name%>(x,y) & 1u;
-        CUMO_STORE_BIT(a3, cumo_bit_pos(p3,s3,idx3,i), z);
+        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), z);
     }
 }
+<% end %>
 
 __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a2, ssize_t o2, uint64_t w2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
 {
@@ -18,11 +21,20 @@ __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssiz
     }
 }
 
-void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a2, size_t p2, ssize_t s2, size_t *idx2, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a2, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_elementwise_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a2,p2,s2,idx2,a3,p3,s3,idx3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/ext/cumo/narray/gen/tmpl_bit/unary.c
+++ b/ext/cumo/narray/gen/tmpl_bit/unary.c
@@ -1,22 +1,30 @@
-void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n);
+
+static int
+<%=c_iter%>_is_flat(cumo_na_bit_iarray_stridx_t* a, cumo_na_indexer_t* indexer)
+{
+    return indexer->ndim == 1 &&
+        CUMO_SDX_IS_STRIDE(a->stridx[0]) && CUMO_SDX_GET_STRIDE(a->stridx[0]) == 1;
+}
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    size_t  p1, p3;
-    ssize_t s1, s3;
-    size_t *idx1, *idx3;
-    CUMO_BIT_DIGIT *a1, *a3;
+    cumo_na_bit_iarray_stridx_t a1 = cumo_na_make_bit_iarray_stridx(&lp->args[0]);
+    cumo_na_bit_iarray_stridx_t a3 = cumo_na_make_bit_iarray_stridx(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
-    CUMO_INIT_PTR_BIT_IDX(lp, 1, a3, p3, s3, idx3);
-    if (s1!=1 || s3!=1 || idx1 || idx3) {
-        <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(a1,p1,s1,idx1,a3,p3,s3,idx3,n);
+    // A word at a time is worth a separate kernel, but it needs both operands
+    // laid out end to end, which after the loop is contracted means one
+    // dimension of step one.
+    if (<%=c_iter%>_is_flat(&a1,&indexer) && <%=c_iter%>_is_flat(&a3,&indexer)) {
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(
+            a1.ptr + a1.pos / CUMO_NB, a1.pos % CUMO_NB,
+            a3.ptr + a3.pos / CUMO_NB, a3.pos % CUMO_NB,
+            indexer.total_size);
     } else {
-        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(a1,p1,a3,p3,n);
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a3,&indexer);
     }
 }
 
@@ -30,7 +38,7 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
-    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 1,1, ain,aout};
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain, aout };
 
     return cumo_na_ndloop(&ndf, 1, self);
 }

--- a/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
@@ -1,12 +1,15 @@
-__global__ void <%="cumo_#{c_iter}_elementwise_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         CUMO_BIT_DIGIT x;
-        CUMO_LOAD_BIT(a1, cumo_bit_pos(p1,s1,idx1,i), x);
+        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
         CUMO_BIT_DIGIT y = m_<%=name%>(x) & 1u;
-        CUMO_STORE_BIT(a3, cumo_bit_pos(p3,s3,idx3,i), y);
+        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), y);
     }
 }
+<% end %>
 
 __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
 {
@@ -16,11 +19,20 @@ __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssiz
     }
 }
 
-void <%="cumo_#{c_iter}_elementwise_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, CUMO_BIT_DIGIT *a3, size_t p3, ssize_t s3, size_t *idx3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_elementwise_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,idx1,a3,p3,s3,idx3,n);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3241,6 +3241,121 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(ZeroDivisionError) { ints[true, 1..-2].divmod(0) }
   end
 
+  # Combines two nested Bit arrays element by element, whatever their depth
+  def zip_bits(a, b, &blk)
+    if a.first.is_a?(Array)
+      a.zip(b).map { |x, y| zip_bits(x, y, &blk) }
+    else
+      a.zip(b).map { |x, y| blk.call(x, y) }
+    end
+  end
+
+  test "Bit results reach every element of a view they cannot flatten" do
+    # A Bit element is one bit, so its position and steps are bit counts and
+    # the byte indexer cannot address it. Comparisons, the isnan family and the
+    # Bit operators each ran once per row of a view before the bit indexer.
+    rows = 9
+    cols = 7
+    xs = Array.new(rows * cols) { |i| ((i * 3) % 13) - 6.0 }
+    src = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    other = Cumo::DFloat.cast(xs.rotate(5)).reshape(rows, cols)
+    m1 = Cumo::Int32.cast(Array.new(rows * cols) { |i| i % 3 }).reshape(rows, cols).gt(1)
+    m2 = Cumo::Int32.cast(Array.new(rows * cols) { |i| i % 4 }).reshape(rows, cols).gt(1)
+    idx = [5, 0, 3, 8, 1]
+
+    views = {
+      "column slice" => ->(a) { a[true, 1...(cols - 1)] },
+      "reversed" => ->(a) { a[true, (cols - 1).step(0, -1)] },
+      "row stride" => ->(a) { a[0.step(rows - 1, 2), true] },
+      "index view" => ->(a) { a[idx, true] },
+      "transpose" => ->(a) { a.transpose },
+    }
+
+    views.each do |what, take|
+      a = take.call(src)
+      b = take.call(other)
+      p1 = take.call(m1)
+      p2 = take.call(m2)
+      fa = a.copy
+      fb = b.copy
+      f1 = p1.copy
+      f2 = p2.copy
+
+      %i[gt ge lt le eq ne].each do |op|
+        assert_equal(fa.send(op, fb).to_a, a.send(op, b).to_a, "#{op} of #{what}")
+      end
+      %i[isnan isinf isfinite signbit].each do |op|
+        assert_equal(fa.send(op).to_a, a.send(op).to_a, "#{op} of #{what}")
+      end
+      # The Bit operators are checked against the elements Ruby sees rather
+      # than against a copy: copy is the same template, so a copy taken the
+      # wrong way would agree with an operator taken the wrong way
+      w1 = p1.to_a
+      w2 = p2.to_a
+      assert_equal(zip_bits(w1, w2) { |u, v| u & v }, (p1 & p2).to_a, "and of #{what}")
+      assert_equal(zip_bits(w1, w2) { |u, v| u | v }, (p1 | p2).to_a, "or of #{what}")
+      assert_equal(zip_bits(w1, w2) { |u, v| u ^ v }, (p1 ^ p2).to_a, "xor of #{what}")
+      assert_equal(zip_bits(w1, w1) { |u, _| u ^ 1 }, (~p1).to_a, "not of #{what}")
+      assert_equal(w1.flatten.count(1), p1.count_true, "count_true of #{what}")
+      assert_equal(w1, f1.to_a, "copy of #{what}")
+
+      cells = take.call(Cumo::DFloat.cast((0...(rows * cols)).to_a).reshape(rows, cols))
+                  .to_a.flatten.map(&:to_i)
+      d = Cumo::Bit.new(rows, cols).fill(0)
+      take.call(d).fill(1)
+      assert_equal(Array.new(rows * cols) { |i| cells.include?(i) ? 1 : 0 }, d.to_a.flatten,
+                   "Bit fill of #{what}")
+    end
+
+    # One dimension is addressed through the indexer's raw index rather than
+    # its per-dimension indices, a path no two-dimensional view reaches
+    len = 40
+    ys = Array.new(len) { |i| ((i * 5) % 17) - 8.0 }
+    flat = Cumo::DFloat.cast(ys)
+    flat2 = Cumo::DFloat.cast(ys.rotate(3))
+    bits1 = Cumo::Int32.cast(Array.new(len) { |i| i % 3 }).gt(1)
+    bits2 = Cumo::Int32.cast(Array.new(len) { |i| i % 4 }).gt(1)
+
+    one_d = {
+      "step 3" => ->(a) { a[0.step(len - 1, 3)] },
+      "reversed" => ->(a) { a[(len - 1).step(0, -1)] },
+      "reversed by 2" => ->(a) { a[(len - 1).step(0, -2)] },
+      "fancy" => ->(a) { a[[7, 2, 39, 0, 15, 15]] },
+      "tail" => ->(a) { a[3..-4] },
+    }
+
+    one_d.each do |what, take|
+      a = take.call(flat)
+      b = take.call(flat2)
+      p1 = take.call(bits1)
+      p2 = take.call(bits2)
+
+      assert_equal(a.copy.gt(b.copy).to_a, a.gt(b).to_a, "1-d gt of #{what}")
+      assert_equal(a.copy.signbit.to_a, a.signbit.to_a, "1-d signbit of #{what}")
+      w1 = p1.to_a
+      w2 = p2.to_a
+      assert_equal(w1.zip(w2).map { |u, v| u & v }, (p1 & p2).to_a, "1-d and of #{what}")
+      assert_equal(w1.map { |u| u ^ 1 }, (~p1).to_a, "1-d not of #{what}")
+      assert_equal(w1.count(1), p1.count_true, "1-d count_true of #{what}")
+      assert_equal(w1, p1.copy.to_a, "1-d copy of #{what}")
+
+      cells = take.call(Cumo::DFloat.cast((0...len).to_a)).to_a.map(&:to_i)
+      d = Cumo::Bit.new(len).fill(0)
+      take.call(d).fill(1)
+      assert_equal(Array.new(len) { |i| cells.include?(i) ? 1 : 0 }, d.to_a, "1-d Bit fill of #{what}")
+    end
+
+    # a 5-d shape runs past the dimension-specialised kernels
+    deep = [2, 2, 3, 2, 5]
+    n = deep.reduce(:*)
+    zs = Array.new(n) { |i| ((i * 7) % 11) - 5.0 }
+    a = Cumo::DFloat.cast(zs).reshape(*deep)
+    assert_equal(zs.map { |x| x > 0 ? 1 : 0 }, a.gt(0).to_a.flatten)
+    assert_equal(a.transpose.copy.gt(0).to_a.flatten, a.transpose.gt(0).to_a.flatten)
+    bd = Cumo::Int32.cast(Array.new(n) { |i| i % 3 }).reshape(*deep).gt(1)
+    assert_equal(bd.transpose.to_a.flatten.map { |u| u ^ 1 }, (~bd.transpose).to_a.flatten)
+  end
+
   test "copy of an RObject view stays on the host" do
     # RObject data is host memory, so it must not take the kernel path
     a = Cumo::RObject.cast([[1, 2, 3], [4, 5, 6], [7, 8, 9]])


### PR DESCRIPTION
A `Cumo::Bit` element is one bit, so its offset and its steps are counted in bits and `cumo_na_iarray_t`, which holds byte steps, cannot reach it. The comparisons, the `isnan` family and the `Bit` operators were therefore the last elementwise group left outside the indexer loop: a view with more than one dimension left after contraction cost one kernel launch per row.

Measured on a 2048x2047 view (2048 rows), best of 5, on an RTX 5070 Ti Laptop. Both columns are taken from a second run so the GPU is at the same clock — the first benchmark run after an idle period reads about 8x slower on every line.

| | before | after |
|---|---|---|
| `a.gt(b)` | 4.08 ms | 0.42 ms |
| `a.eq(b)` | 4.07 ms | 0.41 ms |
| `a.isnan` | 3.60 ms | 0.40 ms |
| `a.signbit` | 3.64 ms | 0.45 ms |
| `p1 & p2` | 3.28 ms | 0.46 ms |
| `~p1` | 3.28 ms | 0.47 ms |
| `bt & bu` (contiguous) | 0.007 ms | 0.007 ms |

`cumo_na_bit_iarray_t` carries bit steps. `cumo_na_bit_iarray_stridx_t` carries index arrays as well, which the `Bit` operators need: ndloop stages an operand into a buffer by whole bytes and cannot do that for bits, so a `Bit` loop has to address its own index arrays rather than let ndloop remove them. Both keep the position absolute instead of splitting it into a word pointer and an offset within that word, which a negative step would take below the array.

The word-at-a-time path of the `Bit` operators is untouched and still taken whenever every operand is contiguous, which is why the last row above does not move.

Results are unchanged: 252 md5 digests covering six two-dimensional views, six one-dimensional views and nine dtypes are identical before and after.

The new test compares each result against what Ruby sees in the operand rather than against a copy of it. `copy` is generated from the same template as the `Bit` operators, so a copy taken the wrong way would have agreed with an operator taken the wrong way — the first version of the test did compare against a copy and missed exactly that. It also covers one-dimensional views on their own, which reach the indexer's raw-index path that no two-dimensional view does; that path is where the one bug found during this work lived. The test was verified by breaking the addressing in all four kernels and confirming each of ten checks is caught.

`rake test` goes from 1504 tests / 19846 assertions to 1505 / 19969, with the same single pre-existing failure (`test_a_failing_free_from_the_gc_hook_does_not_raise`, which fails on master too when the whole suite runs and passes in isolation on both).

Storing between `Bit` and other dtypes is still row at a time (`Bit` to `Int32` 3.3 ms, `Int32` to `Bit` 7.4 ms on the same view). Those templates convert dtypes as well and are left for a separate change.
