### PR TITLE
Add Bit#mask kernel

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -1,3 +1,5 @@
+void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, char *scratch);
+
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -10,9 +12,6 @@ static void
     size_t  count;
     where_opt_t *g;
 
-    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
     g = (where_opt_t*)(lp->opt_ptr);
     count = g->count;
     pidx  = (size_t*)(g->idx1);
@@ -22,6 +21,16 @@ static void
     p2 = lp->args[1].iter[0].pos;
     s2 = lp->args[1].iter[0].step;
     idx2 = lp->args[1].iter[0].idx;
+
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        // pidx stays put: the device-side cursor in the scratch orders the
+        // writes of successive calls instead.
+        cumo_bit_mask_kernel_launch(a,p1,s1,idx1,i,pidx,p2,s2,idx2,g->scratch);
+        return;
+    }
+
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
 
     if (idx1) {
         if (idx2) {
@@ -118,14 +127,20 @@ static VALUE
         }
     }
 
-    // TODO(sonots): bit_count_true synchronizes with CPU. Avoid.
-    n_1 = NUM2SIZET(<%=find_tmpl("count_true_cpu").c_func%>(0, NULL, mask));
+    n_1 = bit_where_count_true(mask);
     idx_1 = cumo_na_new(cIndex, 1, &n_1);
     g.count = 0;
     g.elmsz = SIZEOF_VOIDP;
     g.idx1 = cumo_na_get_pointer_for_write(idx_1);
     g.idx0 = NULL;
+    g.scratch = NULL;
+    if (CUMO_RNARRAY_SIZE(mask) >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+        g.scratch = cumo_bit_where_scratch_new();
+    }
     cumo_na_ndloop3(&ndf, &g, 2, mask, val);
+    if (g.scratch) {
+        cumo_cuda_runtime_free(g.scratch);
+    }
 
     view = cumo_na_s_allocate_view(rb_obj_class(val));
     CumoGetNArrayView(view, nv);

--- a/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
@@ -1,0 +1,54 @@
+// The compaction is where's: the same partial count and block scan put every
+// block's output at the right offset, and the cursor in the scratch carries
+// that offset from one loop segment to the next on the device. Only the
+// scatter differs -- it writes the position of the masked array's element
+// rather than the flat index, so the result indexes that array's data.
+__global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, uint64_t nchunks, uint64_t cpb, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t *block_sums)
+{
+    uint64_t start = blockIdx.x * cpb;
+    uint64_t end = (nchunks - start < cpb) ? nchunks : start + cpb;
+    uint64_t off = block_sums[blockIdx.x];
+    uint64_t c0;
+
+    if (start > nchunks) { start = end = nchunks; }
+    for (c0 = start; c0 < end; c0 += blockDim.x) {
+        uint64_t c = c0 + threadIdx.x;
+        CUMO_BIT_DIGIT z = 0;
+        uint64_t total;
+        uint64_t pre;
+        uint64_t o;
+
+        if (c < end) {
+            z = cumo_bit_chunk(a, p, s, idx, n, nw, c, contiguous, 0);
+        }
+        pre = cumo_bit_block_exscan((uint64_t)__popc(z), &total);
+        o = off + pre;
+        while (z) {
+            uint64_t j = c * CUMO_NB + (uint64_t)(__ffs(z) - 1);
+            out[o++] = idx2 ? p2 + idx2[j] : (size_t)((ssize_t)p2 + (ssize_t)j * s2);
+            z &= z - 1;
+        }
+        off += total;
+        __syncthreads();
+    }
+}
+
+void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, char *scratch)
+{
+    uint64_t nchunks = (n + CUMO_NB - 1) / CUMO_NB;
+    int contiguous = (idx == NULL && s == 1);
+    // A grid of no blocks is an invalid launch configuration.
+    if (n == 0) return;
+    uint64_t nw = contiguous ? (p + n + CUMO_NB - 1) / CUMO_NB : 0;
+    uint64_t nblocks = (nchunks + CUMO_BIT_CHUNK_BLOCK - 1) / CUMO_BIT_CHUNK_BLOCK;
+    uint64_t *running = (uint64_t*)scratch;
+    uint64_t *block_sums = (uint64_t*)scratch + 2;
+    uint64_t cpb;
+
+    if (nblocks > CUMO_BIT_WHERE_MAX_BLOCKS) nblocks = CUMO_BIT_WHERE_MAX_BLOCKS;
+    cpb = (nchunks + nblocks - 1) / nblocks;
+    cumo_bit_where_partial_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,0,nchunks,cpb,block_sums);
+    cumo_bit_where_scan_kernel<<<1, CUMO_BIT_CHUNK_BLOCK>>>(block_sums,nblocks,running);
+    cumo_bit_mask_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,nchunks,cpb,out,p2,s2,idx2,block_sums);
+    cumo_cuda_runtime_check_kernel_launch();
+}

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -34,8 +34,7 @@ class BitTest < Test::Unit::TestCase
       assert { a.count_false == 4 }
       assert { a.where == [1, 2, 4, 7] }
       assert { a.where2 == [[1, 2, 4, 7], [0, 3, 5, 6]] }
-      # TODO(sonots): FIX ME
-      # assert { a.mask(Cumo::DFloat[1,2,3,4,5,6,7,8]) == [2,3,5,8] }
+      assert { a.mask(Cumo::DFloat[1, 2, 3, 4, 5, 6, 7, 8]) == [2, 3, 5, 8] }
       assert { !a.all? }
       assert { a.any? }
       assert { !a.none? }
@@ -67,8 +66,7 @@ class BitTest < Test::Unit::TestCase
       assert { a.count_false == 4 }
       assert { a.where == [1, 2, 4, 7] }
       assert { a.where2 == [[1, 2, 4, 7], [0, 3, 5, 6]] }
-      # TODO(sonots): FIX ME
-      # assert { a.mask(Cumo::DFloat[[1,2,3,4],[5,6,7,8]]) == [2,3,5,8] }
+      assert { a.mask(Cumo::DFloat[[1, 2, 3, 4], [5, 6, 7, 8]]) == [2, 3, 5, 8] }
       assert { !a.all? }
       assert { a.any? }
       assert { !a.none? }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4329,6 +4329,43 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
 
+  test "a boolean mask reaches every element of a view and no others" do
+    mask_expect = lambda do |a, m|
+      flat = a.flatten.to_a
+      bits = m.flatten.to_a
+      flat.each_with_index.select { |_, i| bits[i] == 1 }.map(&:first)
+    end
+    check = lambda do |label, a, m|
+      assert_equal(mask_expect.call(a, m), a[m].to_a, label)
+    end
+    # around a word of bits, and around the size the loop is split at
+    [7, 31, 32, 33, 1000, 8191, 8192, 8193, 40_000].each do |n|
+      a = Cumo::DFloat.new(n).seq
+      check.call("1d n=#{n} half", a, a.gt(n / 2))
+      check.call("1d n=#{n} none", a, a.gt(n * 2))
+      check.call("1d n=#{n} all", a, a.ge(0))
+      check.call("1d n=#{n} alternating", a, (a % 2).eq(0))
+    end
+    # rows long enough that the loop reaches the kernel; the transpose below is
+    # the short-row case, and only an index on the innermost axis reaches the
+    # loop as an index array
+    base = Cumo::DFloat.new(8, 20_000).seq
+    order = (0...20_000).to_a.shuffle(random: Random.new(3))
+    views = {
+      "contiguous" => base,
+      "column slice" => base[true, 0.step(19_999, 2)],
+      "reversed" => base[true, 19_999.step(0, -1)],
+      "index array on the outer axis" => base[[7, 0, 3, 5, 1], true],
+      "index array on the innermost axis" => base[true, order],
+      "index array on both axes" => base[[7, 0, 3, 5, 1], order],
+      "transposed" => base.transpose,
+    }
+    views.each do |label, v|
+      check.call(label, v, v.gt(80_000))
+      check.call("#{label} on a reversed mask", v, v.reverse.gt(80_000))
+    end
+  end
+
   test "at() rejects a scalar subscript" do
     a = Cumo::DFloat.new(3, 3, 3).seq
     assert_raise(IndexError) { a.at(0, 1, 2) }


### PR DESCRIPTION
## Summary

- Compact the masked positions on the GPU, reusing the scan `where` already has: `a[bit_mask]` no longer walks every element on the host behind a `cudaDeviceSynchronize`.
- 2^22 elements 3.79 -> 0.14 ms, a 2048x1024 column slice 1.98 -> 0.07 ms. Nothing measured got slower.
- Ask `count_true` for the size of the result instead of `count_true_cpu`.

## Problem

`a[bit_mask]` reaches `Bit#mask`, whose loop synchronized and then read every bit from the host to build the index array the resulting view is backed by. With `CUMO_SHOW_WARNING=ON` a single masking printed three warnings: `count_true_cpu`, `mask` and `extract_cpu`. The cost followed the number of elements, not the number of selected ones:

| n | `a.gt(x)` | `a[mask]` | `a.sum` |
|---|---|---|---|
| 2^16 | 0.021 ms | 0.130 ms | 0.012 ms |
| 2^20 | 0.125 ms | 1.066 ms | 0.021 ms |
| 2^22 | 0.457 ms | 3.785 ms | 0.047 ms |

`where` (#241) already compacts the set bits on the device: each block counts the hits of a range of chunks, one scan block turns the counts into output positions, and each block scatters its range. `mask` wants the same compaction and differs only in what it writes -- the position of the masked array's element rather than the flat index -- so this adds that one scatter kernel and reuses the other two.

| case | before | after |
|---|---|---|
| 2^16 | 0.130 ms | 0.027 ms |
| 2^20 | 1.066 ms | 0.051 ms |
| 2^22 | 3.785 ms | 0.137 ms |
| 2048x1024 column slice | 1.975 ms | 0.070 ms |
| 2048x2048, index array on the inner axis | 3.948 ms | 2.683 ms |

## Note

The host loop stays for a segment below `CUMO_BIT_WHERE_MIN_KERNEL_SIZE`, as in `where`. It matters: a view whose innermost axis carries an index array cannot be contracted, so the loop runs a segment per row, and launching three kernels for each of 2048 rows took that last row of the table from 3.9 ms to 11.1 ms before the threshold went back in.

Checked against numo 0.9.2.1 over 90 cases -- sizes from 7 to 100000 around the 32-bit word and the segment threshold, no bit set, every bit set, and contiguous, column-sliced, reversed, transposed and index-array views, with the index on the outer axis, the inner axis and both. All identical.

The new test detects a wrong kernel: dropping the index-array branch of the scatter fails it, and so does writing the flat index instead of the element's position. Reaching that branch needs the index on the *innermost* axis and a row above the threshold, which is why the view in the test is 8x20000.

Two `TODO(sonots): FIX ME` assertions in `test/bit_test.rb` pass now and are no longer commented out.
