### PR TITLE
Add sort kernel

### DIFF
--- a/ext/cumo/extconf.rb
+++ b/ext/cumo/extconf.rb
@@ -54,6 +54,7 @@ narray/ndloop
 narray/ndloop_kernel
 narray/data
 narray/data_kernel
+narray/sort_kernel
 narray/types/bit
 narray/types/int8
 narray/types/int16

--- a/ext/cumo/narray/gen/tmpl/sort.c
+++ b/ext/cumo/narray/gen/tmpl/sort.c
@@ -1,3 +1,36 @@
+void cumo_<%=type_name%>_sort_kernel_launch(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat);
+
+// One call sorts every row, so a loop over many short rows costs no more
+// launches than one long row. nan:true keeps the host path: its comparator
+// leaves NaN unordered, and what numo answers there is not a sorted array.
+static void
+<%=c_iter%>_kernel(cumo_na_loop_t *const lp)
+{
+    cumo_na_iarray_t a = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+    int64_t row_len = 1;
+    int64_t n_rows;
+    ssize_t expect = sizeof(dtype);
+    int i, flat = 1;
+
+    for (i = indexer.ndim - lp->reduce_dim; i < indexer.ndim; ++i) {
+        row_len *= (int64_t)indexer.shape[i];
+    }
+    n_rows = row_len > 0 ? (int64_t)indexer.total_size / row_len : 0;
+
+    // The rows have to be laid out end to end for a segmented sort to address
+    // them; anything else is gathered into a buffer of its own first.
+    for (i = indexer.ndim; --i >= 0;) {
+        if (a.step[i] != expect) {
+            flat = 0;
+            break;
+        }
+        expect *= (ssize_t)indexer.shape[i];
+    }
+
+    cumo_<%=type_name%>_sort_kernel_launch(&a, &indexer, n_rows, row_len, flat);
+}
+
 <% (is_float ? ["_ignan","_prnan"] : [""]).each do |j| %>
 static void
 <%=c_iter%><%=j%>(cumo_na_loop_t *const lp)
@@ -40,9 +73,15 @@ static VALUE
   <% if is_float %>
     ndf.func = <%=c_iter%>_ignan;
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, <%=c_iter%>_prnan);
+    if (ndf.func == <%=c_iter%>_ignan) {
+        ndf.func = <%=c_iter%>_kernel;
+        ndf.flag = CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_INDEXER_LOOP;
+    }
   <% else %>
     ndf.func = <%=c_iter%>;
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
+    ndf.func = <%=c_iter%>_kernel;
+    ndf.flag = CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_INDEXER_LOOP;
   <% end %>
     cumo_na_ndloop(&ndf, 2, self, reduce);
     return self;

--- a/ext/cumo/narray/sort_kernel.cu
+++ b/ext/cumo/narray/sort_kernel.cu
@@ -1,0 +1,185 @@
+#include "cumo/narray_kernel.h"
+#include "cumo/indexer.h"
+#include "cumo/template_kernel.h"
+
+#include <cub/cub.cuh>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+extern "C" char* cumo_cuda_runtime_malloc(size_t size);
+extern "C" void cumo_cuda_runtime_free(char *ptr);
+extern "C" void cumo_cuda_runtime_check_kernel_launch(void);
+
+namespace {
+
+// Where each row starts, so that the segmented sort needs no offsets array.
+struct row_offset {
+    int64_t row_len;
+    __host__ __device__ __forceinline__ int64_t operator()(int64_t i) const { return i * row_len; }
+};
+
+inline auto row_begins(int64_t row_len) {
+    return thrust::make_transform_iterator(thrust::counting_iterator<int64_t>(0), row_offset{row_len});
+}
+
+inline auto row_ends(int64_t row_len) {
+    return thrust::make_transform_iterator(thrust::counting_iterator<int64_t>(1), row_offset{row_len});
+}
+
+// The unsigned integer whose ascending order is the order sort wants for the
+// float it comes from: negatives reversed and below the positives, -0.0 below
+// +0.0, and every NaN above everything else whatever its sign. That last part
+// is why a float cannot be its own key -- a radix sort puts a negative NaN
+// first, and numo puts every NaN last.
+template <typename Float> struct float_key;
+
+template <> struct float_key<float> {
+    typedef uint32_t type;
+    __device__ static type of(float x) {
+        type u = __float_as_uint(x);
+        if ((u & 0x7fffffffu) > 0x7f800000u) return ~(type)0;
+        return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
+    }
+};
+
+template <> struct float_key<double> {
+    typedef uint64_t type;
+    __device__ static type of(double x) {
+        type u = (type)__double_as_longlong(x);
+        if ((u & 0x7fffffffffffffffull) > 0x7ff0000000000000ull) return ~(type)0;
+        return (u & 0x8000000000000000ull) ? ~u : (u | 0x8000000000000000ull);
+    }
+};
+
+template <typename Float>
+__global__ void float_key_kernel(const Float* in, typename float_key<Float>::type* out, uint64_t n) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        out[i] = float_key<Float>::of(in[i]);
+    }
+}
+
+// Rows that are not laid out end to end are gathered into a buffer of their
+// own, sorted there and put back, which is two passes over the data against
+// one launch per row.
+template <typename T>
+__global__ void gather_kernel(cumo_na_iarray_t a, cumo_na_indexer_t indexer, T* buf) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim(&indexer, i);
+        buf[i] = *(T*)cumo_na_iarray_at_dim(&a, &indexer);
+    }
+}
+
+template <typename T>
+__global__ void scatter_kernel(cumo_na_iarray_t a, cumo_na_indexer_t indexer, const T* buf) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim(&indexer, i);
+        *(T*)cumo_na_iarray_at_dim(&a, &indexer) = buf[i];
+    }
+}
+
+// One CUB call covers the whole array, so a loop over many short rows costs no
+// more launches than one long row does.
+template <typename Key, typename Value>
+void sort_pairs(const Key* kin, Key* kout, const Value* vin, Value* vout,
+                int64_t total, int64_t n_rows, int64_t row_len) {
+    size_t bytes = 0;
+    if (n_rows == 1) {
+        cub::DeviceRadixSort::SortPairs(nullptr, bytes, kin, kout, vin, vout, total);
+        char* tmp = cumo_cuda_runtime_malloc(bytes);
+        cub::DeviceRadixSort::SortPairs(tmp, bytes, kin, kout, vin, vout, total);
+        cumo_cuda_runtime_check_kernel_launch();
+        cumo_cuda_runtime_free(tmp);
+    } else {
+        cub::DeviceSegmentedRadixSort::SortPairs(nullptr, bytes, kin, kout, vin, vout, total, n_rows,
+                                                 row_begins(row_len), row_ends(row_len));
+        char* tmp = cumo_cuda_runtime_malloc(bytes);
+        cub::DeviceSegmentedRadixSort::SortPairs(tmp, bytes, kin, kout, vin, vout, total, n_rows,
+                                                 row_begins(row_len), row_ends(row_len));
+        cumo_cuda_runtime_check_kernel_launch();
+        cumo_cuda_runtime_free(tmp);
+    }
+}
+
+template <typename Key>
+void sort_keys(const Key* kin, Key* kout, int64_t total, int64_t n_rows, int64_t row_len) {
+    size_t bytes = 0;
+    if (n_rows == 1) {
+        cub::DeviceRadixSort::SortKeys(nullptr, bytes, kin, kout, total);
+        char* tmp = cumo_cuda_runtime_malloc(bytes);
+        cub::DeviceRadixSort::SortKeys(tmp, bytes, kin, kout, total);
+        cumo_cuda_runtime_check_kernel_launch();
+        cumo_cuda_runtime_free(tmp);
+    } else {
+        cub::DeviceSegmentedRadixSort::SortKeys(nullptr, bytes, kin, kout, total, n_rows,
+                                                row_begins(row_len), row_ends(row_len));
+        char* tmp = cumo_cuda_runtime_malloc(bytes);
+        cub::DeviceSegmentedRadixSort::SortKeys(tmp, bytes, kin, kout, total, n_rows,
+                                               row_begins(row_len), row_ends(row_len));
+        cumo_cuda_runtime_check_kernel_launch();
+        cumo_cuda_runtime_free(tmp);
+    }
+}
+
+template <typename T, bool IS_FLOAT>
+void sort_rows(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) {
+    int64_t total = (int64_t)indexer->total_size;
+    if (total == 0) return;
+
+    size_t grid_dim = cumo_get_grid_dim(total);
+    size_t block_dim = cumo_get_block_dim(total);
+
+    T* data = (T*)a->ptr;
+    T* gathered = 0;
+    if (!flat) {
+        gathered = (T*)cumo_cuda_runtime_malloc(sizeof(T) * total);
+        gather_kernel<T><<<grid_dim, block_dim>>>(*a, *indexer, gathered);
+        cumo_cuda_runtime_check_kernel_launch();
+        data = gathered;
+    }
+
+    T* out = (T*)cumo_cuda_runtime_malloc(sizeof(T) * total);
+    if constexpr (IS_FLOAT) {
+        typedef typename float_key<T>::type key_t;
+        key_t* kin = (key_t*)cumo_cuda_runtime_malloc(sizeof(key_t) * total);
+        key_t* kout = (key_t*)cumo_cuda_runtime_malloc(sizeof(key_t) * total);
+        float_key_kernel<T><<<grid_dim, block_dim>>>(data, kin, total);
+        cumo_cuda_runtime_check_kernel_launch();
+        sort_pairs(kin, kout, data, out, total, n_rows, row_len);
+        cumo_cuda_runtime_free((char*)kout);
+        cumo_cuda_runtime_free((char*)kin);
+    } else {
+        sort_keys(data, out, total, n_rows, row_len);
+    }
+
+    if (flat) {
+        cudaMemcpyAsync(data, out, sizeof(T) * total, cudaMemcpyDeviceToDevice, 0);
+        cumo_cuda_runtime_check_kernel_launch();
+    } else {
+        scatter_kernel<T><<<grid_dim, block_dim>>>(*a, *indexer, out);
+        cumo_cuda_runtime_check_kernel_launch();
+        cumo_cuda_runtime_free((char*)gathered);
+    }
+    cumo_cuda_runtime_free((char*)out);
+}
+
+} // namespace
+
+// float_key is only defined for the two float types, so the integer entry
+// points must not instantiate it; the bool picks the branch at compile time.
+#define CUMO_DEF_SORT(name, type, is_float)                                                     \
+    extern "C" void cumo_##name##_sort_kernel_launch(                                           \
+        cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) \
+    {                                                                                           \
+        sort_rows<type, is_float>(a, indexer, n_rows, row_len, flat);                           \
+    }
+
+CUMO_DEF_SORT(int8, int8_t, false)
+CUMO_DEF_SORT(int16, int16_t, false)
+CUMO_DEF_SORT(int32, int32_t, false)
+CUMO_DEF_SORT(int64, int64_t, false)
+CUMO_DEF_SORT(uint8, u_int8_t, false)
+CUMO_DEF_SORT(uint16, u_int16_t, false)
+CUMO_DEF_SORT(uint32, u_int32_t, false)
+CUMO_DEF_SORT(uint64, u_int64_t, false)
+CUMO_DEF_SORT(sfloat, float, true)
+CUMO_DEF_SORT(dfloat, double, true)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3547,6 +3547,58 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  test "sort orders every row, whatever the axis and the layout" do
+    # The sort ran on the host, one row at a time, behind a device
+    # synchronization. The expectations are sorted in Ruby rather than taken
+    # from another cumo call.
+    rows = 12
+    cols = 25
+    n = rows * cols
+    xs = Array.new(n) { |i| ((i * 37) % 101) - 50 }
+    int_types = [Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64, Cumo::UInt8, Cumo::UInt32]
+
+    (int_types + [Cumo::SFloat, Cumo::DFloat]).each do |dtype|
+      vals = dtype == Cumo::UInt8 || dtype == Cumo::UInt32 ? xs.map(&:abs) : xs
+      src = dtype.cast(vals).reshape(rows, cols)
+      table = src.to_a.map { |r| r.map(&:to_i) }
+
+      assert_equal(table.flatten.sort, ints_of(src.sort).flatten, "#{dtype} flat")
+      assert_equal(table.map(&:sort), ints_of(src.sort(axis: 1)), "#{dtype} axis 1")
+      assert_equal(table.transpose.map(&:sort).transpose, ints_of(src.sort(axis: 0)), "#{dtype} axis 0")
+
+      # a view the rows of which are not laid out end to end
+      view = src[true, 0.step(cols - 1, 3)]
+      assert_equal(view.to_a.map { |r| r.map(&:to_i).sort }, ints_of(view.sort(axis: 1)), "#{dtype} column slice")
+
+      rev = src[(rows - 1).step(0, -1), true]
+      assert_equal(rev.to_a.map { |r| r.map(&:to_i).sort }, ints_of(rev.sort(axis: 1)), "#{dtype} reversed rows")
+
+      idx = src[[7, 0, 4, 11, 2], true]
+      assert_equal(idx.to_a.map { |r| r.map(&:to_i).sort }, ints_of(idx.sort(axis: 1)), "#{dtype} index view")
+
+      # a 3-d shape, and an axis that is neither the first nor the last
+      cube = dtype.cast(vals[0, 2 * 5 * 3]).reshape(2, 5, 3)
+      want = map_deep(cube.to_a, &:to_i).map { |plane| plane.transpose.map(&:sort).transpose }
+      assert_equal(want, map_deep(cube.sort(axis: 1).to_a, &:to_i), "#{dtype} 3-d axis 1")
+    end
+
+    # every NaN sorts last whatever its sign, and -0.0 sorts below +0.0
+    nan = Float::NAN
+    neg_nan = Float::INFINITY - Float::INFINITY
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      got = dtype.cast([3.0, nan, 1.0, neg_nan, 2.0]).sort.to_a
+      assert_equal([1.0, 2.0, 3.0], got[0, 3], "#{dtype} NaN last")
+      assert(got[3].nan? && got[4].nan?, "#{dtype} NaN last")
+
+      zeros = dtype.cast([0.0, -1.0, -0.0, 1.0]).sort.to_a
+      assert_equal([-1.0, 0.0, 0.0, 1.0], zeros, "#{dtype} signed zero")
+      assert_equal([1, 1, 0, 0], zeros.map { |x| (1.0 / x).negative? ? 1 : 0 }, "#{dtype} signed zero order")
+    end
+
+    assert_equal([1, 2, 3], Cumo::Int32[3, 1, 2].sort.to_a, "smallest case")
+    assert_equal([7], Cumo::Int32[7].sort.to_a, "one element")
+  end
+
   test "an RObject loop waits for the kernel that fills an index array" do
     # Index arrays are filled by a kernel. Every dtype but RObject hands the
     # index on to a kernel of its own, which the stream already orders, but


### PR DESCRIPTION

## Summary

`sort` ran on the host, one row at a time, behind a `cudaDeviceSynchronize`. It now sorts every row in a single `cub::DeviceSegmentedRadixSort` call, so a loop over many short rows costs no more launches than one long row does.

RTX 5070 Ti Laptop, CUDA 13.0, best of 5 in its own process.

| | master | this PR |
| --- | ---: | ---: |
| 1M `SFloat` | 115.7 ms | 0.47 ms |
| 4M `SFloat` | 500.4 ms | 0.82 ms |
| 1M `Int32` | — | 0.10 ms |
| 1024x1024 along axis 1 | 78.5 ms | 0.54 ms |
| 1024x1024 along axis 0 | 78.5 ms | 1.68 ms |
| 1024x1024 whole array | 78.5 ms | 0.13 ms |

For reference, Numo takes 85.7 ms on the 1M case and 45.4 ms on the 1024x1024 one, so cumo was behind the CPU on all of them before this.

A clean build goes from 40 s to 51 s: CUB is compiled once, in `narray/sort_kernel.cu`, rather than once per dtype.

## Problem

Three things had to be settled to get a radix sort to answer what `sort` already answered.

**A float cannot be its own key.** A radix sort orders by the IEEE total order, which puts a negative NaN first — and `Float::INFINITY - Float::INFINITY` is one. Numo puts every NaN last whatever its sign. So the keys are the unsigned integers whose ascending order is the one `sort` wants (negatives reversed and below the positives, `-0.0` below `+0.0`, every NaN at the top) and the floats ride along as values. Integers are their own keys.

**Rows have to be laid out end to end** for a segmented sort to address them, which `sort(axis: 0)` and a column slice are not. Those are gathered into a buffer of their own, sorted there and put back: two passes over the data, against one launch per row.

**`nan: true` keeps the host path.** Its comparator leaves NaN unordered, and what Numo answers there is not a sorted array — `Numo::SFloat[3, NaN, 1, -NaN, 2].sort(nan: true)` is `[3, NaN, 1, NaN, 2]`. There is nothing there for a radix sort to reproduce.

## Note

`sort_index` and `median` still run on the host. `median` is a sort and a pick, and `sort_index` is `SortPairs` with the index as the value; both are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
