### PR TITLE
Fix an out-of-bounds write through an unchecked cuDNN output array

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -44,6 +44,25 @@ extern VALUE cumo_na_eShapeError;
                  (int)(nd1), (int)(nd2));            \
     }
 
+// An output array given by the caller is written through a descriptor built
+// from another operand, or as if it were contiguous, so cuDNN never learns how
+// long it really is. It has to be checked here instead.
+static inline void
+cumo_cuda_cudnn_check_output(VALUE out, VALUE type, size_t ndim, size_t *shape)
+{
+    cumo_narray_t *na;
+
+    CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(out, type);
+    CumoGetNArray(out, na);
+    CUMO_CUDA_CUDNN_CHECK_DIM_EQ((size_t)(na->ndim), ndim);
+    for (size_t idim = 0; idim < ndim; ++idim) {
+        CUMO_CUDA_CUDNN_CHECK_SIZE_EQ(na->shape[idim], shape[idim]);
+    }
+    if (cumo_na_check_contiguous(out) != Qtrue) {
+        rb_raise(cumo_na_eShapeError, "output NArray must be contiguous");
+    }
+}
+
 void
 cumo_cuda_cudnn_check_status(cudnnStatus_t status);
 

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -150,8 +150,11 @@ static VALUE
     gamma_cont_ptr = cumo_na_get_offset_pointer_for_read(gamma_cont);
     beta_cont_ptr = cumo_na_get_offset_pointer_for_read(beta_cont);
 
-    // TODO: type and shape check
-    if (y == Qnil) y = cumo_na_new(cT, x_ndim, x_shape);
+    if (y == Qnil) {
+        y = cumo_na_new(cT, x_ndim, x_shape);
+    } else {
+        cumo_cuda_cudnn_check_output(y, cT, x_ndim, x_shape);
+    }
     y_ptr = cumo_na_get_offset_pointer_for_write(y);
 
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -123,12 +123,23 @@ static VALUE
     gamma_cont_ptr = cumo_na_get_offset_pointer_for_read(gamma_cont);
     gy_cont_ptr = cumo_na_get_offset_pointer_for_read(gy_cont);
 
-    // TODO: type and shape check
-    if (gx == Qnil) gx = cumo_na_new(cT, x_ndim, x_shape);
+    if (gx == Qnil) {
+        gx = cumo_na_new(cT, x_ndim, x_shape);
+    } else {
+        cumo_cuda_cudnn_check_output(gx, cT, x_ndim, x_shape);
+    }
     gx_ptr = cumo_na_get_offset_pointer_for_write(gx);
-    if (ggamma == Qnil) ggamma = cumo_na_new(cT, gamma_ndim, gamma_shape);
+    if (ggamma == Qnil) {
+        ggamma = cumo_na_new(cT, gamma_ndim, gamma_shape);
+    } else {
+        cumo_cuda_cudnn_check_output(ggamma, cT, gamma_ndim, gamma_shape);
+    }
     ggamma_ptr = cumo_na_get_offset_pointer_for_write(ggamma);
-    if (gbeta == Qnil) gbeta = cumo_na_new(cT, gamma_ndim, gamma_shape);
+    if (gbeta == Qnil) {
+        gbeta = cumo_na_new(cT, gamma_ndim, gamma_shape);
+    } else {
+        cumo_cuda_cudnn_check_output(gbeta, cT, gamma_ndim, gamma_shape);
+    }
     gbeta_ptr = cumo_na_get_offset_pointer_for_write(gbeta);
 
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);

--- a/ext/cumo/narray/gen/tmpl/conv.c
+++ b/ext/cumo/narray/gen/tmpl/conv.c
@@ -83,10 +83,7 @@ static VALUE
                 (int)x_shape[1], (int)w_shape[1]);
     }
 
-    if (y != Qnil) {
-        CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(y, cT);
-    }
-    else {
+    {
         size_t *y_shape = ALLOCA_N(size_t, ndim + 2);
         // out_shape = (batch_size, out_channels, out_1, out_2, ..., out_N)
         y_shape[0] = batch_size;
@@ -95,7 +92,12 @@ static VALUE
             y_shape[i + 2] = cumo_cuda_cudnn_GetConvOutDim(
                     x_shape[i + 2], w_shape[i + 2], int_stride[i], int_pad[i]);
         }
-        y = cumo_na_new(cT, ndim + 2, y_shape);
+        if (y == Qnil) {
+            y = cumo_na_new(cT, ndim + 2, y_shape);
+        }
+        else {
+            cumo_cuda_cudnn_check_output(y, cT, ndim + 2, y_shape);
+        }
     }
 
     x_cont = cumo_na_as_contiguous_array(x);

--- a/ext/cumo/narray/gen/tmpl/conv_grad_w.c
+++ b/ext/cumo/narray/gen/tmpl/conv_grad_w.c
@@ -81,12 +81,11 @@ static VALUE
     cumo_cuda_cudnn_get_int_ary(int_stride, stride, ndim, 1);
     cumo_cuda_cudnn_get_int_ary(int_pad, pad, ndim, 0);
 
-    if (gw != Qnil) {
-        CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(gw, cT);
-        assert(cumo_na_check_contiguous(gw) == Qtrue);
+    if (gw == Qnil) {
+        gw = cumo_na_new(cT, ndim + 2, sizet_w_shape);
     }
     else {
-        gw = cumo_na_new(cT, ndim + 2, sizet_w_shape);
+        cumo_cuda_cudnn_check_output(gw, cT, ndim + 2, sizet_w_shape);
     }
     // w_shape = (out_channels, in_channels, k_1, k_2, ..., k_N)
     // x_shape = (batch_size, in_channels, d_1, d_2, ..., d_N)

--- a/ext/cumo/narray/gen/tmpl/conv_transpose.c
+++ b/ext/cumo/narray/gen/tmpl/conv_transpose.c
@@ -79,7 +79,7 @@ static VALUE
     int int_out_size[CUMO_NA_MAX_DIMENSION];
 
     rb_scan_args(argc, argv, "1:", &w, &kw_hash);
-    rb_get_kwargs(kw_hash, kw_table, 0, 4, opts);
+    rb_get_kwargs(kw_hash, kw_table, 0, 5, opts);
     b = cumo_cuda_cudnn_option_value(opts[0], Qnil);
     stride = cumo_cuda_cudnn_option_value(opts[1], Qnil);
     pad = cumo_cuda_cudnn_option_value(opts[2], Qnil);
@@ -112,18 +112,19 @@ static VALUE
     get_int_out_size(int_out_size, out_size, ndim, x_shape, w_shape, int_stride, int_pad);
 
     // out_shape = (batch_size, out_channels, out_1, out_2, ..., out_N)
-    if (y != Qnil) {
-        CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(y, cT);
-        // TODO: shape check
-    }
-    else {
+    {
         size_t *y_shape = ALLOCA_N(size_t, ndim + 2);
         y_shape[0] = batch_size;
         y_shape[1] = out_channels;
         for (size_t i = 0; i < ndim; ++i) {
             y_shape[i + 2] = int_out_size[i];
         }
-        y = cumo_na_new(cT, ndim + 2, y_shape);
+        if (y == Qnil) {
+            y = cumo_na_new(cT, ndim + 2, y_shape);
+        }
+        else {
+            cumo_cuda_cudnn_check_output(y, cT, ndim + 2, y_shape);
+        }
     }
 
     x_cont = cumo_na_as_contiguous_array(x);

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -99,8 +99,11 @@ static VALUE
     mean_cont_ptr = cumo_na_get_offset_pointer_for_read(mean_cont);
     var_cont_ptr = cumo_na_get_offset_pointer_for_read(var_cont);
 
-    // TODO: type and shape check
-    if (y == Qnil) y = cumo_na_new(cT, x_ndim, x_shape);
+    if (y == Qnil) {
+        y = cumo_na_new(cT, x_ndim, x_shape);
+    } else {
+        cumo_cuda_cudnn_check_output(y, cT, x_ndim, x_shape);
+    }
     y_ptr = cumo_na_get_offset_pointer_for_write(y);
 
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);

--- a/ext/cumo/narray/gen/tmpl/pooling_backward.c
+++ b/ext/cumo/narray/gen/tmpl/pooling_backward.c
@@ -77,11 +77,11 @@ static VALUE
 
     x_shape = nx->shape;
 
-    if (gx != Qnil) {
-        CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(gx, cT);
+    if (gx == Qnil) {
+        gx = cumo_na_new(cT, ndim + 2, x_shape);
     }
     else {
-        gx = cumo_na_new(cT, ndim + 2, x_shape);
+        cumo_cuda_cudnn_check_output(gx, cT, ndim + 2, x_shape);
     }
 
     x_cont = cumo_na_as_contiguous_array(x);

--- a/ext/cumo/narray/gen/tmpl/pooling_forward.c
+++ b/ext/cumo/narray/gen/tmpl/pooling_forward.c
@@ -77,10 +77,7 @@ static VALUE
 
     x_shape = nx->shape;
 
-    if (y != Qnil) {
-        CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(y, cT);
-    }
-    else {
+    {
         size_t *y_shape = ALLOCA_N(size_t, ndim + 2);
         // out_shape = (batch_size, num_channels, out_1, out_2, ..., out_N)
         y_shape[0] = x_shape[0];
@@ -89,7 +86,12 @@ static VALUE
             y_shape[i + 2] = cumo_cuda_cudnn_GetConvOutDim(
                     x_shape[i + 2], int_kernel_size[i], int_stride[i], int_pad[i]);
         }
-        y = cumo_na_new(cT, ndim + 2, y_shape);
+        if (y == Qnil) {
+            y = cumo_na_new(cT, ndim + 2, y_shape);
+        }
+        else {
+            cumo_cuda_cudnn_check_output(y, cT, ndim + 2, y_shape);
+        }
     }
 
     x_cont = cumo_na_as_contiguous_array(x);

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -494,5 +494,64 @@ class CUDNNTest < Test::Unit::TestCase
         # TODO: assert values
       end
     end
+
+    sub_test_case "given output arrays" do
+      setup do
+        @x_shape = [2, 3, 5, 3]
+        @reduced_shape = [1].concat(@x_shape[1..-1])
+        @w_shape = [2, 3, 2, 3]
+        @ksize = [3, 3]
+        @x = dtype.ones(*@x_shape) * 3
+        @gamma = dtype.ones(*@reduced_shape) * 2
+        @beta = dtype.ones(*@reduced_shape)
+        @mean = dtype.ones(*@reduced_shape)
+        @var = dtype.ones(*@reduced_shape)
+        @gy = dtype.ones(*@x_shape)
+        @w = dtype.ones(*@w_shape)
+      end
+
+      test "batch_norm(y:) #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm(@gamma, @beta, y: dtype.zeros(1)) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm(@gamma, @beta, y: dtype.zeros(2, 3, 5, 6)[true, true, true, 0..2]) }
+        y = dtype.zeros(*@x_shape)
+        assert { @x.batch_norm(@gamma, @beta, y: y).equal?(y) }
+        assert { y == @x.batch_norm(@gamma, @beta) }
+      end
+
+      test "fixed_batch_norm(y:) #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) { @x.fixed_batch_norm(@gamma, @beta, @mean, @var, y: dtype.zeros(1)) }
+        y = dtype.zeros(*@x_shape)
+        assert { y == @x.fixed_batch_norm(@gamma, @beta, @mean, @var, y: y) }
+      end
+
+      test "batch_norm_backward(gx:, ggamma:, gbeta:) #{dtype}" do
+        @x.batch_norm(@gamma, @beta)
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, gx: dtype.zeros(1)) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, ggamma: dtype.zeros(1)) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, gbeta: dtype.zeros(1)) }
+        gx = dtype.zeros(*@x_shape)
+        ggamma = dtype.zeros(*@reduced_shape)
+        gbeta = dtype.zeros(*@reduced_shape)
+        assert { @x.batch_norm_backward(@gamma, @gy, gx: gx, ggamma: ggamma, gbeta: gbeta) == [gx, ggamma, gbeta] }
+      end
+
+      test "max_pool(y:) and max_pool_backward(gx:) #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) { @x.max_pool(@ksize, y: dtype.zeros(1)) }
+        y = @x.max_pool(@ksize)
+        gy = dtype.ones(*y.shape)
+        assert_raise(Cumo::NArray::ShapeError) { @x.max_pool_backward(y, gy, @ksize, gx: dtype.zeros(1)) }
+        gx = dtype.zeros(*@x_shape)
+        assert { @x.max_pool_backward(y, gy, @ksize, gx: gx).equal?(gx) }
+      end
+
+      test "conv(y:), conv_transpose(y:) and conv_grad_w(gw:) #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) { @x.conv(@w, y: dtype.zeros(1)) }
+        y = @x.conv(@w)
+        assert_raise(Cumo::NArray::ShapeError) { @x.conv_grad_w(y, @w_shape, gw: dtype.zeros(1)) }
+        gw = dtype.zeros(*@w_shape)
+        assert { @x.conv_grad_w(y, @w_shape, gw: gw).equal?(gw) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.conv_transpose(@w, y: dtype.zeros(1)) }
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Check the class, shape and contiguity of every caller-supplied output array (`y:`, `gx:`, `ggamma:`, `gbeta:`, `gw:`) against the shape the operation is about to write.
- `conv_transpose` never accepted `y:` at all: `rb_get_kwargs` was told 4 optional keywords for a 5-entry table.
- Add 10 tests over the two float dtypes; all 10 fail on master.

## Problem

Each of the eight cuDNN entry points allocates its output when the caller does not supply one, and otherwise takes what it is given. Three of them carried `// TODO: type and shape check` and did neither; the rest checked only the class. cuDNN is then asked to write that buffer through a descriptor built from a *different* operand, so it has no way to learn how long the buffer really is:

```ruby
x = Cumo::SFloat.new(2,3,32,32).seq        # 6144 elements
g = b = Cumo::SFloat.new(3*32*32)
small   = Cumo::SFloat.new(128).fill(0.0)
canary  = Cumo::SFloat.new(1024).fill(-1.0)
canary2 = Cumo::SFloat.new(1024).fill(-1.0)
x.batch_norm(g, b, y: small)
# canary and canary2 both change from -1.0 to normalized values
```

`cudnnBatchNormalizationForwardTraining` is handed `x_desc` for both the input and the output, so it writes `x.size` elements into a 128-element allocation and walks into the next chunks of the pool. `fixed_batch_norm` (`y`) and `batch_norm_backward` (`gx`, `ggamma`, `gbeta`) are the same shape of code. A small `x` does not show it: the pool rounds the allocation up and absorbs the overrun.

The conv and pooling entry points build the descriptor from the output itself, so cuDNN rejects a wrong-sized buffer with `CUDNN_STATUS_BAD_PARAM` rather than overrunning it; they still accepted a non-contiguous view and wrote it as if it were contiguous, which corrupts the elements of the base array that the view skips over. `conv_grad_w` asserted contiguity, which is compiled out with `NDEBUG`.

## Note

The new `cumo_cuda_cudnn_check_output` sits in `cuda/cudnn.h` next to the other `CUMO_CUDA_CUDNN_CHECK_*` helpers.

The five new test cases fail on master for both dtypes: the three batch-norm ones raise nothing at all, and the conv and pooling ones raise `CUDNN_STATUS_BAD_PARAM` instead of a `ShapeError`.
