### PR TITLE
Fix an RObject store that reads an index array before it is written

### DIFF
--- a/ext/cumo/narray/gen/tmpl/fill.c
+++ b/ext/cumo/narray/gen/tmpl/fill.c
@@ -17,6 +17,9 @@ static void
         CUMO_INIT_COUNTER(lp, i);
         CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        // The index array is filled by a kernel; wait for it before reading it
+        // from here.
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         if (idx1) {
             for (; i--;) {
                 CUMO_SET_DATA_INDEX(p1,idx1,dtype,y);

--- a/ext/cumo/narray/gen/tmpl/store_bit.c
+++ b/ext/cumo/narray/gen/tmpl/store_bit.c
@@ -21,6 +21,9 @@ static void
         dtype y;
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        // The index arrays are filled by a kernel; wait for it before reading
+        // them from here.
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         if (idx2) {
             if (idx1) {
                 for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl/store_from.c
+++ b/ext/cumo/narray/gen/tmpl/store_from.c
@@ -32,6 +32,11 @@ static void
     CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    // An index array is filled by a kernel, so the loop below cannot read one
+    // until that has finished. Cumo::RObject is the only dtype whose loop runs
+    // on the host and still sees the index; every other one hands it to a
+    // kernel of its own, which the stream already orders.
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
     {
         <%=dtype%> x;
         dtype y;

--- a/ext/cumo/narray/gen/tmpl/unary_s.c
+++ b/ext/cumo/narray/gen/tmpl/unary_s.c
@@ -16,6 +16,9 @@ static void
     {
         dtype x;
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+        // The index arrays are filled by a kernel; wait for it before reading
+        // them from here.
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
         if (idx1) {
             if (idx2) {
                 for (; i--;) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3547,6 +3547,57 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  test "an RObject loop waits for the kernel that fills an index array" do
+    # Index arrays are filled by a kernel. Every dtype but RObject hands the
+    # index on to a kernel of its own, which the stream already orders, but
+    # RObject keeps its data on the host and reads the index there. Without a
+    # wait the second such store onwards read an index the kernel had not
+    # written yet: zeroes, then whatever the chunk held before, and a bus error
+    # when that was not a valid address.
+    cols = 7
+    order = [6, 0, 5, 1, 4, 2, 3]
+    rows = [[0, 1, 1, 0, 1, 1, 0], [1, 0, 1], [0, 1]]
+    scatter = lambda do |vals|
+      out = Array.new(cols, 0)
+      cols.times { |p| out[order[p]] = vals[p] || 0 }
+      out
+    end
+    want = rows.map(&scatter)
+
+    # A fresh view every time, so the index array comes back out of the pool
+    # rather than being allocated once and reused. Nothing may run between
+    # taking the view and the store, or the kernel finishes on its own and the
+    # window closes.
+    4.times do |i|
+      srcs = rows.map { |v| Cumo::RObject.cast(v) }
+      dst = Cumo::RObject.new(rows.size, cols).fill(0)
+      dst[true, order].store(srcs)
+      assert_equal(want, ints_of(dst), "Array of narrays (#{i})")
+    end
+
+    src = Cumo::Int32.new(3, cols).seq
+    want_src = src.to_a.map(&scatter)
+    4.times do |i|
+      dst = Cumo::RObject.new(3, cols).fill(0)
+      dst[true, order].store(src)
+      assert_equal(want_src, ints_of(dst), "RObject <- Int32 (#{i})")
+    end
+
+    bits = src.gt(9)
+    want_bits = bits.to_a.map(&scatter)
+    4.times do |i|
+      dst = Cumo::RObject.new(3, cols).fill(0)
+      dst[true, order].store(bits)
+      assert_equal(want_bits, ints_of(dst), "RObject <- Bit (#{i})")
+    end
+
+    4.times do |i|
+      dst = Cumo::RObject.new(3, cols).fill(0)
+      dst[true, order].fill(9)
+      assert_equal(Array.new(3) { Array.new(cols, 9) }, ints_of(dst), "RObject fill (#{i})")
+    end
+  end
+
   test "an index array reaches the store an Array of narrays runs" do
     # store_array runs the same-type store inside a loop of its own, which keeps
     # CUMO_NDF_INDEX_LOOP on, so an index array reaches a kernel whose iarray


### PR DESCRIPTION

## Summary

Index arrays are filled by a kernel — `cumo_na_index_aref_naview_index_index_kernel_launch` and friends in `narray/index.c`. Every dtype but `Cumo::RObject` hands the index on to a kernel of its own, which the stream already orders. `Cumo::RObject` keeps its data on the host and reads the index there, so it has to wait, and it did not.

```ruby
rows = [[0, 1, 1, 0, 1, 1, 0], [1, 0, 1], [0, 1]].map { |v| Cumo::RObject.cast(v) }
3.times do
  d = Cumo::RObject.new(3, 7).fill(0)
  d[true, [6, 0, 5, 1, 4, 2, 3]].store(rows)
  p d.to_a
end
# [[1, 0, 1, 0, 1, 1, 0], [0, 0, 0, 0, 0, 1, 1], [1, 0, 0, 0, 0, 0, 0]]   correct
# [[0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0]]
# [[8487041, false, 0, 0, 0, 0, 0], [8421504, false, 0, ...]]
```

The first store is right, the second writes nothing, and the third reads whatever the recycled chunk held and stores it as Ruby `VALUE`s. With something else running on the device at the time it is a bus error inside `iter_robject_store_robject`. Numo has none of this — its index arrays are written on the host.

The four RObject loops that read an index now wait first. Only the store is demonstrated by the test; `fill`, the store from `Bit` and the `NMath` unary loops are the same read and are guarded for the same reason, without a case that shows them failing.

## Problem

`tmpl/store_from.c`'s RObject branch takes `idx1` and `idx2` from `CUMO_INIT_PTR_IDX` and walks them on the host. It carries `CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE`, so it was already understood to be a host loop, but nothing waited for the kernel that produced the index it walks.

The window is narrow, which is why this went unnoticed: anything at all between taking the view and the store gives the index kernel time to finish. The test therefore builds its sources first and puts nothing between `dst[true, order]` and `store`. Removing the wait again is caught by it.

## Note

Not fixed here, and unrelated: `Cumo::RObject` reaches these loops through `store_array`, which is also the path of the upstream `loop_store_subnarray` defects that numo-narray-alt#27 fixes. Those are a separate matter and cumo will take them once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
