### PR TITLE
Add a bincount kernel

### DIFF
--- a/ext/cumo/cuda/runtime.c
+++ b/ext/cumo/cuda/runtime.c
@@ -20,7 +20,7 @@ cumo_cuda_runtime_check_kernel_launch(void)
 }
 
 int*
-cumo_cuda_runtime_error_flag_new(void)
+cumo_cuda_runtime_error_flag_ptr(void)
 {
     static int *flag = NULL;
 
@@ -28,6 +28,13 @@ cumo_cuda_runtime_error_flag_new(void)
         check_status(cudaHostAlloc((void**)&flag, sizeof(int),
                                    cudaHostAllocMapped | cudaHostAllocPortable));
     }
+    return flag;
+}
+
+int*
+cumo_cuda_runtime_error_flag_new(void)
+{
+    int *flag = cumo_cuda_runtime_error_flag_ptr();
     *flag = 0;
     return flag;
 }
@@ -37,6 +44,28 @@ cumo_cuda_runtime_error_flag_get(int *flag)
 {
     check_status(cudaDeviceSynchronize());
     return (*flag != 0);
+}
+
+// The value a kernel is rejecting, so the message the caller raises can name it.
+// Read it only once the flag says there was one; the flag's read synchronizes.
+size_t*
+cumo_cuda_runtime_error_item_ptr(void)
+{
+    static size_t *item = NULL;
+
+    if (item == NULL) {
+        check_status(cudaHostAlloc((void**)&item, sizeof(size_t),
+                                   cudaHostAllocMapped | cudaHostAllocPortable));
+    }
+    return item;
+}
+
+size_t*
+cumo_cuda_runtime_error_item_new(void)
+{
+    size_t *item = cumo_cuda_runtime_error_item_ptr();
+    *item = 0;
+    return item;
 }
 
 ///////////////////////////////////////////

--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -58,6 +58,11 @@ cumo_cuda_runtime_is_device_memory(void* ptr)
 // once per operation.
 int* cumo_cuda_runtime_error_flag_new(void);
 bool cumo_cuda_runtime_error_flag_get(int *flag);
+size_t* cumo_cuda_runtime_error_item_new(void);
+// The same buffers without the reset, so a loop that launches once per row can
+// reset before it and read after it rather than synchronizing every row.
+int* cumo_cuda_runtime_error_flag_ptr(void);
+size_t* cumo_cuda_runtime_error_item_ptr(void);
 
 #if defined(__cplusplus)
 #if 0

--- a/ext/cumo/narray/gen/tmpl/bincount.c
+++ b/ext/cumo/narray/gen/tmpl/bincount.c
@@ -15,39 +15,28 @@ static inline void
    cnt_cT = "cumo_cUInt#{bits}"
    cnt_type = "u_int#{bits}_t"
 %>
+void <%="cumo_#{c_iter}_#{bits}_kernel_launch"%>(char *p1, ssize_t s1, size_t *idx1, uint64_t count, char *p2, ssize_t s2, uint64_t n, int *oor, size_t *item);
+
 static void
 <%=c_iter%>_<%=bits%>(cumo_na_loop_t *const lp)
 {
-    size_t   i, x, n;
+    size_t   i, n;
     char    *p1, *p2;
     ssize_t  s1, s2;
     size_t  *idx1;
+    int     *oor;
+    size_t  *item;
 
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
     i = lp->args[0].shape[0];
     n = lp->args[1].shape[0];
 
-    // initialize
-    for (x=0; x < n; x++) {
-        *(<%=cnt_type%>*)(p2 + s2*x) = 0;
-    }
-
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_<%=bits%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    if (idx1) {
-        for (; i--;) {
-            CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
-            <%=c_func%>_check_item(x, n);
-            (*(<%=cnt_type%>*)(p2 + s2*x))++;
-        }
-    } else {
-        for (; i--;) {
-            CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-            <%=c_func%>_check_item(x, n);
-            (*(<%=cnt_type%>*)(p2 + s2*x))++;
-        }
-    }
+    // The flag is reset before the loop and read after it, so a multi-row input
+    // costs one synchronization rather than one per row.
+    oor = cumo_cuda_runtime_error_flag_ptr();
+    item = cumo_cuda_runtime_error_item_ptr();
+    <%="cumo_#{c_iter}_#{bits}_kernel_launch"%>(p1,s1,idx1,i,p2,s2,n,oor,item);
 }
 
 static VALUE
@@ -58,8 +47,15 @@ static VALUE
     cumo_ndfunc_arg_out_t aout[1] = {{<%=cnt_cT%>,1,shape_out}};
     cumo_ndfunc_t ndf = {<%=c_iter%>_<%=bits%>, CUMO_NO_LOOP|CUMO_NDF_STRIDE_LOOP|CUMO_NDF_INDEX_LOOP,
                     1, 1, ain, aout};
+    int *oor = cumo_cuda_runtime_error_flag_new();
+    size_t *item = cumo_cuda_runtime_error_item_new();
+    VALUE v = cumo_na_ndloop(&ndf, 1, self);
 
-    return cumo_na_ndloop(&ndf, 1, self);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>_<%=bits%>", "<%=type_name%>");
+    if (cumo_cuda_runtime_error_flag_get(oor)) {
+        <%=c_func%>_check_item(*item, length);
+    }
+    return v;
 }
 <% end %>
 // ------- end of Integer count without weights -------
@@ -71,13 +67,16 @@ static VALUE
   cnt_cT = "cumo_c#{fn}loat"
   fn = fn.downcase
 %>
+void <%="cumo_#{c_iter}_#{fn}_kernel_launch"%>(char *p1, ssize_t s1, char *p2, ssize_t s2, uint64_t count, char *p3, ssize_t s3, uint64_t n, int *oor, size_t *item);
+
 static void
 <%=c_iter%>_<%=fn%>(cumo_na_loop_t *const lp)
 {
-    <%=cnt_type%> w;
-    size_t   i, x, n, m;
+    size_t   i, n, m;
     char    *p1, *p2, *p3;
     ssize_t  s1, s2, s3;
+    int     *oor;
+    size_t  *item;
 
     CUMO_INIT_PTR(lp, 0, p1, s1);
     CUMO_INIT_PTR(lp, 1, p2, s2);
@@ -91,19 +90,9 @@ static void
                  "size mismatch along last axis between self and weight");
     }
 
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_<%=fn%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
-    // initialize
-    for (x=0; x < n; x++) {
-        *(<%=cnt_type%>*)(p3 + s3*x) = 0;
-    }
-    for (; i--;) {
-        CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-        CUMO_GET_DATA_STRIDE(p2,s2,<%=cnt_type%>,w);
-        <%=c_func%>_check_item(x, n);
-        (*(<%=cnt_type%>*)(p3 + s3*x)) += w;
-    }
+    oor = cumo_cuda_runtime_error_flag_ptr();
+    item = cumo_cuda_runtime_error_item_ptr();
+    <%="cumo_#{c_iter}_#{fn}_kernel_launch"%>(p1,s1,p2,s2,i,p3,s3,n,oor,item);
 }
 
 static VALUE
@@ -114,8 +103,15 @@ static VALUE
     cumo_ndfunc_arg_out_t aout[1] = {{<%=cnt_cT%>,1,shape_out}};
     cumo_ndfunc_t ndf = {<%=c_iter%>_<%=fn%>, CUMO_NO_LOOP|CUMO_NDF_STRIDE_LOOP,
                     2, 1, ain, aout};
+    int *oor = cumo_cuda_runtime_error_flag_new();
+    size_t *item = cumo_cuda_runtime_error_item_new();
+    VALUE v = cumo_na_ndloop(&ndf, 2, self, weight);
 
-    return cumo_na_ndloop(&ndf, 2, self, weight);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>_<%=fn%>", "<%=type_name%>");
+    if (cumo_cuda_runtime_error_flag_get(oor)) {
+        <%=c_func%>_check_item(*item, length);
+    }
+    return v;
 }
 <% end %>
 // ------- end of Float count with weights -------

--- a/ext/cumo/narray/gen/tmpl/bincount_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/bincount_kernel.cu
@@ -1,0 +1,86 @@
+// atomicAdd on double arrived with sm_60. Before that the compare-and-swap loop
+// the CUDA programming guide gives is the only way to get one, and the default
+// target of the CUDA releases cumo builds against is still below it.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)
+__device__ static inline void <%=c_iter%>_add_double(double *address, double val)
+{
+    unsigned long long int *p = (unsigned long long int*)address;
+    unsigned long long int old = *p, assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(p, assumed, __double_as_longlong(val + __longlong_as_double(assumed)));
+    } while (assumed != old);
+}
+#else
+__device__ static inline void <%=c_iter%>_add_double(double *address, double val) { atomicAdd(address, val); }
+#endif
+
+// A kernel cannot raise, so an item that does not fit the output is reported
+// through the flag and the value is left for the message. Any offending item
+// will do, so the two stores race harmlessly.
+#define cumo_check_bincount_item(x, n)  \
+    if ((x) >= (n)) {                   \
+        *item = (x);                    \
+        *oor = 1;                       \
+        continue;                       \
+    }
+
+<%
+[["32","u_int32_t","unsigned int","1u"],
+ ["64","u_int64_t","unsigned long long","1ull"]].each do |bits,cnt_type,atom_type,one|
+%>
+__global__ void <%="cumo_#{c_iter}_#{bits}_init_kernel"%>(char *p2, ssize_t s2, uint64_t n)
+{
+    for (uint64_t x = blockIdx.x * blockDim.x + threadIdx.x; x < n; x += blockDim.x * gridDim.x) {
+        *(<%=cnt_type%>*)(p2 + s2 * x) = 0;
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_#{bits}_kernel"%>(char *p1, ssize_t s1, size_t *idx1, uint64_t count, char *p2, ssize_t s2, uint64_t n, int *oor, size_t *item)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        size_t x = (size_t)(*(dtype*)(idx1 ? (p1 + idx1[i]) : (p1 + s1 * i)));
+        cumo_check_bincount_item(x, n);
+        atomicAdd((<%=atom_type%>*)(p2 + s2 * x), <%=one%>);
+    }
+}
+
+void <%="cumo_#{c_iter}_#{bits}_kernel_launch"%>(char *p1, ssize_t s1, size_t *idx1, uint64_t count, char *p2, ssize_t s2, uint64_t n, int *oor, size_t *item)
+{
+    <%="cumo_#{c_iter}_#{bits}_init_kernel"%><<<cumo_get_grid_dim(n), cumo_get_block_dim(n)>>>(p2,s2,n);
+    cumo_cuda_runtime_check_kernel_launch();
+    <%="cumo_#{c_iter}_#{bits}_kernel"%><<<cumo_get_grid_dim(count), cumo_get_block_dim(count)>>>(p1,s1,idx1,count,p2,s2,n,oor,item);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>
+
+<%
+[["sf","float","atomicAdd"],
+ ["df","double","#{c_iter}_add_double"]].each do |fn,cnt_type,add|
+%>
+__global__ void <%="cumo_#{c_iter}_#{fn}_init_kernel"%>(char *p3, ssize_t s3, uint64_t n)
+{
+    for (uint64_t x = blockIdx.x * blockDim.x + threadIdx.x; x < n; x += blockDim.x * gridDim.x) {
+        *(<%=cnt_type%>*)(p3 + s3 * x) = 0;
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_#{fn}_kernel"%>(char *p1, ssize_t s1, char *p2, ssize_t s2, uint64_t count, char *p3, ssize_t s3, uint64_t n, int *oor, size_t *item)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        size_t x = (size_t)(*(dtype*)(p1 + s1 * i));
+        cumo_check_bincount_item(x, n);
+        <%=add%>((<%=cnt_type%>*)(p3 + s3 * x), *(<%=cnt_type%>*)(p2 + s2 * i));
+    }
+}
+
+void <%="cumo_#{c_iter}_#{fn}_kernel_launch"%>(char *p1, ssize_t s1, char *p2, ssize_t s2, uint64_t count, char *p3, ssize_t s3, uint64_t n, int *oor, size_t *item)
+{
+    <%="cumo_#{c_iter}_#{fn}_init_kernel"%><<<cumo_get_grid_dim(n), cumo_get_block_dim(n)>>>(p3,s3,n);
+    cumo_cuda_runtime_check_kernel_launch();
+    <%="cumo_#{c_iter}_#{fn}_kernel"%><<<cumo_get_grid_dim(count), cumo_get_block_dim(count)>>>(p1,s1,p2,s2,count,p3,s3,n,oor,item);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+<% end %>
+
+#undef cumo_check_bincount_item

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2007,6 +2007,83 @@ class NArrayTest < Test::Unit::TestCase
       assert_raise(ArgumentError) { a.bincount(minlength: setter.new(a, -1)) }
     end
 
+    def bincount_expect(nested, length)
+      return nested.map { |row| bincount_expect(row, length) } if nested.first.is_a?(Array)
+
+      counts = Array.new(length, 0)
+      nested.each { |x| counts[x] += 1 }
+      counts
+    end
+
+    def bincount_expect_weighted(nested, weights, length)
+      if nested.first.is_a?(Array)
+        return nested.zip(weights).map { |row, w| bincount_expect_weighted(row, w, length) }
+      end
+
+      sums = Array.new(length, 0.0)
+      nested.each_with_index { |x, i| sums[x] += weights[i] }
+      sums
+    end
+
+    test "every element of a view is counted" do
+      # The count ran on the host, one element at a time, behind a device
+      # synchronization. The expectations are tallied in Ruby rather than taken
+      # from a contiguous copy, so a wrong address cannot cancel out.
+      rows = 12
+      cols = 25
+      lim = 37
+      xs = Array.new(rows * cols) { |i| (i * 7) % lim }
+      idx = [9, 0, 4, 11, 2]
+
+      views = {
+        "contiguous" => ->(a) { a },
+        "column slice" => ->(a) { a[true, 3...(cols - 4)] },
+        "reversed" => ->(a) { a[true, (cols - 1).step(0, -1)] },
+        "row stride" => ->(a) { a[0.step(rows - 1, 3), true] },
+        "index view" => ->(a) { a[idx, true] },
+        # the index has to be on the last axis for one to reach the kernel; on
+        # an outer axis ndloop walks it itself
+        "column index" => ->(a) { a[true, [7, 0, 19, 3, 24, 11]] },
+        "transpose" => ->(a) { a.transpose },
+      }
+
+      int_types.each do |dtype|
+        next if dtype == Cumo::Int8 # lim does not fit
+
+        src = dtype.cast(xs).reshape(rows, cols)
+        views.each do |what, take|
+          v = take.call(src)
+          length = v.to_a.flatten.max + 1
+          assert_equal(bincount_expect(v.to_a, length), v.bincount.to_a, "#{dtype} #{what}")
+          assert_equal(bincount_expect(v.to_a, length + 9), v.bincount(minlength: length + 9).to_a,
+                       "#{dtype} #{what} minlength")
+        end
+
+        flat = dtype.cast(xs)
+        [flat[[13, 2, 40, 7, 99, 0, 61]], flat[(0...(rows * cols)).step(5)],
+         flat[((rows * cols) - 1).step(0, -2)]].each_with_index do |v, i|
+          length = v.to_a.max + 1
+          assert_equal(bincount_expect(v.to_a, length), v.bincount.to_a, "#{dtype} 1-d view #{i}")
+        end
+      end
+
+      # weights, whose sums stay exact so the order the additions run in cannot
+      # show up in the answer
+      ws = Array.new(rows * cols) { |i| ((i * 3) % 11) - 5.0 }
+      [Cumo::SFloat, Cumo::DFloat].each do |wtype|
+        src = Cumo::Int32.cast(xs).reshape(rows, cols)
+        weight = wtype.cast(ws).reshape(rows, cols)
+        views.each do |what, take|
+          v = take.call(src)
+          w = take.call(weight)
+          length = v.to_a.flatten.max + 1
+          got = v.bincount(w).to_a
+          want = bincount_expect_weighted(v.to_a, w.to_a, length)
+          assert_equal(want, got, "#{wtype} #{what}")
+        end
+      end
+    end
+
     test "an array large enough that the filling kernel is still running" do
       r = (Cumo::Int32.new(1 << 20).seq % 997).bincount
       assert_equal(997, r.size)


### PR DESCRIPTION

## Summary

`bincount` now zeroes its output and accumulates into it with `atomicAdd` from a kernel. The unweighted counts are integer adds, so they stay exact and order-independent; the float weights reassociate, the way every other reduction on floats in cumo already does.

An item that does not fit the output is reported through `cumo_cuda_runtime_error_flag_*`, with the offending value in a pinned buffer of its own so the message can still name it. The flag is reset before `cumo_na_ndloop` and read after it rather than inside the iterator, so a multi-row input costs one synchronization instead of one per row; `cumo_cuda_runtime_error_{flag,item}_ptr` are the same buffers without the reset, for that.

RTX 5070 Ti Laptop, CUDA 13.0, 1M elements unless stated, best of 10 in its own process and the best of three such runs.

| | master | this PR |
| --- | ---: | ---: |
| `Int32`, 997 bins | 1.621 ms | 0.051 ms |
| `Int32`, 100k bins | 1.615 ms | 0.085 ms |
| `UInt8`, 251 bins | 3.700 ms | 0.050 ms |
| `Int64`, 997 bins | 2.344 ms | 0.063 ms |
| `DFloat` weights | 1.480 ms | 0.073 ms |
| `SFloat` weights | 1.910 ms | 0.059 ms |
| 1k elements, 100 bins | 0.972 ms | 0.046 ms |
| view, step 2 | 2.998 ms | 0.336 ms |
| 256x4096, 997 bins | 1.700 ms | 1.013 ms |

## Problem

The count ran on the host, one element at a time, behind a `cudaDeviceSynchronize`. The whole array had to come across before anything was counted, so a 1M-element `Int32` took 1.6 ms where the min/max scan that sizes the output takes 0.02 ms. A 1k-element array took 0.97 ms — almost all of it the synchronization and the page migration rather than the counting.

The strided view above is still limited by that scan and not by the count: on it `minmax` alone is 0.175 ms against 0.014 ms contiguous. The 256-row case is one iterator call per row, so it pays the per-operation fixed cost 256 times.

## Note

`atomicAdd` fixes neither the order nor the grouping of the additions, so a weighted bincount is no longer reproducible bit-for-bit between runs and it differs from Numo. Measured over 2^18 elements into 1000 bins with weights drawn uniformly from ±5e5, where the sums cancel heavily: `DFloat` differs from Numo by at most 9.6e-13 relative, `SFloat` by at most 4.5e-4. Unweighted counts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
