### PR TITLE
Remove TODO comments whose questions have been answered

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -439,7 +439,6 @@ TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t 
 
 }  // cumo_detail
 
-// TODO(sonots): Optimize indexer by squashing (or reducing) dimensions
 template <typename TypeIn, typename TypeOut, typename ReductionImpl>
 void cumo_reduce(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     if (arg.out_indexer.total_size == 0) {

--- a/ext/cumo/include/cumo/types/int_macro_kernel.h
+++ b/ext/cumo/include/cumo/types/int_macro_kernel.h
@@ -6,10 +6,6 @@
 #define m_sign(x)    (((x)==0) ? 0 : (((x)>0) ? 1 : -1))
 
 __host__ __device__ static inline dtype m_abs(dtype x) {
-    // TODO(sonots): How to handle in CUDA kernel?
-    // if (x==DATA_MIN) {
-    //     rb_raise(cumo_na_eValueError, "cannot convert the minimum integer");
-    // }
     return (x<0)?-x:x;
 }
 

--- a/ext/cumo/include/cumo/types/robject_kernel.h
+++ b/ext/cumo/include/cumo/types/robject_kernel.h
@@ -1,6 +1,3 @@
-//TODO(sonots):
-//typedef VALUE dtype;
-//typedef VALUE rtype;
 typedef void* dtype;
 typedef void* rtype;
 

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1479,7 +1479,6 @@ ndloop_run(VALUE vlp)
     // contract loop (compact dimessions)
     if (CUMO_NDF_TEST(nf,CUMO_NDF_INDEXER_LOOP) && CUMO_NDF_TEST(nf,CUMO_NDF_FLAT_REDUCE)) {
         // do nothing
-        // TODO(sonots): support compacting dimensions in reduction indexer loop if it allows speed up.
     } else {
         if (lp->loop_func == loop_narray) {
             cumo_ndfunc_contract_loop(lp);


### PR DESCRIPTION
## Summary

- Drop four TODO comments whose questions have been answered, and the commented-out code under two of them.

## Problem

`types/robject_kernel.h` opens with a bare `//TODO(sonots):` above `//typedef VALUE dtype;`, which reads as "these typedefs are a placeholder". They are not: `Cumo::RObject` deliberately runs no kernels since #194, so the header only has to let the shared kernel headers compile. Generating `narray/types/robject.c` and `robject_kernel.cu` from the current templates gives zero `kernel_launch` calls and zero `__global__` functions.

`types/int_macro_kernel.h` asks "How to handle in CUDA kernel?" above a commented-out `rb_raise` for `abs(DATA_MIN)`. #230 answered it: the kernel sets an error flag and `gen/tmpl/unary2.c` turns it into `cumo_na_eValueError`, the same mechanism #218 uses for integer division by zero. `Cumo::Int32[-2147483648].abs` raises `Cumo::NArray::ValueError` today. `m_abs` for signed integers has no other kernel caller -- `var`, `stddev` and `rms` are defined for float types only.

`ndloop.c` and `reduce_kernel.h` ask for the reduction indexer loop to compact, or squash, its dimensions, "if it allows speed up". There is no speed up left there: #248 stopped a flat reduction from reading its operand through the indexer at all, and #253 gave a reduction over an outer axis host-side addressing with a coalesced thread split. `DFloat` `sum` over 2^22 elements takes 0.057 ms, about 590 GB/s effective, so the path is bandwidth bound as it stands. `ndloop.c` still skips the contraction and the `// do nothing` above it still says so.

## Note

I went through the other 24 TODO and FIXME comments in `ext/` and `lib/`. Every one of them still describes work that has not been done, so nothing else is touched here.
