### PR TITLE
Fix gemm reading past an operand whose batch dimensions do not match

### DIFF
--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -152,6 +152,14 @@ is_c_contiguous(VALUE a)
     return cumo_na_check_contiguous(a) == Qtrue;
 }
 
+// How many matrices the operand holds, i.e. the product of its batch dimensions.
+static int
+gemm_batch_count(cumo_narray_t *na)
+{
+    size_t matrix_size = ROW_SIZE(na) * COL_SIZE(na);
+    return matrix_size == 0 ? 0 : (int)(CUMO_NA_SIZE(na) / matrix_size);
+}
+
 static gemm_layout_t
 make_gemm_layout(VALUE a)
 {
@@ -175,7 +183,9 @@ make_gemm_layout(VALUE a)
         // force c-contiguous
         layout.a = is_c_contiguous(a) ? a : rb_funcall(a, rb_intern("dup"), 0);
     }
-    layout.stride = ROW_SIZE(na) * COL_SIZE(na);
+    // cuBLAS walks the operand by this stride once per batch, so an operand that
+    // holds a single matrix has to be re-read rather than advanced past its end.
+    layout.stride = gemm_batch_count(na) == 1 ? 0 : ROW_SIZE(na) * COL_SIZE(na);
     return layout;
 }
 
@@ -294,6 +304,7 @@ static VALUE
 {
     VALUE a=self, b, c=Qnil, alpha, beta;
     cumo_narray_t *na, *nb;
+    int a_batch, b_batch, batch;
 
     gemm_args_t g;
     VALUE kw_hash = Qnil;
@@ -317,6 +328,8 @@ static VALUE
     CumoGetNArray(b, nb);
     CHECK_DIM_GE(na, 2);
     CHECK_DIM_GE(nb, 2);
+    CHECK_NON_EMPTY(na);
+    CHECK_NON_EMPTY(nb);
 
     if (ROW_SIZE(nb) != COL_SIZE(na)) {
         rb_raise(cumo_na_eShapeError,"ROW_SIZE(b)=%d must equal to COL_SIZE(a)=%d",
@@ -327,11 +340,25 @@ static VALUE
     g.k = COL_SIZE(na);
     g.n = COL_SIZE(nb);
 
+    // The batch dimensions reach cuBLAS as one stride per operand, so both
+    // operands must hold the same number of matrices. An operand holding a
+    // single matrix is broadcast over the batch; anything else cannot be
+    // expressed with a single stride and would read past the shorter operand.
+    a_batch = gemm_batch_count(na);
+    b_batch = gemm_batch_count(nb);
+    if (a_batch != b_batch && a_batch != 1 && b_batch != 1) {
+        rb_raise(cumo_na_eShapeError,"batch count of a=%d must equal to batch count of b=%d",
+                a_batch, b_batch);
+    }
+    batch = a_batch > b_batch ? a_batch : b_batch;
+
     if (c == Qnil) { // c is not given.
-        int ndim = CUMO_NA_NDIM(na);
+        cumo_narray_t *nbase = a_batch >= b_batch ? na : nb;
+        int ndim = CUMO_NA_NDIM(nbase);
         size_t *shape = ALLOCA_N(size_t, ndim);
-        memcpy(shape, CUMO_NA_SHAPE(na), sizeof(size_t) * (ndim - 1)); // ... x m x k
-        shape[ndim - 1] = g.n; // ... x m x n
+        memcpy(shape, CUMO_NA_SHAPE(nbase), sizeof(size_t) * (ndim - 2)); // batch dimensions
+        shape[ndim - 2] = g.m; // ... x m x n
+        shape[ndim - 1] = g.n;
         c = cumo_na_new(cT, ndim, shape);
     } else {
         cumo_narray_t *nc;
@@ -344,7 +371,11 @@ static VALUE
         }
         if (COL_SIZE(nc) != COL_SIZE(nb)) {
             rb_raise(cumo_na_eShapeError,"COL_SIZE(c)=%d must equal to COL_SIZE(b)=%d",
-                    (int)COL_SIZE(nc), (int)COL_SIZE(nc));
+                    (int)COL_SIZE(nc), (int)COL_SIZE(nb));
+        }
+        if (gemm_batch_count(nc) != batch) {
+            rb_raise(cumo_na_eShapeError,"batch count of c=%d must equal to %d",
+                    gemm_batch_count(nc), batch);
         }
     }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -900,6 +900,39 @@ class NArrayTest < Test::Unit::TestCase
           a = dtype[1..6].reshape(2, 3)
           assert { a.gemm([[1, 2], [3, 4], [5, 6]]) == [[22, 28], [49, 64]] }
         end
+        test "matrix.gemm(matrix) broadcasts an operand that holds one matrix" do
+          b = dtype.new(3, 4).seq
+          # fills the pool next to b, so a read past b shows up as 7
+          neighbour = Array.new(2) { dtype.new(200).fill(7) }
+          a = dtype.new(10, 2, 3).seq
+          c = a.gemm(b)
+          assert { c.shape == [10, 2, 4] }
+          10.times { |i| assert { c[i, true, true] == a[i, true, true].gemm(b) } }
+          assert { neighbour.all? { |n| n == dtype.new(200).fill(7) } }
+        end
+        test "matrix.gemm(matrix) takes the batch dimensions from either operand" do
+          a = dtype.new(2, 3).seq
+          b = dtype.new(4, 3, 4).seq
+          c = a.gemm(b)
+          assert { c.shape == [4, 2, 4] }
+          4.times { |i| assert { c[i, true, true] == a.gemm(b[i, true, true]) } }
+        end
+        test "matrix.gemm(matrix) rejects batch counts that differ" do
+          a = dtype.new(4, 2, 3).seq
+          b = dtype.new(3, 3, 4).seq
+          assert_raise(Cumo::NArray::ShapeError) { a.gemm(b) }
+        end
+        test "matrix.gemm(matrix) rejects an empty operand" do
+          assert_raise(Cumo::NArray::ShapeError) { dtype.new(2, 3).seq.gemm(dtype.new(3, 0)) }
+          assert_raise(Cumo::NArray::ShapeError) { dtype.new(0, 3).gemm(dtype.new(3, 4).seq) }
+          assert_raise(Cumo::NArray::ShapeError) { dtype.new(2, 0).gemm(dtype.new(0, 4)) }
+        end
+        test "matrix.gemm(matrix, c) rejects a c whose batch count differs" do
+          a = dtype.new(4, 2, 3).seq
+          b = dtype.new(3, 4).seq
+          assert_raise(Cumo::NArray::ShapeError) { a.gemm(b, dtype.zeros(2, 4)) }
+          assert { a.gemm(b, dtype.zeros(4, 2, 4)) == a.gemm(b) }
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- Broadcast an operand that holds a single matrix (stride 0) instead of walking it past its end.
- Raise `ShapeError` when the two operands hold a different number of matrices, when `c` holds a different number, and when either operand is empty.
- Take the batch dimensions of a new `c` from whichever operand carries them, so `a.dot(b)` with a 2-D `a` and a 3-D `b` no longer drops every batch but the first.
- Add 20 tests covering the four float/complex dtypes.

## Problem

`iter_..._gemm` derives `batch_count` from the output `c` alone and hands `cublasXgemmStridedBatched` each operand's own matrix size as its stride. When one operand carries fewer matrices than `c`, cuBLAS advances past the end of that operand's allocation and the bytes it reads land in the result.

```ruby
b       = Cumo::DFloat.new(3,4).seq
poison  = Cumo::DFloat.new(200).fill(7.0)
poison2 = Cumo::DFloat.new(200).fill(7.0)
a = Cumo::DFloat.zeros(10,2,3); a[0..9,0,0] = 1.0
c = a.dot(b)
c[9,0,true]  #=> [7.0, 7.0, 7.0, 7.0]   the contents of another NArray
```

`b` holds 12 elements, but `b_layout.stride` is 12 and `batch_count` is 10, so cuBLAS reads `b[0..119]`. With nothing allocated after `b` the extra bytes read as zeros and the wrong answer is silent; with another array there, its contents reach the caller. `lib/cumo/narray/extra.rb` reaches the same path from `a.dot(b)` when `b.ndim == 1`.

The same function divides by `stridec`, which is `ROW_SIZE(c) * COL_SIZE(c)`. An empty operand makes that zero and the integer division raises SIGFPE, which no `rescue` can catch:

```ruby
Cumo::DFloat.new(2,3).dot(Cumo::DFloat.new(3,0))   # SIGFPE
Cumo::DFloat.new(0,3).dot(Cumo::DFloat.new(3,4))   # SIGFPE
```

numo raises `ShapeError` for every empty case, so this now does too.

## Note

The batch dimensions reach cuBLAS as one stride per operand, so only two shapes are expressible: equal batch counts, or one operand holding a single matrix that is broadcast. numo's `dot` broadcasts the batch dimensions the way NumPy does, which needs more than one stride; shapes that need it now raise `ShapeError` instead of returning a wrong-shaped result.

`COL_SIZE(c)` was reported against itself in one error message; it now names `b`.

Every dtype/shape combination this touches was compared against numo 0.9.2.1 and the values agree. The five new test cases fail on master — four as assertion failures, the empty-operand one by taking the test process down with SIGFPE.
