### PR TITLE
Add sort_index kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl/sort_index.c
+++ b/ext/cumo/narray/gen/tmpl/sort_index.c
@@ -1,3 +1,37 @@
+void cumo_<%=type_name%>_sort_index_kernel_launch(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer,
+        cumo_na_iarray_t* idx, cumo_na_iarray_t* out, int64_t n_rows, int64_t row_len, int flat, int idx_bytes);
+
+// args[1] holds the answer for each position, so the sort only has to say
+// which position each rank came from. nan:true keeps the host path, as sort does.
+static void
+<%=c_iter%>_kernel(cumo_na_loop_t *const lp)
+{
+    cumo_na_iarray_t a = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+    cumo_na_iarray_t idx = cumo_na_make_iarray_given_ndim(&lp->args[1], indexer.ndim);
+    cumo_na_iarray_t out = cumo_na_make_iarray_given_ndim(&lp->args[2], indexer.ndim);
+    int64_t row_len = 1;
+    int64_t n_rows;
+    ssize_t expect = sizeof(dtype);
+    int i, flat = 1;
+
+    for (i = indexer.ndim - lp->reduce_dim; i < indexer.ndim; ++i) {
+        row_len *= (int64_t)indexer.shape[i];
+    }
+    n_rows = row_len > 0 ? (int64_t)indexer.total_size / row_len : 0;
+
+    for (i = indexer.ndim; --i >= 0;) {
+        if (a.step[i] != expect) {
+            flat = 0;
+            break;
+        }
+        expect *= (ssize_t)indexer.shape[i];
+    }
+
+    cumo_<%=type_name%>_sort_index_kernel_launch(&a, &indexer, &idx, &out, n_rows, row_len, flat,
+                                                 (int)lp->args[2].elmsz);
+}
+
 <% (is_float ? ["_ignan","_prnan"] : [""]).each do |j|
    [64,32].each do |i| %>
 #define idx_t int<%=i%>_t
@@ -64,6 +98,7 @@ static VALUE
     cumo_narray_t *na;
     VALUE idx, tmp, reduce, res;
     char *buf;
+    int kernel;
     cumo_ndfunc_arg_in_t ain[3] = {{cT,0},{0,0},{cumo_sym_reduce,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{0,0,0}};
     cumo_ndfunc_t ndf = {0, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_CUM, 3,1, ain,aout};
@@ -80,9 +115,11 @@ static VALUE
          ndf.func = <%=type_name%>_index64_qsort_ignan;
          reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf,
                                       <%=type_name%>_index64_qsort_prnan);
+         kernel = (ndf.func == <%=type_name%>_index64_qsort_ignan);
        <% else %>
          ndf.func = <%=type_name%>_index64_qsort;
          reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
+         kernel = 1;
        <% end %>
     } else {
         ain[1].type =
@@ -92,12 +129,23 @@ static VALUE
          ndf.func = <%=type_name%>_index32_qsort_ignan;
          reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf,
                                       <%=type_name%>_index32_qsort_prnan);
+         kernel = (ndf.func == <%=type_name%>_index32_qsort_ignan);
        <% else %>
          ndf.func = <%=type_name%>_index32_qsort;
          reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
+         kernel = 1;
        <% end %>
     }
     rb_funcall(idx, rb_intern("seq"), 0);
+
+    if (kernel) {
+        ndf.func = <%=c_iter%>_kernel;
+        ndf.flag |= CUMO_NDF_INDEXER_LOOP;
+        if (cumo_na_has_idx_p(self)) {
+            self = cumo_na_copy(self); // the indexer loop does not support idx, make contiguous
+        }
+        return cumo_na_ndloop3(&ndf, 0, 3, self, idx, reduce);
+    }
 
     size = na->size*sizeof(void*); // max capa
     buf = rb_alloc_tmp_buffer(&tmp, size);

--- a/ext/cumo/narray/sort_kernel.cu
+++ b/ext/cumo/narray/sort_kernel.cu
@@ -229,6 +229,74 @@ void median_rows(cumo_na_reduction_arg_t* arg, int flat) {
     if (gathered) cumo_cuda_runtime_free((char*)gathered);
 }
 
+// sort_index answers where each element came from, so the sort carries the
+// position along and the values it sorts are thrown away.
+template <typename I>
+__global__ void iota_kernel(I* out, int64_t n) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (uint64_t)n; i += blockDim.x * gridDim.x) {
+        out[i] = (I)i;
+    }
+}
+
+// perm[i] is the position the i-th smallest element sat at, and the index
+// array holds the number to answer for that position.
+template <typename I>
+__global__ void sort_index_scatter_kernel(cumo_na_iarray_t idx, cumo_na_iarray_t out,
+                                          cumo_na_indexer_t indexer, const I* perm) {
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim(&indexer, (uint64_t)perm[i]);
+        I v = *(I*)cumo_na_iarray_at_dim(&idx, &indexer);
+        cumo_na_indexer_set_dim(&indexer, i);
+        *(I*)cumo_na_iarray_at_dim(&out, &indexer) = v;
+    }
+}
+
+template <typename T, bool IS_FLOAT, typename I>
+void sort_index_rows(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, cumo_na_iarray_t* idx,
+                     cumo_na_iarray_t* out, int64_t n_rows, int64_t row_len, int flat) {
+    int64_t total = (int64_t)indexer->total_size;
+    if (total == 0) return;
+
+    size_t grid_dim = cumo_get_grid_dim(total);
+    size_t block_dim = cumo_get_block_dim(total);
+
+    T* data = (T*)a->ptr;
+    T* gathered = 0;
+    if (!flat) {
+        gathered = (T*)cumo_cuda_runtime_malloc(sizeof(T) * total);
+        gather_kernel<T><<<grid_dim, block_dim>>>(*a, *indexer, gathered);
+        cumo_cuda_runtime_check_kernel_launch();
+        data = gathered;
+    }
+
+    I* pin = (I*)cumo_cuda_runtime_malloc(sizeof(I) * total);
+    I* pout = (I*)cumo_cuda_runtime_malloc(sizeof(I) * total);
+    iota_kernel<I><<<grid_dim, block_dim>>>(pin, total);
+    cumo_cuda_runtime_check_kernel_launch();
+
+    if constexpr (IS_FLOAT) {
+        typedef typename float_key<T>::type key_t;
+        key_t* kin = (key_t*)cumo_cuda_runtime_malloc(sizeof(key_t) * total);
+        key_t* kout = (key_t*)cumo_cuda_runtime_malloc(sizeof(key_t) * total);
+        float_key_kernel<T><<<grid_dim, block_dim>>>(data, kin, total);
+        cumo_cuda_runtime_check_kernel_launch();
+        sort_pairs(kin, kout, pin, pout, total, n_rows, row_len);
+        cumo_cuda_runtime_free((char*)kout);
+        cumo_cuda_runtime_free((char*)kin);
+    } else {
+        T* kout = (T*)cumo_cuda_runtime_malloc(sizeof(T) * total);
+        sort_pairs(data, kout, pin, pout, total, n_rows, row_len);
+        cumo_cuda_runtime_free((char*)kout);
+    }
+
+    sort_index_scatter_kernel<I><<<grid_dim, block_dim>>>(*idx, *out, *indexer, pout);
+    cumo_cuda_runtime_check_kernel_launch();
+
+    cumo_cuda_runtime_free((char*)pout);
+    cumo_cuda_runtime_free((char*)pin);
+    if (gathered) cumo_cuda_runtime_free((char*)gathered);
+}
+
 } // namespace
 
 // float_key is only defined for the two float types, so the integer entry
@@ -242,6 +310,16 @@ void median_rows(cumo_na_reduction_arg_t* arg, int flat) {
     extern "C" void cumo_##name##_median_kernel_launch(cumo_na_reduction_arg_t* arg, int flat)  \
     {                                                                                           \
         median_rows<type, is_float>(arg, flat);                                                 \
+    }                                                                                           \
+    extern "C" void cumo_##name##_sort_index_kernel_launch(                                     \
+        cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, cumo_na_iarray_t* idx,                 \
+        cumo_na_iarray_t* out, int64_t n_rows, int64_t row_len, int flat, int idx_bytes)        \
+    {                                                                                           \
+        if (idx_bytes == 4) {                                                                   \
+            sort_index_rows<type, is_float, int32_t>(a, indexer, idx, out, n_rows, row_len, flat); \
+        } else {                                                                                \
+            sort_index_rows<type, is_float, int64_t>(a, indexer, idx, out, n_rows, row_len, flat); \
+        }                                                                                       \
     }
 
 CUMO_DEF_SORT(int8, int8_t, false)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3599,6 +3599,33 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  # Where each element of a row sits once the row is in order, ties left in the
+  # order they came and NaN last. The kernel's radix sort is stable, so this is
+  # an exact expectation rather than one of several valid answers.
+  def sort_index_expect(view, axis)
+    flat = view.to_a.flatten
+    shape = view.shape
+    strides = shape.each_index.map { |i| shape[(i + 1)..].inject(1, :*) }
+    rank = ->(p) { [flat[p].is_a?(Float) && flat[p].nan? ? 1 : 0, flat[p].is_a?(Float) && flat[p].nan? ? 0 : flat[p]] }
+    want = Array.new(flat.size)
+    flat.each_index.group_by { |p|
+      shape.each_index.reject { |d| axis.include?(d) }.map { |d| (p / strides[d]) % shape[d] }
+    }.each_value do |row|
+      order = row.sort_by.with_index { |p, i| rank.call(p) + [i] }
+      row.each_with_index { |p, i| want[p] = order[i] }
+    end
+    want
+  end
+
+  def assert_sort_index(view, what, axes: nil)
+    axes ||= (0...view.ndim).map { |i| [i] } + [(0...view.ndim).to_a]
+    axes.each do |axis|
+      got = axis.size == view.ndim ? view.sort_index : view.sort_index(axis: axis)
+      assert_equal(sort_index_expect(view, axis), got.to_a.flatten,
+                   "#{what} sort_index axis #{axis.inspect}")
+    end
+  end
+
   test "sort orders every row, whatever the axis and the layout" do
     # The sort ran on the host, one row at a time, behind a device
     # synchronization. The expectations are sorted in Ruby rather than taken
@@ -3649,6 +3676,48 @@ class NArrayTest < Test::Unit::TestCase
 
     assert_equal([1, 2, 3], Cumo::Int32[3, 1, 2].sort.to_a, "smallest case")
     assert_equal([7], Cumo::Int32[7].sort.to_a, "one element")
+  end
+
+  test "sort_index says where every element of a row came from" do
+    # The sort ran on the host, one row at a time, behind a device
+    # synchronization, and it read the array through its own index array, which
+    # the indexer loop cannot address.
+    rows = 12
+    cols = 25
+    n = rows * cols
+    xs = Array.new(n) { |i| ((i * 37) % 101) - 50 }
+    int_types = [Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64, Cumo::UInt8, Cumo::UInt32]
+
+    (int_types + [Cumo::SFloat, Cumo::DFloat]).each do |dtype|
+      vals = dtype == Cumo::UInt8 || dtype == Cumo::UInt32 ? xs.map(&:abs) : xs
+      src = dtype.cast(vals).reshape(rows, cols)
+      assert_sort_index(src, dtype.to_s)
+      assert_sort_index(src[true, 0.step(cols - 1, 3)], "#{dtype} column slice")
+      assert_sort_index(src[(rows - 1).step(0, -1), true], "#{dtype} reversed rows")
+      assert_sort_index(src[[7, 0, 4, 11, 2], true], "#{dtype} index view")
+
+      cube = dtype.cast(vals[0, 2 * 5 * 3]).reshape(2, 5, 3)
+      assert_sort_index(cube, "#{dtype} 3-d", axes: [[0], [1], [2], [0, 1], [1, 2], [0, 1, 2]])
+    end
+
+    # every NaN sorts last whatever its sign, and -0.0 sorts below +0.0
+    nan = Float::NAN
+    neg_nan = Float::INFINITY - Float::INFINITY
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      got = dtype.cast([3.0, nan, 1.0, neg_nan, 2.0]).sort_index.to_a
+      assert_equal([2, 4, 0], got[0, 3], "#{dtype} NaN last")
+      assert_equal([1, 3], got[3, 2].sort, "#{dtype} NaN last")
+
+      assert_equal([1, 2, 0, 3], dtype.cast([0.0, -1.0, -0.0, 1.0]).sort_index.to_a,
+                   "#{dtype} signed zero")
+    end
+
+    # nan:true keeps the host path, and it answers what numo answers there
+    assert_equal([0, 1, 2, 3], Cumo::DFloat[3.0, nan, 1.0, 2.0].sort_index(nan: true).to_a,
+                 "nan:true")
+
+    assert_equal([0], Cumo::Int32[7].sort_index.to_a, "one element")
+    assert_equal([1, 2, 0], Cumo::Int32[3, 1, 2].sort_index.to_a, "smallest case")
   end
 
   test "an RObject loop waits for the kernel that fills an index array" do


### PR DESCRIPTION
## Summary

- Carry the position through the same cub segmented sort that `sort` uses, then read the answer for each position out of the index array `sort_index` already builds.
- Copy an index-backed view before the loop, the way the reductions do.
- `nan:true` keeps the host path, as `sort` does.
- 1M SFloat 115.8 -> 1.69 ms, 4M 542.6 -> 6.10 ms, 1024x1024 along axis 1 75.9 -> 1.86 ms, along axis 0 91.8 -> 2.27 ms, Int32 1024x1024 along axis 1 72.0 -> 1.40 ms.

## Problem

`sort_index` sorted on the host, one row at a time, behind a `cudaDeviceSynchronize`, and it allocated a host buffer of one pointer per element to do it. It was slower than numo on the CPU at every size measured.

The kernel path also has to see plain steps: the indexer loop addresses an array by its steps, and an index array leaves those unset, so an index-backed view read row 0 for every row. `accum.c` already copies in that case and this does the same.

## Note

Ties now answer the lowest position, a radix sort being stable, where the host qsort left them in whatever order it happened to produce. Both are valid answers for `sort_index`; numo's own answer for ties is not stable either.
