### PR TITLE
Fix expand_dims handing out a view past CUMO_NA_MAX_DIMENSION

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1158,6 +1158,10 @@ cumo_na_expand_dims(VALUE self, VALUE vdim)
 
     CumoGetNArray(self,na);
     nd = na->ndim;
+    // The indexer and the iarray a kernel receives carry
+    // CUMO_NA_MAX_DIMENSION entries, so a view past that limit is written and
+    // read outside those structures.
+    cumo_na_check_ndim(nd+1);
 
     dim = NUM2INT(vdim);
     if (dim < -nd-1 || dim > nd) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4278,4 +4278,21 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([[7, 8, 9], [1, 2, 3]], a[[2, 0], true].copy.to_a)
     assert_equal([[1, 4, 7], [2, 5, 8], [3, 6, 9]], a.transpose.copy.to_a)
   end
+
+  test "expand_dims stops at the maximum number of dimensions" do
+    max = 12 # CUMO_NA_MAX_DIMENSION
+    a = Cumo::DFloat.zeros(*([2] * (max - 1)))
+    assert_equal(max, a.expand_dims(0).ndim)
+    assert_equal(max, a.expand_dims(max - 1).ndim)
+    b = Cumo::DFloat.zeros(*([2] * max))
+    assert_raise(Cumo::NArray::DimensionError) { b.expand_dims(0) }
+    assert_raise(Cumo::NArray::DimensionError) { b.expand_dims(max) }
+    # dimensions no adjacent pair of which ndloop can contract, so the loop
+    # reaches the kernel with every one of them
+    base = Cumo::DFloat.zeros(*([3] * max))
+    view = base[*([0..1] * max)]
+    assert_raise(Cumo::NArray::DimensionError) { view.expand_dims(max / 2) }
+    view.fill(9.0)
+    assert_equal(view.size, base.flatten.eq(9.0).count_true)
+  end
 end


### PR DESCRIPTION
## Summary

- Run `expand_dims` through `cumo_na_check_ndim` so it cannot hand out a view with more dimensions than the rest of the library can address.
- Add a test; it fails on master.

## Problem

`cumo_na_expand_dims` raises the dimension count with `na2->base.ndim++` without checking it, so a 12-dimensional NArray produces a 13-dimensional view. `CUMO_NA_MAX_DIMENSION` is 12, and the structures a kernel receives size their arrays by it: `cumo_na_indexer_t` carries `shape[12]` and `index[12]`, `cumo_na_iarray_t` carries `step[12]`. Filling them for a 13-dimensional operand writes one element past the end of the caller's stack frame, and the kernel then reads that element back as a stride.

Most operations happen to escape it. Allocating the output goes through `cumo_na_check_ndim`, so anything that produces a new array raises `ndim=13 is too many` first; and `cumo_ndfunc_contract_loop` merges adjacent dimensions, which brings a contiguous view back under the limit. What reaches the kernel is an operation that writes in place, over a view no adjacent pair of which can be contracted:

```ruby
base = Cumo::DFloat.zeros(*([3] * 12))
w = base[*([0..1] * 12)]      # stride[i-1] == 3 * stride[i], so nothing contracts
w.expand_dims(6).fill(9.0)
w.flatten.eq(9.0).count_true  #=> 1, out of 4096
```

`Cumo::NArray.debug = true` shows `user.args[0].ndim = 13` reaching the launcher. `fill`, `[]=`, `store` and `seq` all take that path.

## Note

numo has the same missing check, but its `NA_MAX_DIMENSION` is `sizeof(VALUE) * 8 - 2`, i.e. 62; cumo overrides it to 12 in `include/cumo/narray.h`, and the fixed-length `step[]` in `include/cumo/indexer.h` has no counterpart upstream. The same one-line check is being added to numo-narray-alt, so this stays a no-op when that arrives.
