### PR TITLE
Reduce over an outer axis without the indexer

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -12,6 +12,7 @@ namespace cumo_detail {
 
 static constexpr int64_t max_block_size = 512;
 static constexpr int64_t max_grid_size = 0x7fffffff;
+static constexpr int64_t warp_size = 32;
 
 // A reduction gets one block per output element, so reducing to a single value
 // leaves the whole grid at one block however long the reduce axis is. Below
@@ -33,103 +34,261 @@ static inline int64_t round_up_to_power_of_2(int64_t x) {
     return x + 1;
 }
 
-// True when the flat index into the indexer is also the element offset from
-// ptr, which is what lets the kernels below drop the indexer entirely. An
-// indexer of no dimensions addresses one element at ptr, so it qualifies.
-template <typename Type>
-static bool iarray_is_flat(const cumo_na_iarray_t& iarray, const cumo_na_indexer_t& indexer) {
-    ssize_t expect = static_cast<ssize_t>(sizeof(Type));
-    for (int i = indexer.ndim; --i >= 0;) {
-        if (iarray.step[i] != expect) return false;
-        expect *= static_cast<ssize_t>(indexer.shape[i]);
+static inline ssize_t step_magnitude(ssize_t step) { return step < 0 ? -step : step; }
+
+// How a reduction addresses its operands, worked out on the host.
+//
+// A group of axes is flat when the offset of its i-th element is i * step,
+// which is what lets a loop walk it with one multiply. Getting the offset from
+// cumo_na_indexer_set_dim and cumo_na_iarray_at_dim instead costs far more than
+// the reduction does: those write into the indexer, and the indexer carries
+// shape[] and index[] for CUMO_NA_MAX_DIMENSION, so the copy the kernel writes
+// into cannot stay in registers and every element pays a local memory round
+// trip. Measured on an RTX 5070 Ti, a 2048x2048 sum along the last axis takes
+// 1.89 ms that way and 0.02 ms with the offsets below.
+//
+// split is the first reduce dimension. It is -1 when the reduce axis does not
+// end up on a dimension boundary, which leaves the whole flat index to
+// decompose; the flat forms never need it.
+typedef struct {
+    int split;
+    bool in_out_flat;
+    bool in_reduce_flat;
+    bool out_flat;
+    bool out2_flat;
+    bool out_inner;         // the out axis, not the reduce axis, runs along memory
+    ssize_t in_out_step;    // bytes
+    ssize_t in_reduce_step; // bytes
+    ssize_t out_step;       // bytes
+    ssize_t out2_step;      // bytes
+} cumo_reduce_addr_t;
+
+// True when the offset of the i-th element over dims [begin, end) is i * step.
+static inline bool axes_are_flat(const cumo_na_iarray_t& iarray, const cumo_na_indexer_t& indexer, int begin, int end, ssize_t* step) {
+    if (begin >= end) {
+        *step = 0;
+        return true;
     }
+    ssize_t acc = iarray.step[end - 1];
+    for (int j = end - 1; j > begin; --j) {
+        acc *= static_cast<ssize_t>(indexer.shape[j]);
+        if (iarray.step[j - 1] != acc) return false;
+    }
+    *step = iarray.step[end - 1];
     return true;
+}
+
+static inline cumo_reduce_addr_t make_reduce_addr(const cumo_na_reduction_arg_t& arg, int64_t reduce_total_size) {
+    cumo_reduce_addr_t ad;
+    int in_ndim = arg.in_indexer.ndim;
+    ssize_t whole_step;
+
+    if (axes_are_flat(arg.in, arg.in_indexer, 0, in_ndim, &whole_step)) {
+        // One stride covers the input, so the reduce axis does not have to fall
+        // on a dimension boundary. This is also how the scratch of a split
+        // reduction comes back in.
+        ad.split = -1;
+        ad.in_out_flat = true;
+        ad.in_reduce_flat = true;
+        ad.in_reduce_step = whole_step;
+        ad.in_out_step = whole_step * reduce_total_size;
+    } else {
+        int split = in_ndim;
+        int64_t acc = 1;
+        while (split > 0 && acc < reduce_total_size) {
+            --split;
+            acc *= static_cast<int64_t>(arg.in_indexer.shape[split]);
+        }
+        if (acc == reduce_total_size) {
+            ad.split = split;
+            ad.in_reduce_flat = axes_are_flat(arg.in, arg.in_indexer, split, in_ndim, &ad.in_reduce_step);
+            ad.in_out_flat = axes_are_flat(arg.in, arg.in_indexer, 0, split, &ad.in_out_step);
+        } else {
+            ad.split = -1;
+            ad.in_reduce_flat = false;
+            ad.in_out_flat = false;
+            ad.in_reduce_step = 0;
+            ad.in_out_step = 0;
+        }
+    }
+
+    ad.out_flat = axes_are_flat(arg.out, arg.out_indexer, 0, arg.out_indexer.ndim, &ad.out_step);
+    ad.out2_flat = true;
+    ad.out2_step = 0;
+
+    ssize_t out_inner_step, reduce_inner_step;
+    if (ad.in_out_flat && ad.in_reduce_flat) {
+        out_inner_step = ad.in_out_step;
+        reduce_inner_step = ad.in_reduce_step;
+    } else {
+        out_inner_step = ad.split > 0 ? arg.in.step[ad.split - 1] : 0;
+        reduce_inner_step = (ad.split >= 0 && ad.split < in_ndim) ? arg.in.step[in_ndim - 1] : 0;
+    }
+    ad.out_inner = out_inner_step != 0 &&
+        (reduce_inner_step == 0 || step_magnitude(out_inner_step) < step_magnitude(reduce_inner_step));
+
+    return ad;
+}
+
+static inline void set_reduce_addr_out2(cumo_reduce_addr_t* ad, const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& out2) {
+    ad->out2_flat = axes_are_flat(out2, arg.out_indexer, 0, arg.out_indexer.ndim, &ad->out2_step);
+}
+
+// Threads of a block are consecutive in i_out below out_block_size and
+// consecutive in i_reduce above it, so whichever of the two runs along memory
+// decides whether a block's reads coalesce. Handing the reduce axis every
+// thread is right when it is the contiguous one and wrong when it is not: a
+// 2048x2048 sum along axis 0 otherwise puts each of a block's 512 threads on a
+// different row and reads one element per transaction.
+static inline void reduce_block_split(const cumo_reduce_addr_t& ad, int64_t reduce_total_size, int64_t* out_block_size, int64_t* reduce_block_size) {
+    int64_t rbs = std::min(max_block_size, round_up_to_power_of_2(std::max(int64_t{1}, reduce_total_size)));
+    if (ad.out_inner) {
+        rbs = std::min(rbs, max_block_size / warp_size);
+    }
+    *reduce_block_size = rbs;
+    *out_block_size = max_block_size / rbs;
+}
+
+// Byte offset of the i-th element over dims [begin, end). Everything here is
+// read out of the kernel parameter and nothing is written back, which is what
+// keeps the indexer out of local memory.
+__device__ static inline ssize_t axes_offset(const cumo_na_iarray_t& iarray, const cumo_na_indexer_t& indexer, int begin, int end, int64_t i) {
+    ssize_t off = 0;
+    for (int j = end; --j >= begin;) {
+        int64_t n = static_cast<int64_t>(indexer.shape[j]);
+        off += static_cast<ssize_t>(i % n) * iarray.step[j];
+        i /= n;
+    }
+    return off;
+}
+
+template <bool FLAT>
+__device__ static inline ssize_t reduce_in_out_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, int64_t i_out) {
+    if (FLAT || ad.in_out_flat) return i_out * ad.in_out_step;
+    if (ad.split < 0) return 0;
+    return axes_offset(arg.in, arg.in_indexer, 0, ad.split, i_out);
+}
+
+template <bool FLAT>
+__device__ static inline ssize_t reduce_in_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, ssize_t in_out_off, int64_t i_reduce, int64_t i_in) {
+    if (FLAT || ad.in_reduce_flat) return in_out_off + i_reduce * ad.in_reduce_step;
+    if (ad.split < 0) return axes_offset(arg.in, arg.in_indexer, 0, arg.in_indexer.ndim, i_in);
+    return in_out_off + axes_offset(arg.in, arg.in_indexer, ad.split, arg.in_indexer.ndim, i_reduce);
+}
+
+template <bool FLAT>
+__device__ static inline ssize_t reduce_out_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, int64_t i_out) {
+    if (FLAT || ad.out_flat) return i_out * ad.out_step;
+    return axes_offset(arg.out, arg.out_indexer, 0, arg.out_indexer.ndim, i_out);
+}
+
+template <bool FLAT>
+__device__ static inline ssize_t reduce_out2_offset(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& out2, const cumo_reduce_addr_t& ad, int64_t i_out) {
+    if (FLAT || ad.out2_flat) return i_out * ad.out2_step;
+    return axes_offset(out2, arg.out_indexer, 0, arg.out_indexer.ndim, i_out);
+}
+
+// Combines the accumulators a block holds for one output element. Threads that
+// share out_offset sit reduce_block_size apart, so the tree only has to run
+// down to out_block_size.
+template <typename TypeReduce, typename ReductionImpl>
+__device__ static inline TypeReduce reduce_in_block(TypeReduce accum, TypeReduce* sdata, unsigned int tid, int out_block_size, ReductionImpl& impl) {
+    if (out_block_size > max_block_size / 2) return accum;
+    sdata[tid] = accum;
+    __syncthreads();
+    // NOTE: Compiler optimizes to unroll this loop
+    for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
+        if (out_block_size <= stride) {
+            if (tid < stride) {
+                impl.Reduce(sdata[tid + stride], sdata[tid]);
+            }
+            __syncthreads();
+        }
+    }
+    accum = sdata[tid];
+    __syncthreads();
+    return accum;
+}
+
+// Reduces one output element's slice of the reduce axis, taking every
+// reduce_block_size-th element from begin so that the threads sharing an
+// output split the axis between them. A flat reduce group walks by pointer:
+// recomputing i_reduce * step every element costs a 64-bit multiply, and the
+// contiguous shapes are already at memory bandwidth without it.
+//
+// ARG_INDEX picks what MapIn is handed. arg(min|max) wants the index along the
+// reduction axis, which is what CuPy's reductions pass. Everything else wants
+// the offset of the element from the start of the input, which is the index
+// (min|max)_index answers with.
+template <bool FLAT, bool ARG_INDEX, typename TypeIn, typename ReductionImpl>
+__device__ static inline auto reduce_axis(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, ReductionImpl& impl,
+        ssize_t in_out_off, int64_t i_in, int64_t begin, int64_t end, int64_t reduce_offset, int64_t reduce_block_size) -> decltype(impl.Identity(0)) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    char* in_base = arg.in.ptr;
+    TypeIn* in_head = reinterpret_cast<TypeIn*>(in_base);
+    int64_t i_reduce = begin + reduce_offset;
+    char* p = in_base + reduce_in_offset<FLAT>(arg, ad, in_out_off, i_reduce, i_in);
+    ssize_t advance = ad.in_reduce_step * reduce_block_size;
+
+    TypeReduce accum = ARG_INDEX ? impl.Identity(reduce_offset)
+                                 : impl.Identity(static_cast<int64_t>(reinterpret_cast<TypeIn*>(p) - in_head));
+
+    for (; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(p);
+        impl.Reduce(impl.MapIn(*in_ptr, ARG_INDEX ? i_reduce : static_cast<int64_t>(in_ptr - in_head)), accum);
+        p = (FLAT || ad.in_reduce_flat)
+            ? p + advance
+            : in_base + reduce_in_offset<FLAT>(arg, ad, in_out_off, i_reduce + reduce_block_size, i_in + reduce_block_size);
+    }
+    return accum;
 }
 
 // Reference: cupy reduction kernel
 // Note that reduction and out axis are inverse with cupy. Former axes are out axes, latters are reduce axes.
 
-template <typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, int out_block_size, int reduce_block_size, ReductionImpl impl) {
-    cumo_na_iarray_t& in_iarray = arg.in;
-    cumo_na_iarray_t& out_iarray = arg.out;
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
+template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
     unsigned int tid = threadIdx.x;
 
-    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+
     int64_t reduce_offset = tid / out_block_size; // # of cols == # of elems
+    int64_t out_offset = tid % out_block_size;    // # of rows
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
 
-    int64_t out_offset = tid % out_block_size; // # of rows
-    int64_t out_base = blockIdx.x * out_block_size; // # of rows
-    int64_t out_stride = gridDim.x * out_block_size; // # of rows
+    for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-    for (int64_t i_out = out_base + out_offset; i_out < out_indexer.total_size; i_out += out_stride) {
-        cumo_na_indexer_set_dim(&out_indexer, i_out);
-        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
+        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
-        // Note that spec of (min|max)_index of cumo is different with arg(min|max) of cupy.
-        // Cumo returns index of input elements, CuPy returns index of reduction axis.
-        cumo_na_indexer_set_dim(&in_indexer, i_in);
-        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
-
-        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            cumo_na_indexer_set_dim(&in_indexer, i_in);
-            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-            impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
-            //printf("threadId.x:%d blockIdx.x:%d blockDim.x:%d gridDim.x:%d accum:%d i_in:%ld i_reduce:%ld i_out:%ld in:%p(%d)\n", threadIdx.x, blockIdx.x, blockDim.x, gridDim.x, accum, i_in, i_reduce, i_out, in_ptr, *in_ptr);
-        }
-
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            // NOTE: Compiler optimizes to unroll this loop
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_out < out_indexer.total_size) {
-            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out_iarray, &out_indexer));
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(arg.out.ptr + reduce_out_offset<FLAT>(arg, ad, i_out));
             *out_ptr = impl.MapOut(accum);
-            //printf("threadId.x:%d blockIdx.x:%d blockDim.x:%d gridDim.x:%d accum:%d i_out:%ld out:%p(%d)\n", threadIdx.x, blockIdx.x, blockDim.x, gridDim.x, accum, i_out, out_ptr, *out_ptr);
         }
     }
 }
 
-// reduction_kernel for operands whose flat index is their element offset.
-//
-// Reading an element through cumo_na_indexer_set_dim and cumo_na_iarray_at_dim
-// costs far more than the reduction does: the indexer carries shape[] and
-// index[] for CUMO_NA_MAX_DIMENSION, so the copy the kernel writes into cannot
-// stay in registers and every element pays a local memory round trip. Measured
-// on an RTX 5070 Ti, a 2048x2048 sum along the last axis takes 1.89 ms through
-// the indexer and 0.02 ms through this. A runtime flag inside the one kernel
-// does not help; the indexer has to be absent for the addresses to fold away.
-template <typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_flat_kernel(cumo_na_reduction_arg_t arg, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+// Variant of reduction_kernel for arg-reductions (argmax/argmin), which report
+// the index along the reduction axis rather than the index of an element.
+template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
     unsigned int tid = threadIdx.x;
 
-    TypeIn* in = reinterpret_cast<TypeIn*>(arg.in.ptr);
-    TypeOut* out = reinterpret_cast<TypeOut*>(arg.out.ptr);
     int64_t out_total_size = arg.out_indexer.total_size;
-    int64_t reduce_indexer_total_size = arg.in_indexer.total_size / out_total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
 
     int64_t reduce_offset = tid / out_block_size;
     int64_t out_offset = tid % out_block_size;
@@ -137,89 +296,14 @@ __global__ static void reduction_flat_kernel(cumo_na_reduction_arg_t arg, int ou
     int64_t out_stride = gridDim.x * out_block_size;
 
     for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
-        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
-        TypeReduce accum = impl.Identity(i_in);
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            impl.Reduce(impl.MapIn(in[i_in], i_in), accum);
-        }
+        TypeReduce accum = reduce_axis<FLAT,true,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_out < out_total_size) {
-            out[i_out] = impl.MapOut(accum);
-        }
-    }
-}
-
-// Variant of reduction_kernel for arg-reductions (argmax/argmin).
-//
-// Unlike reduction_kernel, which passes the flat 1-d index of an input element
-// (i.e. index of input elements, same as (min|max)_index), this passes the
-// index along the reduction axis (i_reduce) to the reduction impl. This matches
-// the spec of arg(min|max) which returns indices along the axis.
-template <typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, int out_block_size, int reduce_block_size, ReductionImpl impl) {
-    cumo_na_iarray_t& in_iarray = arg.in;
-    cumo_na_iarray_t& out_iarray = arg.out;
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
-    using TypeReduce = decltype(impl.Identity(0));
-
-    extern __shared__ __align__(8) char sdata_raw[];
-    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
-    unsigned int tid = threadIdx.x;
-
-    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
-    int64_t reduce_offset = tid / out_block_size; // # of cols == # of elems
-
-    int64_t out_offset = tid % out_block_size; // # of rows
-    int64_t out_base = blockIdx.x * out_block_size; // # of rows
-    int64_t out_stride = gridDim.x * out_block_size; // # of rows
-
-    for (int64_t i_out = out_base + out_offset; i_out < out_indexer.total_size; i_out += out_stride) {
-        cumo_na_indexer_set_dim(&out_indexer, i_out);
-        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
-
-        // Note that arg(min|max) returns the index along the reduction axis.
-        TypeReduce accum = impl.Identity(reduce_offset);
-
-        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            cumo_na_indexer_set_dim(&in_indexer, i_in);
-            TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-            impl.Reduce(impl.MapIn(*in_ptr, i_reduce), accum);
-        }
-
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            // NOTE: Compiler optimizes to unroll this loop
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_out < out_indexer.total_size) {
-            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out_iarray, &out_indexer));
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(arg.out.ptr + reduce_out_offset<FLAT>(arg, ad, i_out));
             *out_ptr = impl.MapOut(accum);
         }
     }
@@ -228,58 +312,73 @@ __global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, int out
 // Variant of reduction_kernel writing two results per output element, so that
 // minmax reads the input once instead of reducing it twice. The impl stores
 // through the pointers rather than returning, since there are two of them.
-template <typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2_iarray, int out_block_size, int reduce_block_size, ReductionImpl impl) {
-    cumo_na_iarray_t& in_iarray = arg.in;
-    cumo_na_iarray_t& out_iarray = arg.out;
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
+template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2_iarray, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
     unsigned int tid = threadIdx.x;
 
-    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
-    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
 
+    int64_t reduce_offset = tid / out_block_size;
     int64_t out_offset = tid % out_block_size;
     int64_t out_base = blockIdx.x * out_block_size;
     int64_t out_stride = gridDim.x * out_block_size;
 
-    for (int64_t i_out = out_base + out_offset; i_out < out_indexer.total_size; i_out += out_stride) {
-        cumo_na_indexer_set_dim(&out_indexer, i_out);
-        int64_t i_in = i_out * reduce_indexer_total_size + reduce_offset;
+    for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-        cumo_na_indexer_set_dim(&in_indexer, i_in);
-        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
+        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
-        for (int64_t i_reduce = reduce_offset; i_reduce < reduce_indexer_total_size; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            cumo_na_indexer_set_dim(&in_indexer, i_in);
-            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-            impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
-        }
-
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_out < out_indexer.total_size) {
-            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out_iarray, &out_indexer));
-            TypeOut* out2_ptr = reinterpret_cast<TypeOut*>(cumo_na_iarray_at_dim(&out2_iarray, &out_indexer));
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(arg.out.ptr + reduce_out_offset<FLAT>(arg, ad, i_out));
+            TypeOut* out2_ptr = reinterpret_cast<TypeOut*>(out2_iarray.ptr + reduce_out2_offset<FLAT>(arg, out2_iarray, ad, i_out));
             impl.MapOut(accum, out_ptr, out2_ptr);
+        }
+    }
+}
+
+// First pass of a split reduction: each block takes one chunk of one output's
+// reduce axis and writes its accumulator to partial[i_out * n_split + i_split].
+// MapOut is deliberately not applied — the combine pass needs the accumulator.
+//
+// The scratch is laid out by output so the combine pass can read it flat, but
+// threads are handed out by output first, so a block still covers consecutive
+// outputs when those are the ones running along memory.
+template <bool FLAT, typename TypeIn, typename TypeReduce, typename ReductionImpl>
+__global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+    int64_t partial_total_size = out_total_size * n_split;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i = out_base + out_offset; i < partial_total_size; i += out_stride) {
+        int64_t i_out = i % out_total_size;
+        int64_t i_split = i / out_total_size;
+        int64_t begin = i_split * chunk;
+        int64_t end = begin + chunk;
+        if (end > reduce_total_size) end = reduce_total_size;
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        int64_t i_in = i_out * reduce_total_size + begin + reduce_offset;
+
+        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, begin, end, reduce_offset, reduce_block_size);
+
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            partial[i_out * n_split + i_split] = accum;
         }
     }
 }
@@ -291,114 +390,6 @@ static inline int64_t reduce_split_count(int64_t reduce_total_size, int64_t out_
     int64_t fits = reduce_total_size / min_split_chunk;
     int64_t n = std::min(std::min(want, fits), max_split);
     return n < 2 ? 1 : n;
-}
-
-// First pass of a split reduction: each block takes one chunk of one output's
-// reduce axis and writes its accumulator to partial[i_out * n_split + i_split].
-// MapOut is deliberately not applied — the combine pass needs the accumulator.
-template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
-__global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
-    cumo_na_iarray_t& in_iarray = arg.in;
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
-    extern __shared__ __align__(8) char sdata_raw[];
-    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
-    unsigned int tid = threadIdx.x;
-
-    int64_t reduce_indexer_total_size = in_indexer.total_size / out_indexer.total_size;
-    int64_t partial_total_size = out_indexer.total_size * n_split;
-    int64_t reduce_offset = tid / out_block_size;
-
-    int64_t out_offset = tid % out_block_size;
-    int64_t out_base = blockIdx.x * out_block_size;
-    int64_t out_stride = gridDim.x * out_block_size;
-
-    for (int64_t i_partial = out_base + out_offset; i_partial < partial_total_size; i_partial += out_stride) {
-        int64_t i_out = i_partial / n_split;
-        int64_t begin = (i_partial % n_split) * chunk;
-        int64_t end = begin + chunk;
-        if (end > reduce_indexer_total_size) end = reduce_indexer_total_size;
-        int64_t i_in = i_out * reduce_indexer_total_size + begin + reduce_offset;
-
-        cumo_na_indexer_set_dim(&in_indexer, i_in);
-        TypeIn* in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-        TypeReduce accum = impl.Identity(in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr));
-
-        for (int64_t i_reduce = begin + reduce_offset; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            cumo_na_indexer_set_dim(&in_indexer, i_in);
-            in_ptr = reinterpret_cast<TypeIn*>(cumo_na_iarray_at_dim(&in_iarray, &in_indexer));
-            impl.Reduce(impl.MapIn(*in_ptr, in_ptr - reinterpret_cast<TypeIn*>(in_iarray.ptr)), accum);
-        }
-
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_partial < partial_total_size) {
-            partial[i_partial] = accum;
-        }
-    }
-}
-
-// reduction_partial_kernel without the indexer, for the same reason.
-template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
-__global__ static void reduction_partial_flat_kernel(cumo_na_reduction_arg_t arg, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
-    extern __shared__ __align__(8) char sdata_raw[];
-    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
-    unsigned int tid = threadIdx.x;
-
-    TypeIn* in = reinterpret_cast<TypeIn*>(arg.in.ptr);
-    int64_t out_total_size = arg.out_indexer.total_size;
-    int64_t reduce_indexer_total_size = arg.in_indexer.total_size / out_total_size;
-    int64_t partial_total_size = out_total_size * n_split;
-
-    int64_t reduce_offset = tid / out_block_size;
-    int64_t out_offset = tid % out_block_size;
-    int64_t out_base = blockIdx.x * out_block_size;
-    int64_t out_stride = gridDim.x * out_block_size;
-
-    for (int64_t i_partial = out_base + out_offset; i_partial < partial_total_size; i_partial += out_stride) {
-        int64_t i_out = i_partial / n_split;
-        int64_t begin = (i_partial % n_split) * chunk;
-        int64_t end = begin + chunk;
-        if (end > reduce_indexer_total_size) end = reduce_indexer_total_size;
-        int64_t i_in = i_out * reduce_indexer_total_size + begin + reduce_offset;
-
-        TypeReduce accum = impl.Identity(i_in);
-
-        for (int64_t i_reduce = begin + reduce_offset; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
-            impl.Reduce(impl.MapIn(in[i_in], i_in), accum);
-        }
-
-        if (out_block_size <= max_block_size / 2) {
-            sdata[tid] = accum;
-            __syncthreads();
-            for (int stride = max_block_size / 2; stride > 0; stride >>= 1) {
-                if (out_block_size <= stride) {
-                    if (tid < stride) {
-                        impl.Reduce(sdata[tid + stride], sdata[tid]);
-                    }
-                    __syncthreads();
-                }
-            }
-            accum = sdata[tid];
-            __syncthreads();
-        }
-        if (reduce_offset == 0 && i_partial < partial_total_size) {
-            partial[i_partial] = accum;
-        }
-    }
 }
 
 // Second pass of a split reduction. The input is already accumulators, so
@@ -420,22 +411,21 @@ struct reduce_combine {
 // the partials so the caller can combine them with its own second pass. The
 // caller frees the returned buffer.
 template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
-TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, int64_t n_split, int64_t reduce_total_size, cumo_na_reduction_arg_t* arg2, ReductionImpl& impl) {
+TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int64_t n_split, int64_t reduce_total_size, cumo_na_reduction_arg_t* arg2, ReductionImpl& impl) {
     int64_t chunk = (reduce_total_size + n_split - 1) / n_split;
     int64_t partial_total_size = arg.out_indexer.total_size * n_split;
     TypeReduce* partial = reinterpret_cast<TypeReduce*>(cumo_cuda_runtime_malloc(sizeof(TypeReduce) * partial_total_size));
 
-    int64_t chunk_pow2 = round_up_to_power_of_2(std::max(int64_t{1}, chunk));
-    int64_t reduce_block_size = std::min(max_block_size, chunk_pow2);
-    int64_t out_block_size = max_block_size / reduce_block_size;
+    int64_t out_block_size, reduce_block_size;
+    reduce_block_split(ad, chunk, &out_block_size, &reduce_block_size);
     int64_t out_block_num = (partial_total_size + out_block_size - 1) / out_block_size;
     int64_t grid_size = std::min(max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(TypeReduce) * max_block_size;
 
-    if (iarray_is_flat<TypeIn>(arg.in, arg.in_indexer)) {
-        reduction_partial_flat_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    if (ad.in_out_flat && ad.in_reduce_flat) {
+        reduction_partial_kernel<true,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     } else {
-        reduction_partial_kernel<TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+        reduction_partial_kernel<false,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     }
     cumo_cuda_runtime_check_kernel_launch();
 
@@ -452,27 +442,25 @@ TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, int64_t n_split, in
 // TODO(sonots): Optimize indexer by squashing (or reducing) dimensions
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
-    if (out_indexer.total_size == 0) {
+    if (arg.out_indexer.total_size == 0) {
         return;
     }
 
-    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(size_t{1}, in_indexer.total_size / out_indexer.total_size));
-    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
-    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
-    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
 
     int64_t block_size = cumo_detail::max_block_size;
     int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
-    if (cumo_detail::iarray_is_flat<TypeIn>(arg.in, arg.in_indexer) &&
-        cumo_detail::iarray_is_flat<TypeOut>(arg.out, arg.out_indexer)) {
-        cumo_detail::reduction_flat_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    if (ad.in_out_flat && ad.in_reduce_flat && ad.out_flat) {
+        cumo_detail::reduction_kernel<true,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, ad, out_block_size, reduce_block_size, impl);
     } else {
-        cumo_detail::reduction_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+        cumo_detail::reduction_kernel<false,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, ad, out_block_size, reduce_block_size, impl);
     }
     cumo_cuda_runtime_check_kernel_launch();
 }
@@ -485,18 +473,17 @@ void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     using TypeReduce = decltype(impl.Identity(0));
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
 
-    if (out_indexer.total_size == 0) {
+    if (arg.out_indexer.total_size == 0) {
         return;
     }
 
-    int64_t reduce_total_size = in_indexer.total_size / out_indexer.total_size;
-    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(int64_t{1}, reduce_total_size));
-    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
-    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
-    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
 
     int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
     if (n_split < 2) {
@@ -505,7 +492,7 @@ void cumo_reduce_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     }
 
     cumo_na_reduction_arg_t arg2 = arg;
-    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, n_split, reduce_total_size, &arg2, impl);
+    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, ad, n_split, reduce_total_size, &arg2, impl);
     cumo_reduce<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, cumo_detail::reduce_combine<ReductionImpl>{impl});
     cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }
@@ -515,23 +502,27 @@ void cumo_reduce_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
 // arg.out, since the one out_indexer addresses both.
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce_pair(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, ReductionImpl&& impl) {
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
-    if (out_indexer.total_size == 0) {
+    if (arg.out_indexer.total_size == 0) {
         return;
     }
 
-    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(size_t{1}, in_indexer.total_size / out_indexer.total_size));
-    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
-    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
-    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+    cumo_detail::set_reduce_addr_out2(&ad, arg, out2);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
 
     int64_t block_size = cumo_detail::max_block_size;
     int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
-    cumo_detail::reduction_pair_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out2, out_block_size, reduce_block_size, impl);
+    if (ad.in_out_flat && ad.in_reduce_flat && ad.out_flat && ad.out2_flat) {
+        cumo_detail::reduction_pair_kernel<true,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out2, ad, out_block_size, reduce_block_size, impl);
+    } else {
+        cumo_detail::reduction_pair_kernel<false,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out2, ad, out_block_size, reduce_block_size, impl);
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 
@@ -539,18 +530,17 @@ void cumo_reduce_pair(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, Reduct
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce_pair_split(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, ReductionImpl&& impl) {
     using TypeReduce = decltype(impl.Identity(0));
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
 
-    if (out_indexer.total_size == 0) {
+    if (arg.out_indexer.total_size == 0) {
         return;
     }
 
-    int64_t reduce_total_size = in_indexer.total_size / out_indexer.total_size;
-    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(int64_t{1}, reduce_total_size));
-    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
-    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
-    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
 
     int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
     if (n_split < 2) {
@@ -559,7 +549,7 @@ void cumo_reduce_pair_split(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, 
     }
 
     cumo_na_reduction_arg_t arg2 = arg;
-    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, n_split, reduce_total_size, &arg2, impl);
+    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, ad, n_split, reduce_total_size, &arg2, impl);
     cumo_reduce_pair<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, out2, cumo_detail::reduce_combine<ReductionImpl>{impl});
     cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }
@@ -568,23 +558,26 @@ void cumo_reduce_pair_split(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2, 
 // indices along the reduction axis. See reduction_arg_kernel above.
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce_arg(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
-    cumo_na_indexer_t& in_indexer = arg.in_indexer;
-    cumo_na_indexer_t& out_indexer = arg.out_indexer;
-
-    if (out_indexer.total_size == 0) {
+    if (arg.out_indexer.total_size == 0) {
         return;
     }
 
-    int64_t reduce_total_size_pow2 = cumo_detail::round_up_to_power_of_2(std::max(size_t{1}, in_indexer.total_size / out_indexer.total_size));
-    int64_t reduce_block_size = std::min(cumo_detail::max_block_size, reduce_total_size_pow2);
-    int64_t out_block_size = cumo_detail::max_block_size / reduce_block_size;
-    int64_t out_block_num = (out_indexer.total_size + out_block_size - 1) / out_block_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
 
     int64_t block_size = cumo_detail::max_block_size;
     int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
     int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
 
-    cumo_detail::reduction_arg_kernel<TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, out_block_size, reduce_block_size, impl);
+    if (ad.in_out_flat && ad.in_reduce_flat && ad.out_flat) {
+        cumo_detail::reduction_arg_kernel<true,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, ad, out_block_size, reduce_block_size, impl);
+    } else {
+        cumo_detail::reduction_arg_kernel<false,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, ad, out_block_size, reduce_block_size, impl);
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3241,12 +3241,76 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(ZeroDivisionError) { ints[true, 1..-2].divmod(0) }
   end
 
-  # Combines two nested Bit arrays element by element, whatever their depth
-  def zip_bits(a, b, &blk)
+  # Combines two nested arrays element by element, whatever their depth
+  def zip_deep(a, b, &blk)
     if a.first.is_a?(Array)
-      a.zip(b).map { |x, y| zip_bits(x, y, &blk) }
+      a.zip(b).map { |x, y| zip_deep(x, y, &blk) }
     else
       a.zip(b).map { |x, y| blk.call(x, y) }
+    end
+  end
+
+  def map_deep(x, &blk)
+    x.is_a?(Array) ? x.map { |y| map_deep(y, &blk) } : blk.call(x)
+  end
+
+  # Folds a nested array along one axis, so that a reduction can be checked
+  # without asking another kernel for the answer
+  def fold_axis(nested, axis, &blk)
+    return nested.map { |sub| fold_axis(sub, axis - 1, &blk) } if axis.positive?
+    nested.reduce { |a, b| a.is_a?(Array) ? zip_deep(a, b, &blk) : blk.call(a, b) }
+  end
+
+  def fold_axes(nested, axes, &blk)
+    Array(axes).sort.reverse.inject(nested) { |acc, axis| fold_axis(acc, axis, &blk) }
+  end
+
+  # The same nesting with each leaf replaced by its place in the flattened
+  # array, which is the index max_index and min_index answer with
+  def deep_positions(nested, counter = [0])
+    nested.map { |x| x.is_a?(Array) ? deep_positions(x, counter) : (counter[0] += 1) - 1 }
+  end
+
+  def flat_list(x)
+    x.is_a?(Array) ? x.flatten : [x]
+  end
+
+  def assert_reductions(view, what, axes: nil)
+    nested = view.to_a
+    flat = nested.flatten
+    shape = view.shape
+    strides = shape.each_index.map { |i| shape[(i + 1)..].inject(1, :*) }
+    positions = deep_positions(nested)
+    axes ||= (0...view.ndim).map { |i| [i] } + [(0...view.ndim).to_a]
+
+    axes.each do |ax|
+      tag = "#{what} axis #{ax.inspect}"
+      lo = fold_axes(nested, ax) { |x, y| x < y ? x : y }
+      hi = fold_axes(nested, ax) { |x, y| x < y ? y : x }
+      ptp = lo.is_a?(Array) ? zip_deep(hi, lo) { |x, y| x - y } : hi - lo
+
+      assert_equal(flat_list(fold_axes(nested, ax) { |x, y| x + y }),
+                   view.sum(axis: ax).to_a.flatten, "sum of #{tag}")
+      assert_equal(flat_list(lo), view.min(axis: ax).to_a.flatten, "min of #{tag}")
+      assert_equal(flat_list(hi), view.max(axis: ax).to_a.flatten, "max of #{tag}")
+      assert_equal(flat_list(ptp), view.ptp(axis: ax).to_a.flatten, "ptp of #{tag}")
+
+      got_lo, got_hi = view.minmax(axis: ax)
+      assert_equal(flat_list(lo), got_lo.to_a.flatten, "minmax low of #{tag}")
+      assert_equal(flat_list(hi), got_hi.to_a.flatten, "minmax high of #{tag}")
+
+      at_hi = fold_axes(positions, ax) { |p, q| flat[p] < flat[q] ? q : p }
+      at_lo = fold_axes(positions, ax) { |p, q| flat[q] < flat[p] ? q : p }
+      assert_equal(flat_list(at_hi), view.max_index(axis: ax).to_a.flatten, "max_index of #{tag}")
+      assert_equal(flat_list(at_lo), view.min_index(axis: ax).to_a.flatten, "min_index of #{tag}")
+
+      next unless ax.size == 1
+
+      along = ->(p) { (p / strides[ax.first]) % shape[ax.first] }
+      assert_equal(flat_list(map_deep(at_hi, &along)),
+                   view.argmax(axis: ax.first).to_a.flatten, "argmax of #{tag}")
+      assert_equal(flat_list(map_deep(at_lo, &along)),
+                   view.argmin(axis: ax.first).to_a.flatten, "argmin of #{tag}")
     end
   end
 
@@ -3292,10 +3356,10 @@ class NArrayTest < Test::Unit::TestCase
       # wrong way would agree with an operator taken the wrong way
       w1 = p1.to_a
       w2 = p2.to_a
-      assert_equal(zip_bits(w1, w2) { |u, v| u & v }, (p1 & p2).to_a, "and of #{what}")
-      assert_equal(zip_bits(w1, w2) { |u, v| u | v }, (p1 | p2).to_a, "or of #{what}")
-      assert_equal(zip_bits(w1, w2) { |u, v| u ^ v }, (p1 ^ p2).to_a, "xor of #{what}")
-      assert_equal(zip_bits(w1, w1) { |u, _| u ^ 1 }, (~p1).to_a, "not of #{what}")
+      assert_equal(zip_deep(w1, w2) { |u, v| u & v }, (p1 & p2).to_a, "and of #{what}")
+      assert_equal(zip_deep(w1, w2) { |u, v| u | v }, (p1 | p2).to_a, "or of #{what}")
+      assert_equal(zip_deep(w1, w2) { |u, v| u ^ v }, (p1 ^ p2).to_a, "xor of #{what}")
+      assert_equal(zip_deep(w1, w1) { |u, _| u ^ 1 }, (~p1).to_a, "not of #{what}")
       assert_equal(w1.flatten.count(1), p1.count_true, "count_true of #{what}")
       assert_equal(w1, f1.to_a, "copy of #{what}")
 
@@ -3354,6 +3418,42 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(a.transpose.copy.gt(0).to_a.flatten, a.transpose.gt(0).to_a.flatten)
     bd = Cumo::Int32.cast(Array.new(n) { |i| i % 3 }).reshape(*deep).gt(1)
     assert_equal(bd.transpose.to_a.flatten.map { |u| u ^ 1 }, (~bd.transpose).to_a.flatten)
+  end
+
+  test "reductions reach every element of an axis that is not the innermost" do
+    # Reducing over anything but the last axis went through the indexer and put
+    # every thread of a block on a different row of the input. The expectations
+    # are folded in Ruby rather than read off a contiguous copy, so a wrong
+    # address cannot cancel out between the two sides.
+    rows = 9
+    cols = 7
+    xs = (1..(rows * cols)).to_a.shuffle(random: Random.new(4649))
+    src = Cumo::Int32.cast(xs).reshape(rows, cols)
+    idx = [5, 0, 3, 8, 1]
+
+    views = {
+      "contiguous" => ->(a) { a },
+      "column slice" => ->(a) { a[true, 1...(cols - 1)] },
+      "reversed" => ->(a) { a[true, (cols - 1).step(0, -1)] },
+      "row stride" => ->(a) { a[0.step(rows - 1, 2), true] },
+      "index view" => ->(a) { a[idx, true] },
+      "transpose" => ->(a) { a.transpose },
+    }
+    views.each { |what, take| assert_reductions(take.call(src), what) }
+
+    # a 5-d shape runs past the dimension-specialised accessors
+    deep = [2, 3, 2, 2, 3]
+    n = deep.inject(:*)
+    a = Cumo::Int32.cast((1..n).to_a.shuffle(random: Random.new(57))).reshape(*deep)
+    assert_reductions(a, "5-d")
+    assert_reductions(a.transpose, "5-d transpose")
+    assert_reductions(a[true, [2, 0], true, true, true], "5-d index view")
+
+    # long enough for the reduce axis to be split across a second launch
+    big = Cumo::Int32.new(3000, 33).seq
+    assert_reductions(big, "3000x33", axes: [[0], [1]])
+    assert_reductions(big[true, 0.step(32, 2)], "3000x33 column slice", axes: [[0], [1]])
+    assert_reductions(big.transpose, "3000x33 transpose", axes: [[0], [1]])
   end
 
   test "copy of an RObject view stays on the host" do


### PR DESCRIPTION

ndloop transposes a reduction's axes so the reduce ones come last, which leaves the input non-contiguous for anything but a last-axis reduction. Every element then went through `cumo_na_indexer_set_dim` and `cumo_na_iarray_at_dim`, and because those write into the indexer — 216 bytes of `shape[]` and `index[]` — the kernel's copy cannot stay in registers and each element pays a local memory round trip. On top of that the block handed every one of its 512 threads a different row, so the reads did not coalesce.

- Work the addressing out on the host into `cumo_reduce_addr_t`: a group of axes whose i-th offset is `i * step` collapses to one stride, and the rest is read straight from the kernel parameter without ever writing back.
- Template the kernels on whether both groups came out flat, so the common shapes carry no index decomposition at all.
- Pick the block's out/reduce thread split from the steps, so a reduction along axis 0 gives a warp consecutive outputs instead of consecutive rows.
- Hand out a split reduction's scratch by output first, so the extra pass stays coalesced as well; `reduction_flat_kernel` and `reduction_partial_flat_kernel` fold into the templated forms.
- `argmax`/`argmin` had no contiguous path at all before this and now share one.

## Measured

RTX 5070 Ti Laptop, CUDA 13.0, best of 25 in its own process.

| | master | this PR |
| --- | ---: | ---: |
| `SFloat.new(2048, 2048).sum(axis: 0)` | 2.014 ms | 0.017 ms |
| `DFloat.new(2048, 2048).sum(axis: 0)` | 2.164 ms | 0.032 ms |
| `Int32.new(2048, 2048).sum(axis: 0)` | 2.004 ms | 0.018 ms |
| `minmax(axis: 0)` | 2.368 ms | 0.018 ms |
| `argmax(axis: 1)` | 2.063 ms | 0.033 ms |
| `SFloat.new(64, 2048, 32).sum(axis: [0, 2])` | 1.817 ms | 0.082 ms |
| row-strided view, `sum(axis: 0)` | 3.673 ms | 0.252 ms |
| column-strided view, `sum(axis: 0)` | 2.580 ms | 0.290 ms |
| `sum(axis: 1)` (already contiguous) | 0.029 ms | 0.030 ms |

## Checked

`rake test` passes (1506 tests, 20372 assertions). Every reduction of ten view shapes across seven dtypes was compared against Numo: the set of differences is byte-identical to master's, and all of them are float reassociation in `prod` and in a 4M-element `SFloat` `sum`, where the tree reduction is the more accurate of the two.

The new test folds its expectations in Ruby rather than reading them off a contiguous copy, so a wrong address cannot cancel out between the two sides. Seven deliberate breaks of the addressing — a wrong flat stride, calling every group flat, dropping a dimension from the offset, ignoring the output offset, storing the scratch in the wrong order, ignoring the block width while walking, and swapping the two strides — are each caught by it.
