### PR TITLE
Add Bit#fill kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/fill.c
+++ b/ext/cumo/narray/gen/tmpl_bit/fill.c
@@ -1,18 +1,20 @@
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a3, CUMO_BIT_DIGIT y, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, CUMO_BIT_DIGIT y);
+
+static int
+<%=c_iter%>_is_flat(cumo_na_bit_iarray_stridx_t* a, cumo_na_indexer_t* indexer)
+{
+    return indexer->ndim == 1 &&
+        CUMO_SDX_IS_STRIDE(a->stridx[0]) && CUMO_SDX_GET_STRIDE(a->stridx[0]) == 1;
+}
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  n;
-    size_t  p3;
-    ssize_t s3;
-    size_t *idx3;
-    int     len;
-    CUMO_BIT_DIGIT *a3;
-    CUMO_BIT_DIGIT  y;
+    cumo_na_bit_iarray_stridx_t a3 = cumo_na_make_bit_iarray_stridx(&lp->args[0]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+    CUMO_BIT_DIGIT y;
     VALUE x = lp->option;
-
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     if (x==INT2FIX(0) || x==Qfalse) {
         y = 0;
@@ -23,32 +25,14 @@ static void
         rb_raise(rb_eArgError, "invalid value for Bit");
     }
 
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR_BIT_IDX(lp, 0, a3, p3, s3, idx3);
-    if (idx3) {
-        y = y&1;
-        for (; n--;) {
-            CUMO_STORE_BIT(a3, p3+*idx3, y); idx3++;
-        }
-    } else if (s3!=1) {
-        y = y&1;
-        for (; n--;) {
-            CUMO_STORE_BIT(a3, p3, y); p3+=s3;
-        }
+    // A word at a time is worth a separate kernel, but it needs the elements
+    // laid out end to end, which after the loop is contracted means one
+    // dimension of step one.
+    if (<%=c_iter%>_is_flat(&a3,&indexer)) {
+        <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(
+            a3.ptr + a3.pos / CUMO_NB, a3.pos % CUMO_NB, indexer.total_size, y);
     } else {
-        if (p3>0 || n<CUMO_NB) {
-            len = CUMO_NB - p3;
-            if ((int)n<len) len=n;
-            *a3 = (y & (CUMO_SLB(len)<<p3)) | (*a3 & ~(CUMO_SLB(len)<<p3));
-            a3++;
-            n -= len;
-        }
-        for (; n>=CUMO_NB; n-=CUMO_NB) {
-            *(a3++) = y;
-        }
-        if (n>0) {
-            *a3 = (y & CUMO_SLB(n)) | (*a3 & CUMO_BALL<<n);
-        }
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a3, y & 1, &indexer);
     }
 }
 
@@ -62,7 +46,7 @@ static VALUE
 <%=c_func(1)%>(VALUE self, VALUE val)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{cumo_sym_option}};
-    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 2,0, ain,0};
+    cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2,0, ain,0};
 
     cumo_na_ndloop(&ndf, 2, self, val);
     return self;

--- a/ext/cumo/narray/gen/tmpl_bit/fill_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/fill_kernel.cu
@@ -1,0 +1,42 @@
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a3, CUMO_BIT_DIGIT y, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), y);
+    }
+}
+<% end %>
+
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3, CUMO_BIT_DIGIT y)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        cumo_bit_store_word(a3, w, y, p3, n);
+    }
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a3, CUMO_BIT_DIGIT y, cumo_na_indexer_t* indexer)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a3,y,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a3,y,*indexer);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, CUMO_BIT_DIGIT y)
+{
+    uint64_t w3 = (p3 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w3);
+    size_t block_dim = cumo_get_block_dim(w3);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(a3,p3,n,w3,y);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3395,6 +3395,18 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  def bit_list(narray)
+    narray.to_a.flatten.map(&:to_i)
+  end
+
+  # An array of length total with the named positions set, so a fill can be
+  # checked without asking another cumo call what it should be
+  def bits_set(total, positions, value = 1)
+    a = Array.new(total, value ^ 1)
+    positions.each { |i| a[i] = value }
+    a
+  end
+
   test "Bit results reach every element of a view they cannot flatten" do
     # A Bit element is one bit, so its position and steps are bit counts and
     # the byte indexer cannot address it. Comparisons, the isnan family and the
@@ -3499,6 +3511,54 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(a.transpose.copy.gt(0).to_a.flatten, a.transpose.gt(0).to_a.flatten)
     bd = Cumo::Int32.cast(Array.new(n) { |i| i % 3 }).reshape(*deep).gt(1)
     assert_equal(bd.transpose.to_a.flatten.map { |u| u ^ 1 }, (~bd.transpose).to_a.flatten)
+  end
+
+  test "Bit#fill reaches the bits of a view and no others" do
+    # fill was the last host loop that a plain Cumo::Bit.new(n).fill(1) ran
+    # into. It synchronized with the device and wrote the words from the CPU,
+    # which left the pages there for the next kernel to fault back.
+    [1, 31, 32, 33, 70, 200].each do |n|
+      a = Cumo::Bit.new(n).fill(0)
+      a.fill(1)
+      assert_equal(Array.new(n, 1), bit_list(a), "whole #{n}")
+      a.fill(0)
+      assert_equal(Array.new(n, 0), bit_list(a), "whole #{n} back to zero")
+    end
+
+    # a run that starts and ends inside a word, so the words at either end are
+    # shared with elements the fill must not touch
+    [[3, 40], [31, 33], [32, 64], [0, 99], [63, 65]].each do |b, e|
+      a = Cumo::Bit.new(100).fill(0)
+      a[b..e].fill(1)
+      assert_equal(bits_set(100, (b..e).to_a), bit_list(a), "#{b}..#{e}")
+
+      a = Cumo::Bit.new(100).fill(1)
+      a[b..e].fill(0)
+      assert_equal(bits_set(100, (b..e).to_a, 0), bit_list(a), "#{b}..#{e} to zero")
+    end
+
+    a = Cumo::Bit.new(8, 9).fill(0)
+    a[true, 0.step(8, 3)].fill(1)
+    assert_equal(bits_set(72, (0...8).flat_map { |r| [0, 3, 6].map { |c| r * 9 + c } }),
+                 bit_list(a), "column slice")
+
+    # rows of an index view share a word with rows outside it
+    rows = [3, 0, 5]
+    a = Cumo::Bit.new(8, 9).fill(0)
+    a[rows, true].fill(1)
+    assert_equal(bits_set(72, rows.flat_map { |r| (0...9).map { |c| r * 9 + c } }),
+                 bit_list(a), "index view")
+
+    a = Cumo::Bit.new(70).fill(0)
+    a[60.step(10, -1)].fill(1)
+    assert_equal(bits_set(70, (10..60).to_a), bit_list(a), "reversed")
+
+    a = Cumo::Bit.new(3, 5, 7).fill(0)
+    a[true, 2, true].fill(1)
+    assert_equal(bits_set(105, (0...3).flat_map { |p| (0...7).map { |c| p * 35 + 14 + c } }),
+                 bit_list(a), "3-d row of every plane")
+
+    assert_raise(ArgumentError) { Cumo::Bit.new(4).fill(2) }
   end
 
   test "storing an Array of narrays zeroes the rest of each row" do


### PR DESCRIPTION
## Summary

- Write a word at a time when the elements are laid out end to end, and bit by bit otherwise, the way `Cumo::Bit`'s unary operators already do. The words at either end of a run are shared with elements the fill must not touch, so `cumo_bit_store_word` masks them.
- 2^24 `fill(1)` 0.0241 -> 0.0035 ms, a column slice of 4096x4096 2.658 -> 0.029 ms, an index view of the same 0.990 -> 0.377 ms.
- The first GPU read after a fill drops from 0.689 to 0.237 ms, which is the steady-state cost.

## Problem

`Cumo::Bit#fill` was the last host loop a plain `Cumo::Bit.new(n).fill(1)` ran into, and `tmpl_bit/fill.c` still carried the `TODO(sonots): CUDA kernelize` that says so.

Its standalone cost looked fine — the host memset of a 2 MB Bit array beats numo — but it synchronized with the device and wrote the words from the CPU, which leaves the pages there for the next kernel to fault back. That migration is what the third number above measures.
