### PR TITLE
Fix a store that reads an index array before the kernel fills it

### DIFF
--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1439,6 +1439,20 @@ loop_is_using_idx(cumo_na_md_loop_t *lp)
     return false;
 }
 
+// The md-loops below find each position by reading an index array on the host,
+// whatever memory the data it indexes lives in, and a kernel filled that array.
+// ndloop_sync_user_index covers the dimensions the user function walks; these
+// are the ones ndloop walks itself.
+static void
+ndloop_sync_md_index(cumo_na_md_loop_t *lp)
+{
+    if (!loop_is_using_idx(lp)) {
+        return;
+    }
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop", "any");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+}
+
 static void
 loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp);
 
@@ -1532,6 +1546,7 @@ loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
         rb_bug("bug? lp->ndim = %d\n", lp->ndim);
     }
 
+    ndloop_sync_md_index(lp);
     ndloop_sync_user_index(lp);
 
     if (nd==0 || CUMO_NDF_TEST(nf,CUMO_NDF_INDEXER_LOOP)) {
@@ -1741,6 +1756,8 @@ loop_inspect(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
     cumo_na_text_func_t func = (cumo_na_text_func_t)(nf->func);
     VALUE buf, opt;
 
+    ndloop_sync_md_index(lp);
+
     nd = lp->ndim;
     buf = lp->loop_opt;
     //opt = *(VALUE*)(lp->user.opt_ptr);
@@ -1872,6 +1889,10 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
     ndloop_set_stepidx(lp, 1, a, dim_map, CUMO_NDL_READ);
     LARG(lp,1).shape = &(na->shape[na->ndim-1]);
 
+    // The sub-narray binds its own index array here, after the entry point
+    // looked, so the wait for the kernel that filled it belongs here too.
+    ndloop_sync_md_index(lp);
+
     // loop body
     for (i=i0;;) {
         LARG(lp,1).value = Qtrue;
@@ -1909,6 +1930,8 @@ loop_store_rarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
     int     i;
     VALUE  *a;
     int nd = lp->ndim;
+
+    ndloop_sync_md_index(lp);
 
     // counter
     c = ALLOCA_N(size_t, nd+1);
@@ -2023,6 +2046,8 @@ loop_narray_to_rarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
     VALUE *a;
     volatile VALUE a0;
 
+    ndloop_sync_md_index(lp);
+
     // alloc counter
     c = ALLOCA_N(size_t, nd+1);
     for (i=0; i<=nd; i++) c[i]=0;
@@ -2099,6 +2124,8 @@ loop_narray_with_index(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
     if (lp->n[0] == 0) { // empty array
         return;
     }
+
+    ndloop_sync_md_index(lp);
 
     // pass total ndim to iterator
     lp->user.ndim += nd;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3844,6 +3844,48 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([17], Cumo::Int32[2].poly(1, 2, 3).to_a, "smallest case")
   end
 
+  test "a store from a Ruby Array waits for the kernel that fills an index array" do
+    # ndloop finds each row of an index-backed view by reading its index array
+    # on the host, and a kernel writes that array. Without the wait the store
+    # read whatever the memory pool had left there, and every row of
+    # a[[2, 1], true] landed on row 0.
+    rows = 3
+    cols = 5
+    warm = lambda do
+      3.times do
+        x = Cumo::Int32.zeros(rows, cols)
+        x[[0], true].store([[9] * cols])
+      end
+    end
+    values = [[1] * cols, [2] * cols]
+    want = [[0] * cols, [2] * cols, [1] * cols]
+
+    warm.call
+    a = Cumo::Int32.zeros(rows, cols)
+    a[[2, 1], true].store(values)
+    assert_equal(want, a.to_a, "store")
+
+    warm.call
+    a = Cumo::Int32.zeros(rows, cols)
+    a[[2, 1], true] = values
+    assert_equal(want, a.to_a, "assignment")
+
+    warm.call
+    b = Cumo::Bit.new(rows, cols).fill(0)
+    b[[2, 1], true].store([[1] * cols, [0] * cols])
+    assert_equal([[0] * cols, [0] * cols, [1] * cols], b.to_a.map { |r| r.map(&:to_i) }, "Bit")
+
+    # a sub-narray of the Array binds its own index array inside the loop,
+    # after the entry point has already looked for one
+    n = 40
+    warm.call
+    m = Cumo::Int32.new(4, n).seq
+    d = Cumo::Int32.zeros(2, 2, n)
+    d.store([m[[3, 1], true], m[[0, 2], true]])
+    row = ->(k) { (k * n...(k + 1) * n).to_a }
+    assert_equal([[row.call(3), row.call(1)], [row.call(0), row.call(2)]], d.to_a, "sub-narray")
+  end
+
   test "an RObject loop waits for the kernel that fills an index array" do
     # Index arrays are filled by a kernel. Every dtype but RObject hands the
     # index on to a kernel of its own, which the stream already orders, but


### PR DESCRIPTION
## Summary

- Wait for the kernel before ndloop's own md-loop reads an index array, in the five loops that walk one on the host: `loop_narray`, `loop_inspect`, `loop_store_rarray`, `loop_narray_to_rarray` and `loop_narray_with_index`.
- A sub-narray of the Ruby Array binds its own index array inside `loop_store_subnarray`, after the entry point has already looked, so the same wait belongs there too.
- No measurable cost: the wait only happens when an index array is in the loop, and every path that has one already walks it on the host. `a[idx, true] + 1`, `.sum(axis: 1)`, `.copy`, `= 0.0`, `= b` and `a + 1` all measure the same before and after.

## Problem

```ruby
x = Cumo::Int32.zeros(3, 5); x[[0], true].store([[9] * 5])   # any earlier index store will do
a = Cumo::Int32.zeros(3, 5)
a[[2, 1], true].store([[1] * 5, [2] * 5])
# expected row0=0 row1=2 row2=1
# actual   row0=1 row1=2 row2=0   -- the index is ignored and the rows land on 0, 1
```

Reproduces on master `110fa69` for `Int32`, `DFloat`, `UInt8` and `Bit`, and at 3x65 the values themselves come out wrong (`row0=[513, 512]`, a partly written word). `a[[2, 1], true] = array` goes the same way. Assigning an NArray or a scalar, and every read, are unaffected: those reach a kernel that indexes for itself.

The index array of `a[[2, 1], true]` is written by a kernel, but ndloop's md-loop reads it on the host to find each row. What it read was whatever the memory pool had left there.

`ndloop_sync_user_index` does not cover this. It looks at `LARG(lp,j).iter`, which starts at `lp->ndim` — the dimensions the user function walks — while the md-loop dereferences `LITER(lp,i,j).idx` below that. It also skips when the data is device memory, which is right for a kernel that does its own indexing and wrong for a host loop that walks the index whatever the data is.

The second half is a separate case: `loop_is_using_idx` is false at the top of `loop_store_rarray` when only a source sub-narray has an index, because those iterator slots are bound later, by `ndloop_set_stepidx` inside `loop_store_subnarray`.

```ruby
m = Cumo::Int32.new(4, 40).seq
d = Cumo::Int32.zeros(2, 2, 40)
d.store([m[[3, 1], true], m[[0, 2], true]])   # every row came out as row 0
```

## Note

The second case was pointed out by the session working on numo-narray-alt, from reading this tree; the reproduction above is mine.
