### PR TITLE
Fix a NULL dereference from at() given a scalar subscript

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -951,6 +951,15 @@ cumo_na_aref_md(int argc, VALUE *argv, VALUE self, int keep_dim, int result_nd, 
             if (argv[i] == cumo_sym_new || argv[i] == cumo_sym_minus) {
                 rb_raise(rb_eIndexError,":new is not allowed for at()");
             }
+            // A scalar subscript contributes no entry to the index array that
+            // at() walks. With every subscript scalar the result keeps no
+            // dimension, and the 1-d view built for at() is left with the
+            // zeroed stridx[0] that cumo_na_index_at_nadata() never reaches;
+            // a zero stridx reads as an index array at NULL.
+            if (FIXNUM_P(argv[i]) || RB_TYPE_P(argv[i], T_BIGNUM) ||
+                    RB_TYPE_P(argv[i], T_FLOAT)) {
+                rb_raise(rb_eIndexError,"not allowed type");
+            }
         }
     }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4328,4 +4328,16 @@ class NArrayTest < Test::Unit::TestCase
     view.fill(9.0)
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
+
+  test "at() rejects a scalar subscript" do
+    a = Cumo::DFloat.new(3, 3, 3).seq
+    assert_raise(IndexError) { a.at(0, 1, 2) }
+    assert_raise(IndexError) { a.at([0, 1], 1, 2) }
+    assert_raise(IndexError) { a.at(0.0, 1, 2) }
+    assert_raise(IndexError) { Cumo::DFloat.new(4).seq.at(1) }
+    assert_equal([2.0, 13.0, 24.0], a.at([0, 1, 2], [0, 1, 2], [-1, -2, -3]).to_a)
+    assert_equal([0.0, 13.0], a.at(0..1, 0..1, 0..1).to_a)
+    assert_equal([5.0], a.at([0], [1], [2]).to_a)
+    assert_equal([5.0], a.at(Cumo::Int32[0], Cumo::Int32[1], Cumo::Int32[2]).to_a)
+  end
 end


### PR DESCRIPTION
## Summary

- Reject a scalar subscript in `at()` with `IndexError`, which is what numo-narray answers for the same call.
- Add a test; it fails on master.

## Problem

`at()` addresses one element per entry of the index arrays it is given, so a scalar subscript contributes no entry. With every subscript scalar, `cumo_na_get_result_dimension` returns 0, and `cumo_na_aref_md_protected` still builds the 1-dimensional view that `at()` promises — but its `ndim == 0` branch sets only `offset` and `size`, leaving the `ZALLOC_N`ed `stridx[0]` zero. A zero `stridx` reads as an index array, so the first `ndloop` over that view dereferences NULL:

```ruby
Cumo::DFloat.new(3,3,3).seq.at(0,1,2).to_a
# => [BUG] Segmentation fault at 0x0000000000000000
```

`Cumo::DFloat.new(4).seq.at(1)` and `a.at(0.0, 1, 2)` land in the same place. `a.at([0,1], 1, 2)` reached `ShapeError: index array sizes mismatch` instead, an accident of the sizes rather than a check.

## Note

numo-narray rewrote `na_at` after 0.9.0.9, which is the revision cumo forked; the newer `na_at_parse_each` accepts only Array, Range, ArithmeticSequence, Enumerator and NArray, so all four calls above answer `IndexError: not allowed type` there. cumo still carries the older `at_mode` path, so it needs its own check. All nine `at()` forms I compared now agree with numo 0.9.2.1.
