### PR TITLE
Add real= and imag= kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl/set2.c
+++ b/ext/cumo/narray/gen/tmpl/set2.c
@@ -1,57 +1,20 @@
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char   *p1, *p2;
-    ssize_t s1, s2;
-    size_t *idx1, *idx2;
-    dtype   x;
-    <%=dtype%> y;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
-    CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    if (idx1) {
-        if (idx2) {
-            for (; i--;) {
-                CUMO_GET_DATA(p1+*idx1,dtype,x);
-                CUMO_GET_DATA_INDEX(p2,idx2,<%=dtype%>,y);
-                x = m_<%=name%>(x,y);
-                CUMO_SET_DATA_INDEX(p1,idx1,dtype,x);
-            }
-        } else {
-            for (; i--;) {
-                CUMO_GET_DATA(p1+*idx1,dtype,x);
-                CUMO_GET_DATA_STRIDE(p2,s2,<%=dtype%>,y);
-                x = m_<%=name%>(x,y);
-                CUMO_SET_DATA_INDEX(p1,idx1,dtype,x);
-            }
-        }
-    } else {
-        if (idx2) {
-            for (; i--;) {
-                CUMO_GET_DATA(p1,dtype,x);
-                CUMO_GET_DATA_INDEX(p2,idx2,<%=dtype%>,y);
-                x = m_<%=name%>(x,y);
-                CUMO_SET_DATA_STRIDE(p1,s1,dtype,x);
-            }
-        } else {
-            for (; i--;) {
-                CUMO_GET_DATA(p1,dtype,x);
-                CUMO_GET_DATA_STRIDE(p2,s2,<%=dtype%>,y);
-                x = m_<%=name%>(x,y);
-                CUMO_SET_DATA_STRIDE(p1,s1,dtype,x);
-            }
-        }
-    }
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&indexer);
 }
 
 static VALUE
 <%=c_func(1)%>(VALUE self, VALUE a1)
 {
     cumo_ndfunc_arg_in_t ain[2] = {{CUMO_OVERWRITE,0},{<%=result_class%>,0}};
-    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 2, 0, ain, 0 };
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 0, ain, 0 };
 
     cumo_na_ndloop(&ndf, 2, self, a1);
     return a1;

--- a/ext/cumo/narray/gen/tmpl/set2_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/set2_kernel.cu
@@ -1,0 +1,28 @@
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        *(dtype*)(p1) = m_<%=name%>(*(dtype*)(p1), *(<%=dtype%>*)(p2));
+    }
+}
+<% end %>
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3895,6 +3895,59 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([1, 2, 0], Cumo::Int32[3, 1, 2].sort_index.to_a, "smallest case")
   end
 
+  test "real= and imag= reach every element of a view" do
+    # The two ran on the host, one element at a time, behind a device
+    # synchronization; they were the last of gen/tmpl to do so.
+    rows = 6
+    cols = 10
+    n = rows * cols
+    re = Array.new(n) { |i| (i % 7) - 3.0 }
+    im = Array.new(n) { |i| (i % 5) - 2.0 }
+    fresh = Array.new(n) { |i| (i % 11) - 5.0 }
+
+    [[Cumo::DComplex, Cumo::DFloat], [Cumo::SComplex, Cumo::SFloat]].each do |ct, rt|
+      src = -> { ct.cast(re.each_index.map { |i| Complex(re[i], im[i]) }).reshape(rows, cols) }
+
+      a = src.call
+      a.real = rt.cast(fresh).reshape(rows, cols)
+      assert_equal(fresh.each_index.map { |i| Complex(fresh[i], im[i]) }, a.to_a.flatten, "#{ct} real= array")
+
+      a = src.call
+      a.imag = rt.cast(fresh).reshape(rows, cols)
+      assert_equal(fresh.each_index.map { |i| Complex(re[i], fresh[i]) }, a.to_a.flatten, "#{ct} imag= array")
+
+      a = src.call
+      a.real = 7.0
+      assert_equal(re.each_index.map { |i| Complex(7.0, im[i]) }, a.to_a.flatten, "#{ct} real= scalar")
+
+      # a view whose elements are not laid out end to end
+      picked = (0...cols).step(3).to_a
+      a = src.call
+      a[true, 0.step(cols - 1, 3)].imag = 9.0
+      want = re.each_index.map { |i| Complex(re[i], picked.include?(i % cols) ? 9.0 : im[i]) }
+      assert_equal(want, a.to_a.flatten, "#{ct} imag= of a column slice")
+
+      order = [3, 0, 5]
+      a = src.call
+      a[order, true].real = 4.0
+      want = re.each_index.map { |i| Complex(order.include?(i / cols) ? 4.0 : re[i], im[i]) }
+      assert_equal(want, a.to_a.flatten, "#{ct} real= of an index view")
+
+      a = src.call
+      a[(rows - 1).step(0, -1), true].imag = 2.5
+      assert_equal(re.each_index.map { |i| Complex(re[i], 2.5) }, a.to_a.flatten, "#{ct} imag= of a reversed view")
+
+      # a shape past the rank the indexer has a specialized accessor for
+      deep = ct.cast((0...32).map { |i| Complex(re[i], im[i]) }).reshape(2, 2, 2, 2, 2)
+      deep.real = rt.cast(fresh[0, 32]).reshape(2, 2, 2, 2, 2)
+      assert_equal((0...32).map { |i| Complex(fresh[i], im[i]) }, deep.to_a.flatten, "#{ct} real= 5-d")
+
+      one = ct.cast([Complex(1, 2)])
+      one.imag = 8.0
+      assert_equal([Complex(1, 8)], one.to_a, "#{ct} smallest case")
+    end
+  end
+
   test "poly evaluates every element, whatever the coefficients and the layout" do
     # poly ran with CUMO_NO_LOOP, so ndloop called the iterator once per
     # element and each call synchronized with the device.


### PR DESCRIPTION
## Summary

- Address the whole view in one launch, the way the other elementwise templates do.
- 2^22 DComplex `real=` 4.63 -> 0.45 ms, `imag=` 4.54 -> 0.44 ms, a scalar 3.94 -> 0.37 ms, a 2048x2048 column slice 3.33 -> 0.40 ms, 2^20 SComplex 0.26 -> 0.008 ms. numo on the CPU answers the first three in 4.34 / 4.41 / 3.63 ms.

## Problem

`real=` and `imag=` ran on the host, one element at a time, behind a `cudaDeviceSynchronize`. They were the last two entries of `gen/tmpl` to do so.

## Note

With this, nothing on issue #36's list runs a host loop any more. `gen/tmpl/qsort.c` stays on the host on purpose, for the `nan: true` paths of `sort`, `sort_index` and `median`: that comparator leaves NaN unordered, so numo's own answer there is not a sorted array. `RObject` keeps its host loops by design, its elements being Ruby objects.

Checked by running 27 methods one per process under `CUMO_SHOW_WARNING=ON`, watching for `FIXME: Method "..." synchronizes with CPU`. None of them prints it now.
