### PR TITLE
Run the stores between Bit and another dtype on the GPU

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -141,6 +141,21 @@ cumo_na_make_iarray(cumo_na_loop_args_t* arg)
     return cumo_na_make_iarray_given_ndim(arg, arg->ndim);
 }
 
+static cumo_na_iarray_stridx_t
+cumo_na_make_iarray_stridx(cumo_na_loop_args_t* arg)
+{
+    cumo_na_iarray_stridx_t iarray;
+    iarray.ptr = arg->ptr + arg->iter[0].pos;
+    for (int idim = 0; idim < arg->ndim; ++idim) {
+        if (arg->iter[idim].idx) {
+            CUMO_SDX_SET_INDEX(iarray.stridx[idim], arg->iter[idim].idx);
+        } else {
+            CUMO_SDX_SET_STRIDE(iarray.stridx[idim], arg->iter[idim].step);
+        }
+    }
+    return iarray;
+}
+
 static cumo_na_bit_iarray_stridx_t
 cumo_na_make_bit_iarray_stridx(cumo_na_loop_args_t* arg)
 {

--- a/ext/cumo/narray/gen/tmpl/store_bit.c
+++ b/ext/cumo/narray/gen/tmpl/store_bit.c
@@ -1,13 +1,11 @@
 //<% unless c_iter.include? 'robject' %>
-void <%="cumo_#{c_iter}_index_index_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, size_t *idx1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, ssize_t s1, size_t *idx2, uint64_t n);
-void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, size_t *idx1, ssize_t s2, uint64_t n);
-void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(char *p1, size_t p2, CUMO_BIT_DIGIT *a2, ssize_t s1, ssize_t s2, uint64_t n);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a2, cumo_na_indexer_t* indexer);
 //<% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    //<% if c_iter.include? 'robject' %>
     size_t     i;
     char      *p1;
     size_t     p2;
@@ -18,8 +16,6 @@ static void
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_BIT_IDX(lp, 1, a2, p2, s2, idx2);
-
-    //<% if c_iter.include? 'robject' %>
     {
         CUMO_BIT_DIGIT x;
         dtype y;
@@ -57,19 +53,11 @@ static void
     }
     //<% else %>
     {
-        if (idx2) {
-            if (idx1) {
-                <%="cumo_#{c_iter}_index_index_kernel_launch"%>(p1,p2,a2,idx1,idx2,i);
-            } else {
-                <%="cumo_#{c_iter}_stride_index_kernel_launch"%>(p1,p2,a2,s1,idx2,i);
-            }
-        } else {
-            if (idx1) {
-                <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,a2,idx1,s2,i);
-            } else {
-                <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(p1,p2,a2,s1,s2,i);
-            }
-        }
+        cumo_na_iarray_stridx_t a1 = cumo_na_make_iarray_stridx(&lp->args[0]);
+        cumo_na_bit_iarray_stridx_t a2 = cumo_na_make_bit_iarray_stridx(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
     }
     //<% end %>
 }
@@ -79,7 +67,14 @@ static VALUE
 <%=c_func(:nodef)%>(VALUE self, VALUE obj)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{Qnil,0}};
+    //<% if c_iter.include? 'robject' %>
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 2,0, ain,0};
+    <% else %>
+    // Without INDEXER_LOOP ndloop walks the outer dimensions itself and the
+    // kernel runs once per row. INDEX_LOOP has to stay on: ndloop cannot stage
+    // the Bit operand into a buffer, since a buffer copy moves whole bytes.
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2,0, ain,0};
+    <% end %>
 
     cumo_na_ndloop(&ndf, 2, self, obj);
     return self;

--- a/ext/cumo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array.c
@@ -24,8 +24,19 @@ static void
 
     if (lp->args[1].ptr) {
         if (v1 == Qtrue) {
-            iter_<%=type_name%>_store_<%=type_name%>(lp);
+            // The loop counter is the destination length, but the sub-narray
+            // may be shorter. Copy only what the source actually holds, or the
+            // kernel would read past its end; the rest is zero-filled below.
             i = lp->args[1].shape[0];
+            if (i > n) {
+                i = n;
+            }
+            CUMO_NDL_CNT(lp) = i;
+            iter_<%=type_name%>_store_<%=type_name%>(lp);
+            CUMO_NDL_CNT(lp) = n;
+            // The tail below writes the rest from the host, and the word at the
+            // boundary is shared with the elements the kernel just stored.
+            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
             if (idx1) {
                 idx1 += i;
             } else {

--- a/ext/cumo/narray/gen/tmpl_bit/store_bit.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_bit.c
@@ -1,80 +1,30 @@
-#include <stdio.h>
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n);
+
+static int
+<%=c_iter%>_is_flat(cumo_na_bit_iarray_stridx_t* a, cumo_na_indexer_t* indexer)
+{
+    return indexer->ndim == 1 &&
+        CUMO_SDX_IS_STRIDE(a->stridx[0]) && CUMO_SDX_GET_STRIDE(a->stridx[0]) == 1;
+}
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    ssize_t p1, p3;
-    ssize_t s1, s3;
-    size_t *idx1, *idx3;
-    int     o1, l1, r1, len;
-    CUMO_BIT_DIGIT *a1, *a3;
-    CUMO_BIT_DIGIT  x;
+    cumo_na_bit_iarray_stridx_t a3 = cumo_na_make_bit_iarray_stridx(&lp->args[0]);
+    cumo_na_bit_iarray_stridx_t a1 = cumo_na_make_bit_iarray_stridx(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR_BIT_IDX(lp, 0, a3, p3, s3, idx3);
-    CUMO_INIT_PTR_BIT_IDX(lp, 1, a1, p1, s1, idx1);
-    if (s1!=1 || s3!=1 || idx1 || idx3) {
-        for (; n--;) {
-            CUMO_LOAD_BIT_STEP(a1, p1, s1, idx1, x);
-            CUMO_STORE_BIT_STEP(a3, p3, s3, idx3, x);
-        }
+    // A word at a time is worth a separate kernel, but it needs both operands
+    // laid out end to end, which after the loop is contracted means one
+    // dimension of step one.
+    if (<%=c_iter%>_is_flat(&a1,&indexer) && <%=c_iter%>_is_flat(&a3,&indexer)) {
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(
+            a1.ptr + a1.pos / CUMO_NB, a1.pos % CUMO_NB,
+            a3.ptr + a3.pos / CUMO_NB, a3.pos % CUMO_NB,
+            indexer.total_size);
     } else {
-        a1 += p1/CUMO_NB;
-        p1 %= CUMO_NB;
-        a3 += p3/CUMO_NB;
-        p3 %= CUMO_NB;
-        o1 =  p1-p3;
-        l1 =  CUMO_NB+o1;
-        r1 =  CUMO_NB-o1;
-        if (p3>0 || n<CUMO_NB) {
-            len = CUMO_NB - p3;
-            if ((int)n<len) len=n;
-            if (o1>=0) x = *a1>>o1;
-            else       x = *a1<<-o1;
-            if (p1+len>(ssize_t)CUMO_NB)  x |= *(a1+1)<<r1;
-            a1++;
-            *a3 = (x & (CUMO_SLB(len)<<p3)) | (*a3 & ~(CUMO_SLB(len)<<p3));
-            a3++;
-            n -= len;
-        }
-        if (o1==0) {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                x = *(a1++);
-                *(a3++) = x;
-            }
-        } else {
-            for (; n>=CUMO_NB; n-=CUMO_NB) {
-                if (o1==0) {
-                    x = *a1;
-                } else if (o1>0) {
-                    x = *a1>>o1  | *(a1+1)<<r1;
-                } else {
-                    x = *a1<<-o1 | *(a1-1)>>l1;
-                }
-                a1++;
-                *(a3++) = x;
-            }
-        }
-        if (n>0) {
-            if (o1==0) {
-                x = *a1;
-            } else if (o1>0) {
-                x = *a1>>o1;
-                if ((int)n>r1) {
-                    x |= *(a1+1)<<r1;
-                }
-            } else {
-                x = *(a1-1)>>l1;
-                if ((int)n>-o1) {
-                    x |= *a1<<-o1;
-                }
-            }
-            *a3 = (x & CUMO_SLB(n)) | (*a3 & CUMO_BALL<<n);
-        }
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a3,&indexer);
     }
 }
 
@@ -82,7 +32,10 @@ static VALUE
 <%=c_func(:nodef)%>(VALUE self, VALUE obj)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{Qnil,0}};
-    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 2,0, ain,0};
+    // ndloop cannot stage a Bit operand into a buffer — a buffer copy moves
+    // whole bytes — so INDEX_LOOP stays on and the kernel walks both operands'
+    // own indices.
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2,0, ain,0};
 
     cumo_na_ndloop(&ndf, 2, self, obj);
     return self;

--- a/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
@@ -1,0 +1,47 @@
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        CUMO_BIT_DIGIT x;
+        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
+        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), x);
+    }
+}
+<% end %>
+
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_gather_word(a1,o1,w1,w);
+        cumo_bit_store_word(a3, w, x, p3, n);
+    }
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n)
+{
+    ssize_t o1 = (ssize_t)p1 - (ssize_t)p3;
+    uint64_t w1 = (p1 + n + CUMO_NB - 1) / CUMO_NB;
+    uint64_t w3 = (p3 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w3);
+    size_t block_dim = cumo_get_block_dim(w3);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(a1,o1,w1,a3,p3,n,w3);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/ext/cumo/narray/gen/tmpl_bit/store_from.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_from.c
@@ -1,6 +1,11 @@
+//<% unless c_iter.include? 'robject' %>
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_iarray_stridx_t* a2, cumo_na_indexer_t* indexer);
+//<% end %>
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
+    //<% if c_iter.include? 'robject' %>
     ssize_t  i, s1, s2;
     size_t   p1;
     char    *p2;
@@ -9,7 +14,6 @@ static void
     CUMO_BIT_DIGIT *a1;
     CUMO_BIT_DIGIT  y;
 
-    // TODO(sonots): CUDA kernelize
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("store_<%=name%>", "<%=type_name%>");
     cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
@@ -46,6 +50,15 @@ static void
             }
         }
     }
+    //<% else %>
+    {
+        cumo_na_bit_iarray_stridx_t a1 = cumo_na_make_bit_iarray_stridx(&lp->args[0]);
+        cumo_na_iarray_stridx_t a2 = cumo_na_make_iarray_stridx(&lp->args[1]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
+    }
+    //<% end %>
 }
 
 
@@ -53,7 +66,14 @@ static VALUE
 <%=c_func(:nodef)%>(VALUE self, VALUE obj)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{Qnil,0}};
+    //<% if c_iter.include? 'robject' %>
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 2,0, ain,0};
+    <% else %>
+    // The Bit side cannot be staged into a buffer by ndloop — a buffer copy
+    // moves whole bytes — so INDEX_LOOP stays on and the kernel walks both
+    // operands' own indices.
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2,0, ain,0};
+    <% end %>
 
     cumo_na_ndloop(&ndf, 2, self, obj);
     return self;

--- a/ext/cumo/narray/gen/tmpl_bit/store_from_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_from_kernel.cu
@@ -1,18 +1,17 @@
 <% unless c_iter.include? 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a2, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_iarray_stridx_t a2, cumo_na_indexer_t indexer)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        CUMO_BIT_DIGIT x;
-        CUMO_LOAD_BIT(a2.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a2, &indexer), x);
-        char* p1 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a1, &indexer);
-        *(dtype*)(p1) = m_from_real(x);
+        char* p2 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a2, &indexer);
+        CUMO_BIT_DIGIT y = <%=macro%>(*(<%=dtype%>*)(p2));
+        CUMO_STORE_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), y);
     }
 }
 <% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a2, cumo_na_indexer_t* indexer)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_iarray_stridx_t* a2, cumo_na_indexer_t* indexer)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1524,9 +1524,6 @@ cumo_na_to_binary(VALUE self)
     cumo_narray_t *na;
     int offset_in_bits;
 
-    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_to_binary", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
     CumoGetNArray(self,na);
     if (na->type == CUMO_NARRAY_VIEW_T) {
         // Cumo::Bit measures the offset in bits, so it cannot be added to a
@@ -1539,6 +1536,12 @@ cumo_na_to_binary(VALUE self)
         }
     }
     len = NUM2SIZET(cumo_na_byte_size(self));
+
+    // After the dup above, not before it: the copy is a kernel and the string
+    // is built by reading its result from the host.
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_to_binary", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+
     ptr = cumo_na_get_pointer_for_read(self);
     str = rb_usascii_str_new(ptr+offset,len);
     RB_GC_GUARD(self);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3420,6 +3420,118 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(bd.transpose.to_a.flatten.map { |u| u ^ 1 }, (~bd.transpose).to_a.flatten)
   end
 
+  test "stores between Bit and another dtype reach every element of a view" do
+    # A Bit element is one bit, so the byte iarray cannot address it and ndloop
+    # cannot stage it into a buffer either. Both directions ran once per row of
+    # a view, and the Bit destination ran on the host. Expectations are built in
+    # Ruby, not read off a contiguous copy, which shares the templates here.
+    rows = 9
+    cols = 7
+    n = rows * cols
+    xs = Array.new(n) { |i| ((i * 5) % 17) - 8 }
+    src = Cumo::Int32.cast(xs).reshape(rows, cols)
+    bits = src.gt(0)
+    idx = [5, 0, 3, 8, 1]
+
+    views = {
+      "contiguous" => ->(a) { a },
+      "column slice" => ->(a) { a[true, 1...(cols - 1)] },
+      "reversed" => ->(a) { a[true, (cols - 1).step(0, -1)] },
+      "row stride" => ->(a) { a[0.step(rows - 1, 2), true] },
+      "index view" => ->(a) { a[idx, true] },
+      "transpose" => ->(a) { a.transpose },
+    }
+
+    views.each do |what, take|
+      iv = take.call(src)
+      bv = take.call(bits)
+      want_bit = map_deep(iv.to_a) { |x| x.positive? ? 1 : 0 }
+      cells = take.call(Cumo::Int32.cast((0...n).to_a).reshape(rows, cols)).to_a.flatten
+
+      assert_equal(want_bit, bv.to_a, "bit view #{what}")
+
+      [Cumo::Int32, Cumo::DFloat].each do |k|
+        assert_equal(want_bit, k.cast(bv).to_a.then { |a| map_deep(a, &:to_i) }, "#{k}.cast of #{what}")
+        dst = k.zeros(*bv.shape)
+        dst.store(bv)
+        assert_equal(want_bit, map_deep(dst.to_a, &:to_i), "#{k}.store bit of #{what}")
+
+        whole = k.zeros(rows, cols)
+        take.call(whole).store(bv)
+        want = Array.new(n, 0)
+        cells.each_with_index { |cell, i| want[cell] = want_bit.flatten[i] }
+        assert_equal(want, map_deep(whole.to_a, &:to_i).flatten, "#{k} view <- bit of #{what}")
+      end
+
+      [iv, Cumo::DFloat.cast(iv)].each do |source|
+        dst = Cumo::Bit.new(*source.shape)
+        dst.store(source)
+        assert_equal(map_deep(source.to_a) { |x| x.zero? ? 0 : 1 }, dst.to_a,
+                     "bit.store #{source.class} of #{what}")
+
+        whole = Cumo::Bit.new(rows, cols).fill(1)
+        take.call(whole).store(source)
+        want = Array.new(n, 1)
+        flat = map_deep(source.to_a) { |x| x.zero? ? 0 : 1 }.flatten
+        cells.each_with_index { |cell, i| want[cell] = flat[i] }
+        assert_equal(want, whole.to_a.flatten, "bit view <- #{source.class} of #{what}")
+      end
+
+      dst = Cumo::Bit.new(*bv.shape)
+      dst.store(bv)
+      assert_equal(want_bit, dst.to_a, "bit.store bit of #{what}")
+
+      whole = Cumo::Bit.new(rows, cols).fill(0)
+      take.call(whole).store(bv)
+      want = Array.new(n, 0)
+      cells.each_with_index { |cell, i| want[cell] = want_bit.flatten[i] }
+      assert_equal(want, whole.to_a.flatten, "bit view <- bit of #{what}")
+    end
+
+    # a Bit view whose first element is not the first bit of its word
+    flat = Array.new(200) { |i| ((i * 7) % 3).zero? ? 1 : 0 }
+    long = Cumo::Bit.cast(flat)
+    [0, 1, 8, 31, 32, 33, 63, 64, 65, 100, 127, 128].each do |i|
+      v = long[i..(i + 20)]
+      want = flat[i, 21]
+      assert_equal(want, v.to_a, "offset #{i}")
+      assert_equal(want, Cumo::Int32.cast(v).to_a, "Int32.cast at offset #{i}")
+
+      d = Cumo::Bit.new(200).fill(0)
+      d[i..(i + 20)] = v
+      assert_equal(Array.new(200) { |k| (k >= i && k <= i + 20) ? flat[k] : 0 }, d.to_a,
+                   "bit aset at offset #{i}")
+
+      e = Cumo::Bit.new(200).fill(1)
+      e[i..(i + 20)] = Cumo::Int32.new(21).seq % 2
+      assert_equal(Array.new(200) { |k| (k >= i && k <= i + 20) ? (k - i) % 2 : 1 }, e.to_a,
+                   "int aset at offset #{i}")
+    end
+
+    # a 5-d shape runs past the dimension-specialised accessors
+    deep = [2, 2, 3, 2, 5]
+    m = deep.inject(:*)
+    a = Cumo::Int32.cast((0...m).to_a).reshape(*deep)
+    b = a.gt(m / 2).transpose
+    assert_equal(map_deep(a.transpose.to_a) { |x| x > (m / 2) ? 1 : 0 }, b.to_a, "5-d bit view")
+    assert_equal(b.to_a, map_deep(Cumo::Int32.cast(b).to_a, &:to_i), "5-d Int32.cast")
+    dst = Cumo::Bit.new(*b.shape)
+    dst.store(a.transpose)
+    assert_equal(map_deep(a.transpose.to_a) { |x| x.zero? ? 0 : 1 }, dst.to_a, "5-d bit.store int")
+    dst2 = Cumo::Bit.new(*b.shape)
+    dst2.store(b)
+    assert_equal(b.to_a, dst2.to_a, "5-d bit.store bit")
+
+    # a sub-array shorter than the row it is stored into is zero-filled, and the
+    # kernel must not read past its end
+    short = Cumo::Bit.new(3, 5).fill(1)
+    short.store([Cumo::Bit.cast([1, 0, 1]), Cumo::Bit.cast([0, 1]), Cumo::Bit.cast([1, 1, 0, 1, 0])])
+    assert_equal([[1, 0, 1, 0, 0], [0, 1, 0, 0, 0], [1, 1, 0, 1, 0]], short.to_a)
+    short2 = Cumo::Bit.new(3, 5).fill(1)
+    short2.store([Cumo::Int32.cast([1, 0, 5]), Cumo::Int32.cast([0, 2]), Cumo::Int32.cast([1, 1, 0, 3, 0])])
+    assert_equal([[1, 0, 1, 0, 0], [0, 1, 0, 0, 0], [1, 1, 0, 1, 0]], short2.to_a)
+  end
+
   test "reductions reach every element of an axis that is not the innermost" do
     # Reducing over anything but the last axis went through the indexer and put
     # every thread of a block on a different row of the input. The expectations


### PR DESCRIPTION

A `Cumo::Bit` element is one bit, so its position and steps are bit counts and `cumo_na_iarray_t` — a `char*` and byte steps — cannot address it. ndloop cannot stage a Bit operand into a buffer either, because a buffer copy moves whole bytes. Both stores that cross the Bit boundary were left behind by that: `Int32 <- Bit` had a kernel but ran it once per row of a non-contiguous view, and every store *into* a Bit array ran on the host behind a `cudaDeviceSynchronize`.

- Mix the bit indexer added in #252 with a byte one in the same kernel; `cumo_na_make_iarray_stridx` is the byte-side counterpart of `cumo_na_make_bit_iarray_stridx`.
- `Bit <- Bit` keeps its word-at-a-time path for contiguous operands and takes the bit indexer otherwise, the same shape `tmpl_bit/unary.c` already has.
- `to_binary` now synchronizes after the `dup` it may take rather than before it. The copy is a kernel now, and the string is built by reading its result from the host; without this a Bit view with a bit offset marshalled as zeroes.
- `tmpl_bit/store_array.c` clamps the loop counter to the sub-narray's length before handing it to the nested store, as `tmpl/store_array.c` already does, and waits for it before writing the tail — the host tail and the kernel share the word at the boundary, and the host's read-modify-write is not atomic against the kernel's.

## Measured

RTX 5070 Ti Laptop, CUDA 13.0, 2048x512 operands, best of 20 in its own process.

| | master | this PR |
| --- | ---: | ---: |
| `Int32 <- Bit`, column slice | 3.395 ms | 0.018 ms |
| `Int32.cast(bit view)` | 3.393 ms | 0.019 ms |
| `DFloat <- Bit`, column slice | 3.291 ms | 0.018 ms |
| `Bit <- Int32`, column slice | 1.451 ms | 0.048 ms |
| `Bit <- DFloat`, column slice | 1.405 ms | 0.048 ms |
| `Bit <- Int32`, contiguous | 1.102 ms | 0.057 ms |
| `Bit <- Bit`, column slice | 0.294 ms | 0.049 ms |
| `Bit <- Bit`, index view | 0.466 ms | 0.051 ms |
| `Int32 <- Bit`, contiguous | 0.010 ms | 0.011 ms |

A contiguous `Bit <- Bit` reads 0.0041 ms on master against 0.0055 ms here, but only because the host loop leaves the result in host memory and the benchmark reads it back from there. With the result consumed on the GPU — `d.store(s); d.count_true` — it is 0.988 ms on master and 0.026 ms here.

No `FIXME: ... synchronizes with CPU` warning is left on any store touching Bit.

## Checked

`rake test` passes (1507 tests, 20504 assertions). 445 md5s covering ten dtypes, six view shapes, fifteen bit offsets, a 5-d shape and the short-sub-array path are identical to master's. The same results were compared against Numo: everything agrees except `to_binary` and `marshal` of a Bit view with a bit offset, where Numo answers zeroes and cumo already had the fix.

The new test builds its expectations in Ruby rather than from a contiguous copy, which shares the templates under test. Six deliberate breaks of the addressing — reading or writing either operand as if it were contiguous, in each of the three templates, and dropping the offset from the word path — are each caught by it, and moving `to_binary`'s synchronize back before the `dup` is caught by `test_to_binary_of_a_bit_view_with_an_offset`.
