### PR TITLE
Fix a subclass of RObject being treated as device memory

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -103,7 +103,7 @@ cumo_na_copy(VALUE self)
     // Everything else goes through the indexer so that ndloop hands the whole
     // view over at once: walking the outer dimensions itself costs a
     // synchronization per step when an operand carries an index array.
-    if (rb_obj_class(self) != cumo_cRObject) {
+    if (!rb_obj_is_kind_of(self, cumo_cRObject)) {
         ndf.func = iter_copy_bytes_indexer;
         ndf.flag = CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP;
     }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -615,7 +615,7 @@ cumo_na_data_byte_size(VALUE self)
 static void
 cumo_na_free_owned_ptr(VALUE self, void *ptr)
 {
-    if (rb_obj_class(self) == cumo_cRObject) {
+    if (rb_obj_is_kind_of(self, cumo_cRObject)) {
         xfree(ptr);
     } else {
         cumo_cuda_runtime_free(ptr);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4340,4 +4340,14 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([5.0], a.at([0], [1], [2]).to_a)
     assert_equal([5.0], a.at(Cumo::Int32[0], Cumo::Int32[1], Cumo::Int32[2]).to_a)
   end
+
+  test "a subclass of RObject keeps its data on the host too" do
+    klass = Class.new(Cumo::RObject)
+    a = klass.new(6)
+    a.allocate
+    a.store([1, 2, 3, 4, 5, 6])
+    assert_equal([1, 2, 3, 4, 5, 6], a.copy.to_a)
+    assert_equal([5, 1, 3], a[[4, 0, 2]].copy.to_a)
+    assert_equal(true, a.free)
+  end
 end


### PR DESCRIPTION
## Summary

- Pick the allocator and the copy path for `Cumo::RObject` with `rb_obj_is_kind_of` rather than an exact class match, so a subclass is treated as the host-memory type it is.
- Add a test; it takes the test process down with SIGSEGV on master.

## Problem

`Cumo::RObject` is the one dtype whose data lives in host memory: `allocate` calls `xmalloc` for it and the CUDA allocator for everything else. That branch is chosen in the template at generation time, from `is_object`, so a subclass inherits the host allocation. Two places decide the same question at runtime, and they compare the exact class:

- `cumo_na_free_owned_ptr` (`narray.c`) hands the pointer to `cumo_cuda_runtime_free`, which walks the pool, misses, and calls `cudaFree` on a `malloc` block.
- `cumo_na_copy` (`data.c`) sends the operand down the kernel path, where a kernel reads and writes host memory.

```ruby
klass = Class.new(Cumo::RObject)
a = klass.new(6); a.allocate; a.store([1, 2, 3, 4, 5, 6])
a.copy    # [BUG] Segmentation fault
a.free    # Cumo::CUDA::RuntimeError: invalid argument (error=1)
```

`store_binary` with a frozen String reaches the same deallocator through `cumo_na_set_pointer` and raises the same error.

## Note

Both sites are cumo's own: numo has no host/device split to decide. `marshal_dump` and `marshal_load` compare the exact class the same way, which makes a subclass dump raw `VALUE` pointers into the stream; that code is shared with numo-narray, so it is left for the upstream fix to be backported.

Comparing 16 operations between `Cumo::RObject` and a subclass, and the same 16 between `Numo::RObject` and a subclass, the two libraries now disagree on none of them. `dup`, `reshape`, `transpose`, `+`, `sum`, `eq`, `inspect` and `cast` still answer differently for a subclass than for the base class, identically in numo and in cumo.
