### PR TITLE
Fix a sort in place of a view backed by an index array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/sort.c
+++ b/ext/cumo/narray/gen/tmpl/sort.c
@@ -1,4 +1,4 @@
-void cumo_<%=type_name%>_sort_kernel_launch(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat);
+void cumo_<%=type_name%>_sort_kernel_launch(cumo_na_iarray_stridx_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat);
 
 // One call sorts every row, so a loop over many short rows costs no more
 // launches than one long row. nan:true keeps the host path: its comparator
@@ -6,7 +6,7 @@ void cumo_<%=type_name%>_sort_kernel_launch(cumo_na_iarray_t* a, cumo_na_indexer
 static void
 <%=c_iter%>_kernel(cumo_na_loop_t *const lp)
 {
-    cumo_na_iarray_t a = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_stridx_t a = cumo_na_make_iarray_stridx(&lp->args[0]);
     cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
     int64_t row_len = 1;
     int64_t n_rows;
@@ -21,7 +21,7 @@ static void
     // The rows have to be laid out end to end for a segmented sort to address
     // them; anything else is gathered into a buffer of its own first.
     for (i = indexer.ndim; --i >= 0;) {
-        if (a.step[i] != expect) {
+        if (!CUMO_SDX_IS_STRIDE(a.stridx[i]) || CUMO_SDX_GET_STRIDE(a.stridx[i]) != expect) {
             flat = 0;
             break;
         }

--- a/ext/cumo/narray/sort_kernel.cu
+++ b/ext/cumo/narray/sort_kernel.cu
@@ -58,22 +58,33 @@ __global__ void float_key_kernel(const Float* in, typename float_key<Float>::typ
     }
 }
 
+// sort writes its answer back where it read it, so an in-place sort of a view
+// backed by an index array has to address that array; the other two callers
+// hand over an array they copied themselves and never do.
+__device__ static inline char* at(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer) {
+    return cumo_na_iarray_at_dim(a, indexer);
+}
+
+__device__ static inline char* at(cumo_na_iarray_stridx_t* a, cumo_na_indexer_t* indexer) {
+    return cumo_na_iarray_stridx_at_dim(a, indexer);
+}
+
 // Rows that are not laid out end to end are gathered into a buffer of their
 // own, sorted there and put back, which is two passes over the data against
 // one launch per row.
-template <typename T>
-__global__ void gather_kernel(cumo_na_iarray_t a, cumo_na_indexer_t indexer, T* buf) {
+template <typename T, typename Iarray>
+__global__ void gather_kernel(Iarray a, cumo_na_indexer_t indexer, T* buf) {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim(&indexer, i);
-        buf[i] = *(T*)cumo_na_iarray_at_dim(&a, &indexer);
+        buf[i] = *(T*)at(&a, &indexer);
     }
 }
 
-template <typename T>
-__global__ void scatter_kernel(cumo_na_iarray_t a, cumo_na_indexer_t indexer, const T* buf) {
+template <typename T, typename Iarray>
+__global__ void scatter_kernel(Iarray a, cumo_na_indexer_t indexer, const T* buf) {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim(&indexer, i);
-        *(T*)cumo_na_iarray_at_dim(&a, &indexer) = buf[i];
+        *(T*)at(&a, &indexer) = buf[i];
     }
 }
 
@@ -121,7 +132,7 @@ void sort_keys(const Key* kin, Key* kout, int64_t total, int64_t n_rows, int64_t
 }
 
 template <typename T, bool IS_FLOAT>
-void sort_rows(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) {
+void sort_rows(cumo_na_iarray_stridx_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) {
     int64_t total = (int64_t)indexer->total_size;
     if (total == 0) return;
 
@@ -303,7 +314,7 @@ void sort_index_rows(cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, cumo_na_ia
 // points must not instantiate it; the bool picks the branch at compile time.
 #define CUMO_DEF_SORT(name, type, is_float)                                                     \
     extern "C" void cumo_##name##_sort_kernel_launch(                                           \
-        cumo_na_iarray_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) \
+        cumo_na_iarray_stridx_t* a, cumo_na_indexer_t* indexer, int64_t n_rows, int64_t row_len, int flat) \
     {                                                                                           \
         sort_rows<type, is_float>(a, indexer, n_rows, row_len, flat);                           \
     }                                                                                           \

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3655,6 +3655,14 @@ class NArrayTest < Test::Unit::TestCase
       idx = src[[7, 0, 4, 11, 2], true]
       assert_equal(idx.to_a.map { |r| r.map(&:to_i).sort }, ints_of(idx.sort(axis: 1)), "#{dtype} index view")
 
+      # sorted in place there is nowhere but the index array to put the answer
+      fresh = dtype.cast(vals).reshape(rows, cols)
+      fresh[[7, 0, 4, 11, 2], true].inplace.sort(axis: 1)
+      assert_equal(idx.to_a.map { |r| r.map(&:to_i).sort },
+                   ints_of(fresh[[7, 0, 4, 11, 2], true]), "#{dtype} index view in place")
+      assert_equal(ints_of(src[[1, 3, 5, 6, 8, 9, 10], true]),
+                   ints_of(fresh[[1, 3, 5, 6, 8, 9, 10], true]), "#{dtype} rows outside the index view")
+
       # a 3-d shape, and an axis that is neither the first nor the last
       cube = dtype.cast(vals[0, 2 * 5 * 3]).reshape(2, 5, 3)
       want = map_deep(cube.to_a, &:to_i).map { |plane| plane.transpose.map(&:sort).transpose }


### PR DESCRIPTION
## Summary

- Address the array through `cumo_na_iarray_stridx_t`, which carries either a step or an index array per dimension, in the gather and scatter `sort` uses for rows that are not laid out end to end.
- Same speed measured: 1M flat 0.123 -> 0.125 ms, 1024x1024 along axis 1 0.540 -> 0.541 ms, along axis 0 1.674 -> 1.726 ms.

## Problem

```ruby
a = Cumo::SFloat.cast((0...20).map { |i| ((i * 7) % 11) - 5 }).reshape(4, 5)
a[[2, 0, 3, 1], true].inplace.sort(axis: 1)
```

leaves three of the four rows untouched and sorts the fourth into the wrong place. numo answers correctly, and so does cumo's own host path, still reachable as `sort(axis: 1, nan: true)`, so this arrived with #259.

The indexer loop addresses an array by its steps, and a dimension backed by an index array leaves that step unset, so every row read row 0. `median` and `sort_index` copy the input before the loop and never meet it; `sort` cannot, since an in-place sort has to put the answer back where it read it.
