### PR TITLE
Run the nan-aware reductions on the GPU

### DIFF
--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -12,7 +12,7 @@ void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(cumo_na_reduction_arg_t
 static void
 <%=c_iter%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    <% if type_name == 'robject' || name == 'kahan_sum' || nan == '_nan' %>
+    <% if type_name == 'robject' || name == 'kahan_sum' %>
     {
         size_t   n;
         char    *p1, *p2;
@@ -78,13 +78,6 @@ static VALUE
   <% else %>
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
   <% end %>
-    //<% if is_float && indexer_ops.include?(name) && type_name != 'robject' %>
-    // Only the kernel reads the indexer. The nan iterator just selected is a
-    // host loop over lp->args[0].iter[0], which the indexer path does not set up.
-    if (ndf.func == <%=c_iter%>_nan) {
-        ndf.flag &= ~CUMO_NDF_INDEXER_LOOP;
-    }
-    //<% end %>
     if (cumo_na_has_idx_p(self)) {
         VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
         v =  cumo_na_ndloop(&ndf, 2, copy, reduce);

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -69,6 +69,76 @@ struct cumo_<%=type_name%>_rms_impl {
     __device__ rtype MapOut(rtype accum) { return r_sqrt(accum / n); }
 };
 
+// The nan-aware forms. An element with a NaN in either component maps to an
+// accumulator that contributes nothing: Reduce above already returns early on
+// a zero count, and mean and rms carry the count of what was left rather than
+// the length of the reduce axis.
+struct cumo_<%=type_name%>_sum_nan_impl {
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_zero; }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return not_nan(in) ? in : m_zero; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum = m_add(next, accum); }
+    __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_prod_nan_impl {
+    __device__ <%=dtype%> Identity(int64_t /*index*/) { return m_one; }
+    __device__ <%=dtype%> MapIn(dtype in, int64_t /*index*/) { return not_nan(in) ? in : m_one; }
+    __device__ void Reduce(<%=dtype%> next, <%=dtype%>& accum) { accum = m_mul(next, accum); }
+    __device__ <%=dtype%> MapOut(<%=dtype%> accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_moments_nan_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ Moments MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {0, m_zero, 0}; }
+        return {1, in, 0};
+    }
+};
+
+struct cumo_<%=type_name%>_var_nan_impl : cumo_<%=type_name%>_moments_nan_impl {
+    // Every element being NaN leaves no count. numo divides by count-1 in
+    // unsigned arithmetic there, so it answers +0 rather than the -0 that
+    // dividing by -1 would give.
+    __device__ rtype MapOut(Moments accum) { return accum.n == 0 ? 0 : accum.m2 / (accum.n - 1); }
+};
+
+struct cumo_<%=type_name%>_stddev_nan_impl : cumo_<%=type_name%>_moments_nan_impl {
+    __device__ rtype MapOut(Moments accum) { return accum.n == 0 ? 0 : r_sqrt(accum.m2 / (accum.n - 1)); }
+};
+
+struct cumo_<%=type_name%>_mean_nan_impl {
+    struct SumAndCount {
+        dtype sum;
+        rtype n;
+    };
+    __device__ SumAndCount Identity(int64_t /*index*/) { return {m_zero, 0}; }
+    __device__ SumAndCount MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {m_zero, 0}; }
+        return {in, 1};
+    }
+    __device__ void Reduce(SumAndCount next, SumAndCount& accum) {
+        accum.sum = m_add(next.sum, accum.sum);
+        accum.n += next.n;
+    }
+    __device__ dtype MapOut(SumAndCount accum) { return c_div_r(accum.sum, accum.n); }
+};
+
+struct cumo_<%=type_name%>_rms_nan_impl {
+    struct SumAndCount {
+        rtype sum;
+        rtype n;
+    };
+    __device__ SumAndCount Identity(int64_t /*index*/) { return {0, 0}; }
+    __device__ SumAndCount MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {0, 0}; }
+        return {c_abs_square(in), 1};
+    }
+    __device__ void Reduce(SumAndCount next, SumAndCount& accum) {
+        accum.sum += next.sum;
+        accum.n += next.n;
+    }
+    __device__ rtype MapOut(SumAndCount accum) { return r_sqrt(accum.sum / accum.n); }
+};
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -106,4 +176,34 @@ void cumo_<%=type_name%>_rms_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     rtype n = (rtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
     cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_impl>(*arg, cumo_<%=type_name%>_rms_impl{n});
+}
+
+void cumo_<%=type_name%>_sum_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_sum_nan_impl>(*arg, cumo_<%=type_name%>_sum_nan_impl{});
+}
+
+void cumo_<%=type_name%>_prod_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, <%=dtype%>, cumo_<%=type_name%>_prod_nan_impl>(*arg, cumo_<%=type_name%>_prod_nan_impl{});
+}
+
+void cumo_<%=type_name%>_mean_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_mean_nan_impl>(*arg, cumo_<%=type_name%>_mean_nan_impl{});
+}
+
+void cumo_<%=type_name%>_var_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_var_nan_impl>(*arg, cumo_<%=type_name%>_var_nan_impl{});
+}
+
+void cumo_<%=type_name%>_stddev_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_stddev_nan_impl>(*arg, cumo_<%=type_name%>_stddev_nan_impl{});
+}
+
+void cumo_<%=type_name%>_rms_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_nan_impl>(*arg, cumo_<%=type_name%>_rms_nan_impl{});
 }

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -57,6 +57,62 @@ struct cumo_<%=type_name%>_rms_impl {
     __device__ rtype MapOut(rtype accum) { return m_sqrt(accum / n); }
 };
 
+// The nan-aware forms. A NaN maps to an accumulator that contributes nothing:
+// Reduce above already returns early on a zero count, so the moments never see
+// it, and mean and rms carry the count of what was left rather than the length
+// of the reduce axis.
+struct cumo_<%=type_name%>_moments_nan_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ Moments MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {0, m_zero, 0}; }
+        return {1, in, 0};
+    }
+};
+
+struct cumo_<%=type_name%>_var_nan_impl : cumo_<%=type_name%>_moments_nan_impl {
+    // Every element being NaN leaves no count. numo divides by count-1 in
+    // unsigned arithmetic there, so it answers +0 rather than the -0 that
+    // dividing by -1 would give.
+    __device__ rtype MapOut(Moments accum) { return accum.n == 0 ? 0 : accum.m2 / (accum.n - 1); }
+};
+
+struct cumo_<%=type_name%>_stddev_nan_impl : cumo_<%=type_name%>_moments_nan_impl {
+    __device__ rtype MapOut(Moments accum) { return accum.n == 0 ? 0 : m_sqrt(accum.m2 / (accum.n - 1)); }
+};
+
+struct cumo_<%=type_name%>_mean_nan_impl {
+    struct SumAndCount {
+        dtype sum;
+        rtype n;
+    };
+    __device__ SumAndCount Identity(int64_t /*index*/) { return {m_zero, 0}; }
+    __device__ SumAndCount MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {m_zero, 0}; }
+        return {in, 1};
+    }
+    __device__ void Reduce(SumAndCount next, SumAndCount& accum) {
+        accum.sum = m_add(next.sum, accum.sum);
+        accum.n += next.n;
+    }
+    __device__ dtype MapOut(SumAndCount accum) { return m_div(accum.sum, m_from_real(accum.n)); }
+};
+
+struct cumo_<%=type_name%>_rms_nan_impl {
+    struct SumAndCount {
+        rtype sum;
+        rtype n;
+    };
+    __device__ SumAndCount Identity(int64_t /*index*/) { return {0, 0}; }
+    __device__ SumAndCount MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {0, 0}; }
+        return {m_square(m_abs(in)), 1};
+    }
+    __device__ void Reduce(SumAndCount next, SumAndCount& accum) {
+        accum.sum += next.sum;
+        accum.n += next.n;
+    }
+    __device__ rtype MapOut(SumAndCount accum) { return m_sqrt(accum.sum / accum.n); }
+};
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -84,4 +140,24 @@ void cumo_<%=type_name%>_rms_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     rtype n = (rtype)(arg->in_indexer.total_size / arg->out_indexer.total_size);
     cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_impl>(*arg, cumo_<%=type_name%>_rms_impl{n});
+}
+
+void cumo_<%=type_name%>_mean_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_mean_nan_impl>(*arg, cumo_<%=type_name%>_mean_nan_impl{});
+}
+
+void cumo_<%=type_name%>_var_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_var_nan_impl>(*arg, cumo_<%=type_name%>_var_nan_impl{});
+}
+
+void cumo_<%=type_name%>_stddev_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_stddev_nan_impl>(*arg, cumo_<%=type_name%>_stddev_nan_impl{});
+}
+
+void cumo_<%=type_name%>_rms_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_nan_impl>(*arg, cumo_<%=type_name%>_rms_nan_impl{});
 }

--- a/ext/cumo/narray/gen/tmpl/minmax.c
+++ b/ext/cumo/narray/gen/tmpl/minmax.c
@@ -1,12 +1,15 @@
 <% unless type_name == 'robject' %>
 void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2);
+<% if is_float %>
+void cumo_<%=type_name%>_minmax_nan_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2);
+<% end %>
 <% end %>
 
 <% (is_float ? ["","_nan"] : [""]).each do |j| %>
 static void
 <%=c_iter%><%=j%>(cumo_na_loop_t *const lp)
 {
-    <% if type_name == 'robject' || j == '_nan' %>
+    <% if type_name == 'robject' %>
     {
         size_t   n;
         char    *p1;
@@ -27,7 +30,7 @@ static void
     {
         cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
         cumo_na_iarray_t out2 = cumo_na_make_iarray_given_ndim(&lp->args[2], arg.out_indexer.ndim);
-        cumo_<%=type_name%>_minmax_kernel_launch(&arg, &out2);
+        cumo_<%=type_name%>_minmax<%=j%>_kernel_launch(&arg, &out2);
     }
     <% end %>
 }
@@ -59,11 +62,7 @@ static VALUE
     reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
   <% end %>
     //<% unless type_name == 'robject' %>
-    // Only the kernel reads the indexer. The nan iterator above is a host loop
-    // over lp->args[0].iter[0], which CUMO_NDF_INDEXER_LOOP does not set up.
-    if (ndf.func == <%=c_iter%>) {
-        ndf.flag |= CUMO_NDF_INDEXER_LOOP;
-    }
+    ndf.flag |= CUMO_NDF_INDEXER_LOOP;
     //<% end %>
     if (cumo_na_has_idx_p(self)) {
         VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -101,6 +101,61 @@ struct cumo_<%=type_name%>_ptp_impl {
     }
 };
 
+<% if is_float %>
+// The nan-aware forms of the reductions above. sum, prod and their kin skip a
+// NaN, so it maps to the identity and the tree never sees it. min and max go
+// the other way: numo answers NaN as soon as one element is NaN, and a NaN
+// absorbs in Reduce because it loses every comparison.
+struct cumo_<%=type_name%>_sum_nan_impl {
+    __device__ dtype Identity(int64_t /*index*/) { return m_zero; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return not_nan(in) ? in : m_zero; }
+    __device__ void Reduce(dtype next, dtype& accum) { accum = m_add(next, accum); }
+    __device__ dtype MapOut(dtype accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_prod_nan_impl {
+    __device__ dtype Identity(int64_t /*index*/) { return m_one; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return not_nan(in) ? in : m_one; }
+    __device__ void Reduce(dtype next, dtype& accum) { accum = m_mul(next, accum); }
+    __device__ dtype MapOut(dtype accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_min_nan_impl {
+    __device__ dtype Identity(int64_t /*index*/) { return DATA_MAX; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { if (!not_nan(next) || next < accum) { accum = next; } }
+    __device__ dtype MapOut(dtype accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_max_nan_impl {
+    __device__ dtype Identity(int64_t /*index*/) { return DATA_MIN; }
+    __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
+    __device__ void Reduce(dtype next, dtype& accum) { if (!not_nan(next) || accum < next) { accum = next; } }
+    __device__ dtype MapOut(dtype accum) { return accum; }
+};
+
+struct cumo_<%=type_name%>_minmax_nan_impl {
+    struct MinAndMax {
+        dtype min;
+        dtype max;
+    };
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
+    __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
+    __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
+        if (!not_nan(next.min) || next.min < accum.min) { accum.min = next.min; }
+        if (!not_nan(next.max) || accum.max < next.max) { accum.max = next.max; }
+    }
+    __device__ void MapOut(MinAndMax accum, dtype* out_min, dtype* out_max) {
+        *out_min = accum.min;
+        *out_max = accum.max;
+    }
+};
+
+struct cumo_<%=type_name%>_ptp_nan_impl : cumo_<%=type_name%>_minmax_nan_impl {
+    __device__ dtype MapOut(MinAndMax accum) { return m_sub(accum.max, accum.min); }
+};
+<% end %>
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -137,3 +192,35 @@ void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo
 {
     cumo_reduce_pair_split<dtype, dtype, cumo_<%=type_name%>_minmax_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_impl{});
 }
+<% if is_float %>
+
+void cumo_<%=type_name%>_sum_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_sum_nan_impl>(*arg, cumo_<%=type_name%>_sum_nan_impl{});
+}
+
+void cumo_<%=type_name%>_prod_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_prod_nan_impl>(*arg, cumo_<%=type_name%>_prod_nan_impl{});
+}
+
+void cumo_<%=type_name%>_min_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_min_nan_impl>(*arg, cumo_<%=type_name%>_min_nan_impl{});
+}
+
+void cumo_<%=type_name%>_max_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_max_nan_impl>(*arg, cumo_<%=type_name%>_max_nan_impl{});
+}
+
+void cumo_<%=type_name%>_ptp_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_ptp_nan_impl>(*arg, cumo_<%=type_name%>_ptp_nan_impl{});
+}
+
+void cumo_<%=type_name%>_minmax_nan_kernel_launch(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* out2)
+{
+    cumo_reduce_pair_split<dtype, dtype, cumo_<%=type_name%>_minmax_nan_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_nan_impl{});
+}
+<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4329,6 +4329,81 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
 
+  test "the nan-aware reductions skip NaN, and min and max answer NaN" do
+    nan = Float::NAN
+    flat = ->(v) { v.respond_to?(:ndim) ? v.to_a.flatten : [v] }
+    nan_p = lambda do |v|
+      return v.real.nan? || v.imag.nan? if v.is_a?(Complex)
+      v.respond_to?(:nan?) && v.nan?
+    end
+    close = lambda do |got, want, label|
+      g = flat.call(got)
+      w = flat.call(want)
+      assert_equal(w.size, g.size, label)
+      g.zip(w).each_with_index do |(x, y), i|
+        if nan_p.call(y)
+          assert(nan_p.call(x), "#{label}[#{i}]: expected NaN, got #{x.inspect}")
+        else
+          assert_in_delta(0, (x - y).abs, (y.abs * 1e-5) + 1e-5, "#{label}[#{i}]")
+        end
+      end
+    end
+
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      with = dtype.cast([3.0, -1.0, nan, 1.0, 5.0])
+      kept = dtype.cast([3.0, -1.0, 1.0, 5.0])
+      %i[sum prod mean var stddev rms].each do |op|
+        close.call(with.send(op, nan: true), kept.send(op), "#{dtype} #{op}")
+      end
+      %i[min max ptp].each { |op| close.call(with.send(op, nan: true), nan, "#{dtype} #{op}") }
+      close.call(with.minmax(nan: true)[0], nan, "#{dtype} minmax min")
+      close.call(with.minmax(nan: true)[1], nan, "#{dtype} minmax max")
+
+      none = dtype.cast([nan] * 4)
+      close.call(none.sum(nan: true), 0, "#{dtype} sum of all NaN")
+      close.call(none.prod(nan: true), 1, "#{dtype} prod of all NaN")
+      close.call(none.var(nan: true), 0, "#{dtype} var of all NaN")
+      close.call(none.stddev(nan: true), 0, "#{dtype} stddev of all NaN")
+      %i[mean rms min max ptp].each do |op|
+        close.call(none.send(op, nan: true), nan, "#{dtype} #{op} of all NaN")
+      end
+    end
+
+    # whole rows are NaN, so the answer is the plain reduction over the rows
+    # that are left
+    [Cumo::DFloat, Cumo::DComplex].each do |dtype|
+      base = dtype.new(6, 40).seq + 1
+      nan_rows = [1, 4]
+      kept_rows = (0...6).to_a - nan_rows
+      a = base.copy
+      a[nan_rows, true] = nan
+      kept = base[kept_rows, true]
+      %i[sum mean var stddev rms].each do |op|
+        close.call(a.send(op, axis: 0, nan: true), kept.send(op, axis: 0), "#{dtype} #{op} axis 0")
+        close.call(a.send(op, nan: true), kept.send(op), "#{dtype} #{op} flat")
+        close.call(a.transpose.send(op, axis: 1, nan: true), kept.transpose.send(op, axis: 1),
+                   "#{dtype} #{op} transposed")
+      end
+      next if dtype == Cumo::DComplex
+
+      # every column meets a NaN row, so every one of these is NaN
+      all_nan = Cumo::DFloat.new(40).fill(nan)
+      %i[min max ptp].each do |op|
+        close.call(a.send(op, axis: 0, nan: true), all_nan, "#{dtype} #{op} axis 0")
+        close.call(a.transpose.send(op, axis: 1, nan: true), all_nan, "#{dtype} #{op} transposed")
+      end
+      got = a.minmax(axis: 0, nan: true)
+      close.call(got[0], all_nan, "#{dtype} minmax axis 0 min")
+      close.call(got[1], all_nan, "#{dtype} minmax axis 0 max")
+      # a column with no NaN keeps the plain answer
+      clean = base[kept_rows, true]
+      %i[min max ptp].each do |op|
+        close.call(clean.send(op, axis: 0, nan: true), clean.send(op, axis: 0),
+                   "#{dtype} #{op} axis 0 without nan")
+      end
+    end
+  end
+
   test "a boolean mask reaches every element of a view and no others" do
     mask_expect = lambda do |a, m|
       flat = a.flatten.to_a


### PR DESCRIPTION
## Summary

- Give every nan-aware reduction a `ReductionImpl` of its own, so `nan: true` takes the same kernel path the plain form already takes instead of synchronizing and walking the array on the host.
- 2^22 `DFloat` elements: `sum` 2.27 -> 0.06 ms, `min` 4.20 -> 0.05 ms, `var` 6.61 -> 0.46 ms.
- Add a test over both families of semantics; three injected faults each fail it.

## Problem

`gen/tmpl/accum.c` sent `nan == '_nan'` to the host loop, and cleared `CUMO_NDF_INDEXER_LOOP` again when it did, so `sum(nan: true)` and its kin paid a `cudaDeviceSynchronize` and then read every element through managed memory. `minmax` did the same. The cost was one to two orders of magnitude:

| op | before | after |
|---|---|---|
| `sum(nan: true)` | 2.273 ms | 0.058 ms |
| `prod(nan: true)` | 3.540 ms | 0.057 ms |
| `mean(nan: true)` | 3.712 ms | 0.086 ms |
| `stddev(nan: true)` | 7.016 ms | 0.464 ms |
| `var(nan: true)` | 6.607 ms | 0.464 ms |
| `rms(nan: true)` | 3.422 ms | 0.107 ms |
| `min(nan: true)` | 4.195 ms | 0.054 ms |
| `max(nan: true)` | 3.923 ms | 0.054 ms |
| `ptp(nan: true)` | 4.409 ms | 0.078 ms |
| `minmax(nan: true)` | 3.388 ms | 0.078 ms |

`DFloat`, 2^22 elements, on an RTX 5070 Ti Laptop. The plain forms of the same reductions answer in 0.04 to 0.45 ms, so `nan: true` now costs about what the plain form costs.

There are two families of semantics and they need opposite treatment. `sum`, `prod`, `mean`, `var`, `stddev` and `rms` skip a NaN, so a NaN maps to the identity and the tree never sees it; `mean` and `rms` then have to carry the count of what was left rather than the length of the reduce axis, and the moments accumulator already ignores a zero count. `min`, `max`, `ptp` and `minmax` go the other way: numo answers NaN as soon as one element is NaN, which a NaN does on its own in `Reduce` because it loses every comparison.

## Note

Compared against numo 0.9.2.1 over 640 cases: `SFloat`, `DFloat`, `SComplex` and `DComplex`, lengths 5 and 1000, with no NaN, some NaN, a NaN first, a NaN last and every element NaN, then again over `axis: 0`, `axis: 1`, `axis: [0, 1]` and the flat reduction, on contiguous, column-sliced, reversed, transposed and index-array views.

Every case agrees except two, and both are differences the plain reductions already have on this hardware:

- single-precision `var` and `stddev` differ in the last digits, because the kernel combines Chan's online moments while numo takes two passes with the exact mean. `Cumo::SFloat#var` without `nan: true` gives the same 796.1811523 against numo's 796.1812134 on master today. `DFloat` and `DComplex` agree exactly.
- `DComplex#prod` differs in the sign of a zero, because the tree multiplies in a different order. `Cumo::DComplex#prod` without `nan: true` already answers `-0.0+0.0i` where numo answers `0.0+0.0i`.

Every element being NaN leaves `var` and `stddev` with no count. numo divides by `count - 1` in unsigned arithmetic there and answers `+0`, so the kernel returns `0` rather than the `-0` that dividing by `-1` would give.

`max_index`, `min_index`, `argmax`, `argmin` and `kahan_sum` still run on the host; they are separate mechanisms and not in this change.
