### PR TITLE
Add poly kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl/poly.c
+++ b/ext/cumo/narray/gen/tmpl/poly.c
@@ -1,3 +1,25 @@
+<% unless type_name == 'robject' %>
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* x, cumo_na_iarray_t* coef, int ncoef, cumo_na_iarray_t* z, cumo_na_indexer_t* indexer);
+
+// Horner over every element in one launch. The host loop this replaces ran
+// once per element, each time behind a cudaDeviceSynchronize.
+static void
+<%=c_iter%>_kernel(cumo_na_loop_t *const lp)
+{
+    int i, ncoef = lp->narg - 2;
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+    cumo_na_iarray_t x = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t z = cumo_na_make_iarray(&lp->args[lp->narg - 1]);
+    cumo_na_iarray_t *coef = ALLOCA_N(cumo_na_iarray_t, ncoef > 0 ? ncoef : 1);
+
+    for (i = 0; i < ncoef; ++i) {
+        coef[i] = cumo_na_make_iarray(&lp->args[i + 1]);
+    }
+    <%="cumo_#{c_iter}_kernel_launch"%>(&x, coef, ncoef, &z, &indexer);
+}
+<% end %>
+
+<% if type_name == 'robject' %>
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -16,6 +38,7 @@ static void
     }
     *(dtype*)CUMO_NDL_PTR(lp,lp->narg-1) = y;
 }
+<% end %>
 
 /*
   Calculate polynomial.
@@ -31,7 +54,11 @@ static VALUE
     VALUE *argv;
     volatile VALUE v, a;
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_NO_LOOP, 0, 1, 0, aout };
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>_kernel, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_INDEXER_LOOP, 0, 1, 0, aout };
+    <% end %>
 
     argc = RARRAY_LEN(args);
     ndf.nin = argc+1;

--- a/ext/cumo/narray/gen/tmpl/poly_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/poly_kernel.cu
@@ -1,0 +1,46 @@
+<% unless type_name == 'robject' %>
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t x, cumo_na_iarray_t* coef, int ncoef, cumo_na_iarray_t z, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        int k;
+        dtype xv, y;
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        xv = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&x, &indexer);
+        // No coefficient at all answers x itself, which is what the host loop did
+        y = (ncoef > 0) ? *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&coef[ncoef - 1], &indexer) : xv;
+        for (k = ncoef - 2; k >= 0; --k) {
+            y = m_mul(xv, y);
+            y = m_add(y, *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&coef[k], &indexer));
+        }
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&z, &indexer) = y;
+    }
+}
+<% end %>
+
+// The coefficient count is whatever the caller passed, so the kernel reads the
+// coefficients through a device array rather than a kernel argument.
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* x, cumo_na_iarray_t* coef, int ncoef, cumo_na_iarray_t* z, cumo_na_indexer_t* indexer)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    size_t bytes = sizeof(cumo_na_iarray_t) * (ncoef > 0 ? ncoef : 1);
+    cumo_na_iarray_t* d_coef = (cumo_na_iarray_t*)cumo_cuda_runtime_malloc(bytes);
+
+    if (ncoef > 0) {
+        cudaMemcpyAsync(d_coef, coef, sizeof(cumo_na_iarray_t) * ncoef, cudaMemcpyHostToDevice, 0);
+    }
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*x, d_coef, ncoef, *z, *indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*x, d_coef, ncoef, *z, *indexer);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+    cumo_cuda_runtime_free((char*)d_coef);
+}
+<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3686,6 +3686,15 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([7], Cumo::Int32[7].sort.to_a, "one element")
   end
 
+  # Horner from Ruby, so the expectation does not come from another cumo call.
+  # A coefficient is either one number or a value per element.
+  def poly_expect(values, coefs)
+    values.each_with_index.map do |x, i|
+      cs = coefs.map { |c| c.is_a?(Array) ? c[i] : c }
+      cs.empty? ? x : cs.reverse.reduce { |y, c| y * x + c }
+    end
+  end
+
   test "sort_index says where every element of a row came from" do
     # The sort ran on the host, one row at a time, behind a device
     # synchronization, and it read the array through its own index array, which
@@ -3726,6 +3735,53 @@ class NArrayTest < Test::Unit::TestCase
 
     assert_equal([0], Cumo::Int32[7].sort_index.to_a, "one element")
     assert_equal([1, 2, 0], Cumo::Int32[3, 1, 2].sort_index.to_a, "smallest case")
+  end
+
+  test "poly evaluates every element, whatever the coefficients and the layout" do
+    # poly ran with CUMO_NO_LOOP, so ndloop called the iterator once per
+    # element and each call synchronized with the device.
+    rows = 6
+    cols = 10
+    small = Array.new(rows * cols) { |i| (i * 13) % 3 }
+    wide = Array.new(rows * cols) { |i| (i * 13) % 5 }
+
+    # every dtype, with values an 8-bit result still holds
+    [Cumo::Int8, Cumo::Int32, Cumo::UInt8, Cumo::UInt32,
+     Cumo::SFloat, Cumo::DFloat, Cumo::SComplex, Cumo::DComplex, Cumo::RObject].each do |dtype|
+      src = dtype.cast(small).reshape(rows, cols)
+      assert_equal(poly_expect(small, []), src.poly.to_a.flatten, "#{dtype} no coefficient")
+      assert_equal(poly_expect(small, [3]), src.poly(3).to_a.flatten, "#{dtype} one coefficient")
+      assert_equal(poly_expect(small, [1, 2, 3]), src.poly(1, 2, 3).to_a.flatten, "#{dtype} three")
+      assert_equal(poly_expect(small, [small, 2]), src.poly(src, 2).to_a.flatten,
+                   "#{dtype} a coefficient that varies per element")
+    end
+
+    [Cumo::Int32, Cumo::Int64, Cumo::SFloat, Cumo::DFloat, Cumo::DComplex].each do |dtype|
+      src = dtype.cast(wide).reshape(rows, cols)
+      coefs = [1, 2, 3, 4, 5, 6]
+      assert_equal(poly_expect(wide, coefs), src.poly(*coefs).to_a.flatten, "#{dtype} six coefficients")
+
+      view = src[true, 0.step(cols - 1, 3)]
+      assert_equal(poly_expect(view.to_a.flatten, [1, 2, 3]), view.poly(1, 2, 3).to_a.flatten,
+                   "#{dtype} column slice")
+
+      rev = src[(rows - 1).step(0, -1), true]
+      assert_equal(poly_expect(rev.to_a.flatten, [1, 2, 3]), rev.poly(1, 2, 3).to_a.flatten,
+                   "#{dtype} reversed rows")
+
+      idx = src[[3, 0, 5, 1], true]
+      assert_equal(poly_expect(idx.to_a.flatten, [1, 2, 3]), idx.poly(1, 2, 3).to_a.flatten,
+                   "#{dtype} index view")
+      assert_equal(poly_expect(idx.to_a.flatten, [idx.to_a.flatten, 2]), idx.poly(idx, 2).to_a.flatten,
+                   "#{dtype} index view with a coefficient of its own")
+
+      # a shape past the dimension the indexer has a specialized accessor for
+      deep = dtype.cast(wide[0, 2 * 2 * 2 * 2 * 2]).reshape(2, 2, 2, 2, 2)
+      assert_equal(poly_expect(deep.to_a.flatten, [1, 2, 3]), deep.poly(1, 2, 3).to_a.flatten,
+                   "#{dtype} 5-d")
+    end
+
+    assert_equal([17], Cumo::Int32[2].poly(1, 2, 3).to_a, "smallest case")
   end
 
   test "an RObject loop waits for the kernel that fills an index array" do


### PR DESCRIPTION
## Summary

- Evaluate Horner over the whole array in one launch. The coefficient count is whatever the caller passed, so the coefficients reach the kernel as a device array of indexed operands, which also lets a coefficient vary per element as `poly` allows.
- Keep the host loop for `RObject`.
- 2^20 DFloat with 3 coefficients 163.8 -> 0.021 ms, 2^22 636.5 -> 0.181 ms, 1024x1024 column slice 79.6 -> 0.014 ms. numo on the CPU answers the same three in 7.4 / 38.4 / 3.8 ms.

## Problem

`poly` ran with `CUMO_NO_LOOP`, so ndloop called the iterator once per element and every one of those calls ran a `cudaDeviceSynchronize`. It was 21x slower than numo on the CPU, the only method left in the checklist that lost by an order of magnitude.

## Note

The kernel emits the indexer's per-rank accessors (`cumo_na_indexer_set_dim0`..`dim4`) the way the other kernel templates do. With the generic accessor alone it ran at 16 GB/s against the 385 GB/s the specialized ones reach: the generic one divides and takes a remainder per element, and a 64-bit integer division is emulated on the device.
