### PR TITLE
Add Bit#store kernel for a Ruby Array

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array.c
@@ -1,3 +1,12 @@
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, CUMO_BIT_DIGIT* z, uint64_t n);
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, CUMO_BIT_DIGIT* z, uint64_t n);
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT* z, uint64_t n);
+void <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, CUMO_BIT_DIGIT z, uint64_t n);
+void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, CUMO_BIT_DIGIT z, uint64_t n);
+
+#define <%=c_iter%>_set(buf, i, z)                                      \
+    if ((z) & 1) { (buf)[(i) / CUMO_NB] |= (CUMO_BIT_DIGIT)1 << ((i) % CUMO_NB); }
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -6,16 +15,17 @@ static void
     VALUE  v1;
     CUMO_BIT_DIGIT *a1;
     size_t p1;
-    size_t s1, *idx1;
+    // Every other Bit iterator declares the step signed, which is what tells
+    // CUMO_INIT_PTR_BIT_IDX to leave the position alone for a view that walks
+    // backwards. Unsigned here, it normalized the pointer to the first word of
+    // the view and then walked below it.
+    ssize_t s1;
+    size_t *idx1;
     VALUE  x;
     double y;
     CUMO_BIT_DIGIT z;
     size_t len, c;
     double beg, step;
-
-    // TODO(sonots): CUDA kernelize
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
@@ -34,14 +44,6 @@ static void
             CUMO_NDL_CNT(lp) = i;
             iter_<%=type_name%>_store_<%=type_name%>(lp);
             CUMO_NDL_CNT(lp) = n;
-            // The tail below writes the rest from the host, and the word at the
-            // boundary is shared with the elements the kernel just stored.
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-            if (idx1) {
-                idx1 += i;
-            } else {
-                p1 += s1 * i;
-            }
         }
         goto loop_end;
     }
@@ -57,7 +59,18 @@ static void
         n1 = 1;
     }
 
-    if (idx1) {
+    {
+        // Reading a Ruby Array is host work whatever happens, so the bits are
+        // packed into a staging buffer here and one copy carries them over.
+        //
+        // The staging buffer is held by a Ruby object rather than a plain local:
+        // the conversion loop below raises for a value which is not a number,
+        // and ndloop has no way to free a buffer it does not know about.
+        VALUE  buf;
+        uint64_t nw = (n + CUMO_NB - 1) / CUMO_NB;
+        CUMO_BIT_DIGIT* host_z = RB_ALLOCV_N(CUMO_BIT_DIGIT, buf, nw ? nw : 1);
+
+        memset(host_z, 0, sizeof(CUMO_BIT_DIGIT) * (nw ? nw : 1));
         for (i=i1=0; i1<n1 && i<n; i1++) {
             if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
@@ -69,48 +82,57 @@ static void
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;
                     z = m_from_double(y);
-                    CUMO_STORE_BIT(a1, p1+*idx1, z); idx1++;
+                    <%=c_iter%>_set(host_z, i, z);
                 }
             }
             else if (TYPE(x) != T_ARRAY) {
                 if (x == Qnil) x = INT2FIX(0);
                 z = m_num_to_data(x);
-                CUMO_STORE_BIT(a1, p1+*idx1, z); idx1++;
+                <%=c_iter%>_set(host_z, i, z);
                 i++;
             }
         }
-    } else {
-        for (i=i1=0; i1<n1 && i<n; i1++) {
-            if (!cumo_na_store_rary_fetch(v1, i1, &x)) break;
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
-#else
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
-#endif
-                cumo_na_step_sequence(x,&len,&beg,&step);
-                for (c=0; c<len && i<n; c++,i++) {
-                    y = beg + step * c;
-                    z = m_from_double(y);
-                    CUMO_STORE_BIT(a1, p1, z); p1+=s1;
+
+        // A run that starts on a word and ends on one owns every word it
+        // covers, so it goes straight over with no staging buffer of its own.
+        if (!idx1 && s1 == 1 && p1 == 0 && i % CUMO_NB == 0) {
+            cumo_cuda_runtime_check_status(
+                cudaMemcpyAsync(a1,host_z,sizeof(CUMO_BIT_DIGIT)*(i/CUMO_NB),cudaMemcpyHostToDevice,0));
+        } else {
+            uint64_t iw = (i + CUMO_NB - 1) / CUMO_NB;
+            CUMO_BIT_DIGIT* device_z =
+                (CUMO_BIT_DIGIT*)cumo_cuda_runtime_malloc(sizeof(CUMO_BIT_DIGIT) * (iw ? iw : 1));
+            cudaError_t status =
+                cudaMemcpyAsync(device_z,host_z,sizeof(CUMO_BIT_DIGIT)*iw,cudaMemcpyHostToDevice,0);
+            if (status == 0 && i > 0) {
+                if (idx1) {
+                    <%="cumo_#{c_iter}_index_kernel_launch"%>(a1,p1,idx1,device_z,i);
+                } else if (s1 == 1) {
+                    <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(a1,p1,device_z,i);
+                } else {
+                    <%="cumo_#{c_iter}_stride_kernel_launch"%>(a1,p1,s1,device_z,i);
                 }
+                // The kernel reads device_z, so wait for it before giving the
+                // buffer back. The memory pool hands a freed chunk straight out
+                // again, and a host write into that managed memory does not wait
+                // for the stream, so the kernel would read the new contents.
+                status = cudaStreamSynchronize(0);
             }
-            else if (TYPE(x) != T_ARRAY) {
-                z = m_num_to_data(x);
-                CUMO_STORE_BIT(a1, p1, z); p1+=s1;
-                i++;
-            }
+            cumo_cuda_runtime_free((void*)device_z);
+            cumo_cuda_runtime_check_status(status);
         }
+        RB_ALLOCV_END(buf);
     }
 
  loop_end:
     z = m_zero;
-    if (idx1) {
-        for (; i<n; i++) {
-            CUMO_STORE_BIT(a1, p1+*idx1, z); idx1++;
-        }
-    } else {
-        for (; i<n; i++) {
-            CUMO_STORE_BIT(a1, p1, z); p1+=s1;
+    // i may exceed n when the sub-narray is longer than the destination;
+    // n-i would then wrap around as size_t.
+    if (i < n) {
+        if (idx1) {
+            <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(a1,p1,idx1+i,z,n-i);
+        } else {
+            <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(a1,p1+s1*i,s1,z,n-i);
         }
     }
 }

--- a/ext/cumo/narray/gen/tmpl_bit/store_array_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array_kernel.cu
@@ -1,0 +1,89 @@
+// Bit i of the packed buffer the host filled
+__device__ static inline CUMO_BIT_DIGIT
+<%="cumo_#{c_iter}_bit"%>(const CUMO_BIT_DIGIT* z, uint64_t i)
+{
+    return (z[i / CUMO_NB] >> (i % CUMO_NB)) & 1u;
+}
+
+__global__ void <%="cumo_#{c_iter}_index_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, const CUMO_BIT_DIGIT* z, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT y = <%="cumo_#{c_iter}_bit"%>(z, i);
+        CUMO_STORE_BIT(a1, p1 + idx1[i], y);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, const CUMO_BIT_DIGIT* z, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT y = <%="cumo_#{c_iter}_bit"%>(z, i);
+        CUMO_STORE_BIT(a1, p1 + s1 * i, y);
+    }
+}
+
+// The staging buffer starts at bit 0, so the destination's own offset is the
+// only shift between the two, and the words at either end of the run are
+// shared with elements the store must not touch.
+__global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, const CUMO_BIT_DIGIT* z, uint64_t nz, uint64_t n, uint64_t w1)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w1; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_gather_word(z, -(ssize_t)p1, nz, w);
+        cumo_bit_store_word(a1, w, x, p1, n);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_index_scalar_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, CUMO_BIT_DIGIT z, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_STORE_BIT(a1, p1 + idx1[i], z);
+    }
+}
+
+__global__ void <%="cumo_#{c_iter}_stride_scalar_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, CUMO_BIT_DIGIT z, uint64_t n)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+        CUMO_STORE_BIT(a1, p1 + s1 * i, z);
+    }
+}
+
+void <%="cumo_#{c_iter}_index_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, CUMO_BIT_DIGIT* z, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(a1,p1,idx1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_stride_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, CUMO_BIT_DIGIT* z, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_contiguous_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, CUMO_BIT_DIGIT* z, uint64_t n)
+{
+    uint64_t nz = (n + CUMO_NB - 1) / CUMO_NB;
+    uint64_t w1 = (p1 + n + CUMO_NB - 1) / CUMO_NB;
+    size_t grid_dim = cumo_get_grid_dim(w1);
+    size_t block_dim = cumo_get_block_dim(w1);
+    <%="cumo_#{c_iter}_contiguous_kernel"%><<<grid_dim, block_dim>>>(a1,p1,z,nz,n,w1);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_index_scalar_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, size_t *idx1, CUMO_BIT_DIGIT z, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_index_scalar_kernel"%><<<grid_dim, block_dim>>>(a1,p1,idx1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_stride_scalar_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, CUMO_BIT_DIGIT z, uint64_t n)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_scalar_kernel"%><<<grid_dim, block_dim>>>(a1,p1,s1,z,n);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3513,6 +3513,104 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(bd.transpose.to_a.flatten.map { |u| u ^ 1 }, (~bd.transpose).to_a.flatten)
   end
 
+  test "Bit stores a Ruby Array into the bits of a view and no others" do
+    # The store walked the bits from the host behind a device synchronization.
+    # It also declared the step unsigned, which stopped CUMO_INIT_PTR_BIT_IDX
+    # from leaving the position alone for a view that walks backwards, so a
+    # reversed view starting past the first word walked below the array.
+    [1, 31, 32, 33, 64, 65, 100].each do |n|
+      vals = Array.new(n) { |i| (i * 7) % 3 == 0 ? 1 : 0 }
+      assert_equal(vals, bit_list(Cumo::Bit.cast(vals)), "cast #{n}")
+
+      a = Cumo::Bit.new(n).fill(1)
+      a.store(vals[0, n / 2])
+      assert_equal(vals[0, n / 2] + Array.new(n - n / 2, 0), bit_list(a), "source shorter than #{n}")
+
+      a = Cumo::Bit.new(n).fill(0)
+      a.store(vals + vals)
+      assert_equal(vals, bit_list(a), "source longer than #{n}")
+    end
+
+    # a run that starts and ends inside a word
+    # the last two are a whole number of words that does not start on one, the
+    # shape the word-at-a-time path must not take
+    [[3, 40], [31, 33], [32, 64], [0, 99], [63, 65], [3, 34], [33, 96]].each do |b, e|
+      vals = Array.new(e - b + 1) { |i| i % 2 }
+      a = Cumo::Bit.new(100).fill(0)
+      a[b..e].store(vals)
+      want = Array.new(100, 0)
+      vals.each_with_index { |v, i| want[b + i] = v }
+      assert_equal(want, bit_list(a), "#{b}..#{e}")
+    end
+
+    a = Cumo::Bit.new(8, 9).fill(0)
+    a[true, 0.step(8, 3)].store(Array.new(8) { [1, 0, 1] })
+    assert_equal(bits_set(72, (0...8).flat_map { |r| [r * 9, r * 9 + 6] }), bit_list(a), "column slice")
+
+    rows = [3, 0, 5]
+    a = Cumo::Bit.new(8, 9).fill(0)
+    a[rows, true].store(rows.map { Array.new(9, 1) })
+    assert_equal(bits_set(72, rows.flat_map { |r| (0...9).map { |j| r * 9 + j } }), bit_list(a), "index view")
+
+    # a reversed view whose first bit is past the first word
+    [10, 33, 70, 200].each do |n|
+      vals = Array.new(n) { |i| i % 4 == 0 ? 1 : 0 }
+      a = Cumo::Bit.new(n).fill(0)
+      a[(n - 1).step(0, -1)].store(vals)
+      want = Array.new(n)
+      vals.each_with_index { |v, i| want[n - 1 - i] = v }
+      assert_equal(want, bit_list(a), "reversed #{n}")
+    end
+
+    a = Cumo::Bit.new(70).fill(0)
+    a[69.step(0, -3)].store(Array.new(24) { |i| i % 2 })
+    want = Array.new(70, 0)
+    24.times { |i| want[69 - i * 3] = i % 2 }
+    assert_equal(want, bit_list(a), "reversed with a step")
+
+    # a Range element expands, and what is left of the row is zeroed
+    a = Cumo::Bit.new(8).fill(1)
+    a.store([(0..3)])
+    assert_equal([0, 1, 1, 1, 0, 0, 0, 0], bit_list(a), "Range")
+
+    a = Cumo::Bit.new(6).fill(1)
+    a.store([1, nil, 1])
+    assert_equal([1, 0, 1, 0, 0, 0], bit_list(a), "nil")
+
+    a = Cumo::Bit.new(8).fill(1)
+    a.store([])
+    assert_equal(Array.new(8, 0), bit_list(a), "empty")
+
+    # an element of the Array that is a narray of its own
+    a = Cumo::Bit.new(2, 10).fill(1)
+    a.store([Cumo::Bit.cast([1, 0, 1]), Cumo::Bit.cast([0, 1])])
+    assert_equal([1, 0, 1] + Array.new(7, 0) + [0, 1] + Array.new(8, 0), bit_list(a), "sub-narray")
+
+    # an index array on the innermost dimension, which the loop hands to the
+    # store itself rather than walking outside it
+    order = [7, 2, 5, 0, 8]
+    a = Cumo::Bit.new(3, 9).fill(0)
+    a[true, order].store(Array.new(3) { |r| Array.new(order.size) { |j| (r + j) % 2 } })
+    want = Array.new(27, 0)
+    3.times { |r| order.each_with_index { |col, j| want[r * 9 + col] = (r + j) % 2 } }
+    assert_equal(want, bit_list(a), "index on the innermost axis")
+
+    a = Cumo::Bit.new(3, 9).fill(1)
+    a[true, order].store(Array.new(3) { [1, 0] })
+    want = Array.new(27, 1)
+    3.times { |r| order.each_with_index { |col, j| want[r * 9 + col] = (j < 2 ? [1, 0][j] : 0) } }
+    assert_equal(want, bit_list(a), "index on the innermost axis, rows shorter than it")
+
+    # the zero fill of a row shorter than the destination goes through the
+    # index array as well
+    a = Cumo::Bit.new(8, 9).fill(1)
+    a[[3, 0], true].store([[1, 0, 1], [0, 1]])
+    want = Array.new(72, 1)
+    [1, 0, 1, 0, 0, 0, 0, 0, 0].each_with_index { |v, j| want[3 * 9 + j] = v }
+    [0, 1, 0, 0, 0, 0, 0, 0, 0].each_with_index { |v, j| want[j] = v }
+    assert_equal(want, bit_list(a), "index view with rows shorter than the destination")
+  end
+
   test "Bit#fill reaches the bits of a view and no others" do
     # fill was the last host loop that a plain Cumo::Bit.new(n).fill(1) ran
     # into. It synchronized with the device and wrote the words from the CPU,


### PR DESCRIPTION
## Summary

- Pack the bits into a staging buffer on the host — reading a Ruby Array is host work whatever happens — and carry them over with one copy, then write them from a kernel: a word at a time for a contiguous run, bit by bit through the step or the index array otherwise. A run that both starts and ends on a word goes straight into the destination with no staging buffer of its own.
- Declare the step signed. Every other Bit iterator does, and it is what tells `CUMO_INIT_PTR_BIT_IDX` to leave the position alone for a view that walks backwards.
- The zero fill of what the source did not reach becomes a kernel too, so the synchronization the sub-narray branch needed before it is gone.

## Problem

`tmpl_bit/store_array.c` still carried the `TODO(sonots): CUDA kernelize` and walked the bits from the host behind a `cudaDeviceSynchronize`. It was the last Bit template to do so.

Unsigned, the step made `CUMO_INIT_PTR_BIT_IDX` normalize the pointer to the first word of the view and then walk below it, so a reversed view starting past bit 32 was a **SEGV on master**:

```ruby
a = Cumo::Bit.new(70).fill(0)
a[69.step(0, -1)].store(Array.new(70, 1))   # master: segmentation fault in store_array.c:124
```

## Note

Measured on an RTX 5070 Ti Laptop. `Cumo::Bit.cast(array)` is unchanged at 19.3 ms for 2^20 elements and 0.079 ms for 2^12 — walking the Ruby Array is what it costs, and no kernel can help with that. What changes is what the store leaves behind: the first GPU read after one drops from 0.491 to 0.029 ms, the pages no longer having been dragged to the CPU.

A 256-row store goes 1.70 -> 2.01 ms. The per-row staging buffer costs more than the host loop did at that size, which is the same trade the numeric `store_array` already makes: `Cumo::DFloat.new(256, 1024).store(rows)` measures 2.09 ms on the same machine.
