### PR TITLE
Run the nan-aware index reductions on the GPU and split their axis

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -350,7 +350,7 @@ __global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_n
 // The scratch is laid out by output so the combine pass can read it flat, but
 // threads are handed out by output first, so a block still covers consecutive
 // outputs when those are the ones running along memory.
-template <bool FLAT, typename TypeIn, typename TypeReduce, typename ReductionImpl>
+template <bool FLAT, bool ARG, typename TypeIn, typename TypeReduce, typename ReductionImpl>
 __global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
@@ -374,7 +374,7 @@ __global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cum
         ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
         int64_t i_in = i_out * reduce_total_size + begin + reduce_offset;
 
-        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, begin, end, reduce_offset, reduce_block_size);
+        TypeReduce accum = reduce_axis<FLAT,ARG,TypeIn>(arg, ad, impl, in_out_off, i_in, begin, end, reduce_offset, reduce_block_size);
 
         accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
         if (reduce_offset == 0) {
@@ -410,7 +410,7 @@ struct reduce_combine {
 // Allocates the scratch and runs the first pass, then points arg2's input at
 // the partials so the caller can combine them with its own second pass. The
 // caller frees the returned buffer.
-template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
+template <typename TypeIn, typename TypeReduce, typename ReductionImpl, bool ARG = false>
 TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int64_t n_split, int64_t reduce_total_size, cumo_na_reduction_arg_t* arg2, ReductionImpl& impl) {
     int64_t chunk = (reduce_total_size + n_split - 1) / n_split;
     int64_t partial_total_size = arg.out_indexer.total_size * n_split;
@@ -423,9 +423,9 @@ TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t 
     int64_t shared_mem_size = sizeof(TypeReduce) * max_block_size;
 
     if (ad.in_out_flat && ad.in_reduce_flat) {
-        reduction_partial_kernel<true,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+        reduction_partial_kernel<true,ARG,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     } else {
-        reduction_partial_kernel<false,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+        reduction_partial_kernel<false,ARG,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     }
     cumo_cuda_runtime_check_kernel_launch();
 
@@ -578,6 +578,36 @@ void cumo_reduce_arg(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
         cumo_detail::reduction_arg_kernel<false,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, ad, out_block_size, reduce_block_size, impl);
     }
     cumo_cuda_runtime_check_kernel_launch();
+}
+
+// cumo_reduce_split for the arg form. The partials already carry indices along
+// the reduce axis, so the second pass combines them with the plain kernel.
+// Only for an impl whose Identity ignores its index argument.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_arg_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    if (arg.out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
+    if (n_split < 2) {
+        cumo_reduce_arg<TypeIn, TypeOut, ReductionImpl>(arg, std::forward<ReductionImpl>(impl));
+        return;
+    }
+
+    cumo_na_reduction_arg_t arg2 = arg;
+    TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl, true>(arg, ad, n_split, reduce_total_size, &arg2, impl);
+    cumo_reduce<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, cumo_detail::reduce_combine<ReductionImpl>{impl});
+    cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }
 
 #endif // CUMO_REDUCE_KERNEL_H

--- a/ext/cumo/narray/gen/tmpl/accum_arg.c
+++ b/ext/cumo/narray/gen/tmpl/accum_arg.c
@@ -2,15 +2,14 @@
 
 <%   [64,32].each do |i| %>
 <% unless type_name == 'robject' %>
-void cumo_<%=type_name%>_<%=name%>_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg);
+void cumo_<%=type_name%>_<%=name%><%=nan%>_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg);
 <% end %>
 
 #define idx_t int<%=i%>_t
 static void
 <%=c_iter%>_arg<%=i%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    // TODO(sonots): Support nan in CUDA
-    <% if type_name == 'robject' || nan == '_nan' %>
+    <% if type_name == 'robject' %>
     {
         size_t   n, idx;
         char    *d_ptr, *o_ptr;
@@ -28,7 +27,7 @@ static void
     <% else %>
     {
         cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
-        cumo_<%=type_name%>_<%=name%>_int<%=i%>_kernel_launch(&arg);
+        cumo_<%=type_name%>_<%=name%><%=nan%>_int<%=i%>_kernel_launch(&arg);
     }
     <% end %>
 }
@@ -109,14 +108,6 @@ static VALUE
             reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
             <% end %>
         }
-
-        <% if is_float %>
-        // Only the kernel reads the indexer. The nan iterator just selected is a
-        // host loop over lp->args[0].iter[0], which the indexer path does not set up.
-        if (ndf.func == iter_nan) {
-            ndf.flag &= ~CUMO_NDF_INDEXER_LOOP;
-        }
-        <% end %>
 
         if (cumo_na_has_idx_p(self)) {
             VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous

--- a/ext/cumo/narray/gen/tmpl/accum_arg_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_arg_kernel.cu
@@ -13,36 +13,104 @@
 #endif
 
 struct cumo_<%=type_name%>_argmin_int<%=i%>_impl {
-    struct MinAndArgMin {
-        dtype min;
-        idx_t argmin;
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
     };
-    __device__ MinAndArgMin Identity(idx_t index) { return {DATA_MAX, index}; }
-    __device__ MinAndArgMin MapIn(dtype in, idx_t index) { return {in, index}; }
-    // A tie keeps the earlier element, whichever thread found it: the blocks
-    // and the shared-memory tree fold in an order unrelated to the input.
-    __device__ void Reduce(MinAndArgMin next, MinAndArgMin& accum) {
-        if (accum.min > next.min || (accum.min == next.min && next.argmin < accum.argmin)) {
-            accum = next;
+    // The identity has to lose to any element, including a NaN, and it
+    // carries the largest index so that a tie goes to the earlier one.
+    // NaN is the identity for the float types, the way it is for min and
+    // max, so that every element being NaN answers the first index as
+    // numo does.
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {<% if is_float %>(dtype)nan("")<% else %>DATA_MAX<% end %>, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+<% if is_float %>
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (accum_nan && (!next_nan || next.index < accum.index)) { accum = next; }
+            return;
         }
+<% end %>
+        if (accum.value > next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
     }
-    __device__ idx_t MapOut(MinAndArgMin accum) { return accum.argmin; }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
 };
 
-struct cumo_<%=type_name%>_argmax_int<%=i%>_impl {
-    struct MaxAndArgMax {
-        dtype max;
-        idx_t argmax;
+<% if is_float %>
+// numo answers the index of the first NaN as soon as one element is NaN,
+// so a NaN wins outright here and the earliest of them wins among
+// themselves. The identity cannot be NaN for that reason.
+struct cumo_<%=type_name%>_argmin_nan_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
     };
-    __device__ MaxAndArgMax Identity(idx_t index) { return {DATA_MIN, index}; }
-    __device__ MaxAndArgMax MapIn(dtype in, idx_t index) { return {in, index}; }
-    __device__ void Reduce(MaxAndArgMax next, MaxAndArgMax& accum) {
-        if (accum.max < next.max || (accum.max == next.max && next.argmax < accum.argmax)) {
-            accum = next;
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {(dtype)INFINITY, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (next_nan && (!accum_nan || next.index < accum.index)) { accum = next; }
+            return;
         }
+        if (accum.value > next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
     }
-    __device__ idx_t MapOut(MaxAndArgMax accum) { return accum.argmax; }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
 };
+<% end %>
+
+struct cumo_<%=type_name%>_argmax_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
+    };
+    // The identity has to lose to any element, including a NaN, and it
+    // carries the largest index so that a tie goes to the earlier one.
+    // NaN is the identity for the float types, the way it is for min and
+    // max, so that every element being NaN answers the first index as
+    // numo does.
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {<% if is_float %>(dtype)nan("")<% else %>DATA_MIN<% end %>, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+<% if is_float %>
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (accum_nan && (!next_nan || next.index < accum.index)) { accum = next; }
+            return;
+        }
+<% end %>
+        if (accum.value < next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
+    }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
+};
+
+<% if is_float %>
+// numo answers the index of the first NaN as soon as one element is NaN,
+// so a NaN wins outright here and the earliest of them wins among
+// themselves. The identity cannot be NaN for that reason.
+struct cumo_<%=type_name%>_argmax_nan_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
+    };
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {-(dtype)INFINITY, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (next_nan && (!accum_nan || next.index < accum.index)) { accum = next; }
+            return;
+        }
+        if (accum.value < next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
+    }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
+};
+<% end %>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -53,13 +121,27 @@ extern "C" {
 
 void cumo_<%=type_name%>_argmin_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce_arg<dtype, idx_t, cumo_<%=type_name%>_argmin_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmin_int<%=i%>_impl{});
+    cumo_reduce_arg_split<dtype, idx_t, cumo_<%=type_name%>_argmin_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmin_int<%=i%>_impl{});
 }
+<% if is_float %>
+
+void cumo_<%=type_name%>_argmin_nan_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_arg_split<dtype, idx_t, cumo_<%=type_name%>_argmin_nan_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmin_nan_int<%=i%>_impl{});
+}
+<% end %>
 
 void cumo_<%=type_name%>_argmax_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce_arg<dtype, idx_t, cumo_<%=type_name%>_argmax_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmax_int<%=i%>_impl{});
+    cumo_reduce_arg_split<dtype, idx_t, cumo_<%=type_name%>_argmax_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmax_int<%=i%>_impl{});
 }
+<% if is_float %>
+
+void cumo_<%=type_name%>_argmax_nan_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_arg_split<dtype, idx_t, cumo_<%=type_name%>_argmax_nan_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_argmax_nan_int<%=i%>_impl{});
+}
+<% end %>
 
 #undef idx_t
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -9,8 +9,7 @@ void cumo_<%=type_name%>_<%=name%><%=nan%>_int<%=i%>_kernel_launch(cumo_na_reduc
 static void
 <%=c_iter%>_index<%=i%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    // TODO(sonots): Support nan in CUDA
-    <% if type_name == 'robject' || nan == '_nan' %>
+    <% if type_name == 'robject' %>
     {
         size_t   n, idx;
         char    *d_ptr, *i_ptr, *o_ptr;
@@ -94,7 +93,7 @@ static VALUE
         <% if is_float %>
         cumo_na_iter_func_t iter_nan;
         <% end %>
-        cumo_ndfunc_arg_in_t ain[3] = {{Qnil,0},{cumo_sym_reduce,0},{Qnil,0}};
+        cumo_ndfunc_arg_in_t ain[2] = {{Qnil,0},{cumo_sym_reduce,0}};
         cumo_ndfunc_arg_out_t aout[1] = {{0,0,0}};
         cumo_ndfunc_t ndf = {0, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_EXTRACT|CUMO_NDF_INDEXER_LOOP, 2,1, ain,aout};
 
@@ -118,27 +117,6 @@ static VALUE
             reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
             <% end %>
         }
-
-        <% if is_float %>
-        if (ndf.func == iter_nan) {
-            // The nan-aware path has no kernel and reads the index out of a seq
-            // array, the way robject does. Only that path takes a third argument.
-            VALUE idx = cumo_na_new(aout[0].type, na->ndim, na->shape);
-            rb_funcall(idx, rb_intern("seq"), 0);
-            ain[1].type = Qnil;
-            ain[2].type = cumo_sym_reduce;
-            ndf.nin = 3;
-            ndf.flag &= ~CUMO_NDF_INDEXER_LOOP;
-            if (cumo_na_has_idx_p(self)) {
-                self = cumo_na_copy(self);
-            }
-            ret = cumo_na_ndloop(&ndf, 3, self, idx, reduce);
-            if (cumo_compatible_mode_enabled_p()) {
-                return rb_funcall(ret, rb_intern("extract_cpu"), 0);
-            }
-            return ret;
-        }
-        <% end %>
 
         if (cumo_na_has_idx_p(self)) {
             VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous

--- a/ext/cumo/narray/gen/tmpl/accum_index_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_index_kernel.cu
@@ -13,36 +13,104 @@
 #endif
 
 struct cumo_<%=type_name%>_min_index_int<%=i%>_impl {
-    struct MinAndArgMin {
-        dtype min;
-        idx_t argmin;
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
     };
-    __device__ MinAndArgMin Identity(idx_t index) { return {DATA_MAX, index}; }
-    __device__ MinAndArgMin MapIn(dtype in, idx_t index) { return {in, index}; }
-    // A tie keeps the earlier element, whichever thread found it: the blocks
-    // and the shared-memory tree fold in an order unrelated to the input.
-    __device__ void Reduce(MinAndArgMin next, MinAndArgMin& accum) {
-        if (accum.min > next.min || (accum.min == next.min && next.argmin < accum.argmin)) {
-            accum = next;
+    // The identity has to lose to any element, including a NaN, and it
+    // carries the largest index so that a tie goes to the earlier one.
+    // NaN is the identity for the float types, the way it is for min and
+    // max, so that every element being NaN answers the first index as
+    // numo does.
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {<% if is_float %>(dtype)nan("")<% else %>DATA_MAX<% end %>, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+<% if is_float %>
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (accum_nan && (!next_nan || next.index < accum.index)) { accum = next; }
+            return;
         }
+<% end %>
+        if (accum.value > next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
     }
-    __device__ idx_t MapOut(MinAndArgMin accum) { return accum.argmin; }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
 };
 
-struct cumo_<%=type_name%>_max_index_int<%=i%>_impl {
-    struct MaxAndArgMax {
-        dtype max;
-        idx_t argmax;
+<% if is_float %>
+// numo answers the index of the first NaN as soon as one element is NaN,
+// so a NaN wins outright here and the earliest of them wins among
+// themselves. The identity cannot be NaN for that reason.
+struct cumo_<%=type_name%>_min_index_nan_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
     };
-    __device__ MaxAndArgMax Identity(idx_t index) { return {DATA_MIN, index}; }
-    __device__ MaxAndArgMax MapIn(dtype in, idx_t index) { return {in, index}; }
-    __device__ void Reduce(MaxAndArgMax next, MaxAndArgMax& accum) {
-        if (accum.max < next.max || (accum.max == next.max && next.argmax < accum.argmax)) {
-            accum = next;
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {(dtype)INFINITY, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (next_nan && (!accum_nan || next.index < accum.index)) { accum = next; }
+            return;
         }
+        if (accum.value > next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
     }
-    __device__ idx_t MapOut(MaxAndArgMax accum) { return accum.argmax; }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
 };
+<% end %>
+
+struct cumo_<%=type_name%>_max_index_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
+    };
+    // The identity has to lose to any element, including a NaN, and it
+    // carries the largest index so that a tie goes to the earlier one.
+    // NaN is the identity for the float types, the way it is for min and
+    // max, so that every element being NaN answers the first index as
+    // numo does.
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {<% if is_float %>(dtype)nan("")<% else %>DATA_MIN<% end %>, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+<% if is_float %>
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (accum_nan && (!next_nan || next.index < accum.index)) { accum = next; }
+            return;
+        }
+<% end %>
+        if (accum.value < next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
+    }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
+};
+
+<% if is_float %>
+// numo answers the index of the first NaN as soon as one element is NaN,
+// so a NaN wins outright here and the earliest of them wins among
+// themselves. The identity cannot be NaN for that reason.
+struct cumo_<%=type_name%>_max_index_nan_int<%=i%>_impl {
+    struct ValueAndIndex {
+        dtype value;
+        idx_t index;
+    };
+    __device__ ValueAndIndex Identity(idx_t /*index*/) { return {-(dtype)INFINITY, INT<%=i%>_MAX}; }
+    __device__ ValueAndIndex MapIn(dtype in, idx_t index) { return {in, index}; }
+    __device__ void Reduce(ValueAndIndex next, ValueAndIndex& accum) {
+        bool accum_nan = !not_nan(accum.value);
+        bool next_nan = !not_nan(next.value);
+        if (accum_nan || next_nan) {
+            if (next_nan && (!accum_nan || next.index < accum.index)) { accum = next; }
+            return;
+        }
+        if (accum.value < next.value || (accum.value == next.value && next.index < accum.index)) { accum = next; }
+    }
+    __device__ idx_t MapOut(ValueAndIndex accum) { return accum.index; }
+};
+<% end %>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -53,13 +121,27 @@ extern "C" {
 
 void cumo_<%=type_name%>_min_index_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, idx_t, cumo_<%=type_name%>_min_index_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_min_index_int<%=i%>_impl{});
+    cumo_reduce_split<dtype, idx_t, cumo_<%=type_name%>_min_index_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_min_index_int<%=i%>_impl{});
 }
+<% if is_float %>
+
+void cumo_<%=type_name%>_min_index_nan_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, idx_t, cumo_<%=type_name%>_min_index_nan_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_min_index_nan_int<%=i%>_impl{});
+}
+<% end %>
 
 void cumo_<%=type_name%>_max_index_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
-    cumo_reduce<dtype, idx_t, cumo_<%=type_name%>_max_index_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_max_index_int<%=i%>_impl{});
+    cumo_reduce_split<dtype, idx_t, cumo_<%=type_name%>_max_index_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_max_index_int<%=i%>_impl{});
 }
+<% if is_float %>
+
+void cumo_<%=type_name%>_max_index_nan_int<%=i%>_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, idx_t, cumo_<%=type_name%>_max_index_nan_int<%=i%>_impl>(*arg, cumo_<%=type_name%>_max_index_nan_int<%=i%>_impl{});
+}
+<% end %>
 
 #undef idx_t
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4329,6 +4329,80 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
 
+  test "the index reductions answer the earliest extreme, and the first NaN with nan" do
+    nan = Float::NAN
+    inf = Float::INFINITY
+    got = lambda do |a, op, nan_aware = false|
+      v = nan_aware ? a.send(op, nan: true) : a.send(op)
+      v = v.to_a if v.respond_to?(:ndim)
+      v = v.first while v.is_a?(Array) && v.size == 1
+      v
+    end
+    check = lambda do |label, a, want|
+      %i[max_index min_index argmax argmin].each_with_index do |op, i|
+        assert_equal(want[i], got.call(a, op), "#{label} #{op}")
+      end
+    end
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      # long enough that the reduce axis is split across blocks
+      n = 20_000
+      body = (0...n).map { |i| (i * 7 % 101) - 50.0 }
+      want = [body.each_with_index.max_by { |v, i| [v, -i] }[1],
+              body.each_with_index.min_by { |v, i| [v, i] }[1]]
+      check.call("#{dtype} plain", dtype.cast(body), [want[0], want[1], want[0], want[1]])
+
+      # -inf must not lose to the identity, and every element being NaN or the
+      # same value answers 0 as numo does
+      check.call("#{dtype} all -inf", dtype.cast([-inf] * n), [0, 0, 0, 0])
+      check.call("#{dtype} all +inf", dtype.cast([inf] * n), [0, 0, 0, 0])
+      check.call("#{dtype} all NaN", dtype.cast([nan] * n), [0, 0, 0, 0])
+      check.call("#{dtype} -inf 0 1 inf", dtype.cast([-inf, 0.0, 1.0, inf]), [3, 0, 3, 0])
+      check.call("#{dtype} ties", dtype.cast([1.0, 2.0, 2.0, 1.0]), [1, 0, 1, 0])
+
+      # without a NaN anywhere, nan: true has to answer what the plain form does
+      clean = dtype.cast(body)
+      %i[max_index min_index argmax argmin].each do |op|
+        assert_equal(got.call(clean, op), got.call(clean, op, true), "#{dtype} #{op} nan: true, no NaN")
+      end
+
+      with_nan = dtype.cast([3.0, -1.0, nan, 1.0, nan])
+      %i[max_index min_index argmax argmin].each do |op|
+        assert_equal(2, got.call(with_nan, op, true), "#{dtype} #{op} takes the first NaN")
+        assert_equal(op.to_s.include?("max") ? 0 : 1, got.call(with_nan, op),
+                     "#{dtype} #{op} without nan skips NaN")
+      end
+    end
+
+    [Cumo::Int32, Cumo::Int64].each do |dtype|
+      lo = dtype == Cumo::Int32 ? -(2**31) : -(2**63)
+      check.call("#{dtype} all min", dtype.cast([lo] * 100), [0, 0, 0, 0])
+      check.call("#{dtype} ties", dtype.cast([1, 2, 2, 1]), [1, 0, 1, 0])
+    end
+
+    # a column whose every element is the identity's own value: the identity
+    # has to lose to it, or the answer is the identity's index rather than the
+    # first element of that column
+    {
+      "column of -inf" => [[[5.0, -inf], [6.0, -inf]], [[2, 1], [0, 1]]],
+      "column of +inf" => [[[5.0, inf], [6.0, inf]], [[2, 1], [0, 1]]],
+      "column of NaN" => [[[5.0, nan], [6.0, nan]], [[2, 1], [0, 1]]],
+    }.each do |label, (src, want)|
+      a = Cumo::DFloat.cast(src)
+      assert_equal(want[0], a.max_index(axis: 0).to_a, "#{label} max_index")
+      assert_equal(want[1], a.min_index(axis: 0).to_a, "#{label} min_index")
+    end
+
+    b = Cumo::DFloat.new(5, 24).seq
+    [b, b.transpose, b[true, 23.step(0, -1)]].each_with_index do |v, vi|
+      [0, 1].each do |ax|
+        %i[max_index min_index argmax argmin].each do |op|
+          assert_equal(v.send(op, axis: ax).to_a, v.send(op, axis: ax, nan: true).to_a,
+                       "view #{vi} axis #{ax} #{op} over a view with no NaN")
+        end
+      end
+    end
+  end
+
   test "the nan-aware reductions skip NaN, and min and max answer NaN" do
     nan = Float::NAN
     flat = ->(v) { v.respond_to?(:ndim) ? v.to_a.flatten : [v] }


### PR DESCRIPTION
## Summary

- Give `max_index`, `min_index`, `argmax` and `argmin` a nan-aware `ReductionImpl`, so `nan: true` stops synchronizing and walking the array on the host.
- Split the reduce axis across blocks for all four, plain and nan-aware alike. A flat reduction gave the grid one block, which is why `max_index` took 33 times what `max` takes.
- 2^22 `DFloat` elements: `max_index` 1.80 -> 0.06 ms, `max_index(nan: true)` 5.51 -> 0.12 ms.

## Problem

`accum_index.c` and `accum_arg.c` sent `nan == '_nan'` to the host loop and cleared `CUMO_NDF_INDEXER_LOOP` again when they did, the way `accum.c` did before #275. `accum_index.c` went further and built a `seq` index array as a third operand for that path.

The plain forms were on the GPU but slow for a flat reduction: `cumo_reduce` sizes the grid by the number of outputs, and a whole-array reduction has one, so 2^22 elements went through a single block.

| op | before | after |
|---|---|---|
| `max_index` | 1.795 ms | 0.056 ms |
| `max_index(nan: true)` | 5.509 ms | 0.115 ms |
| `min_index` | 1.787 ms | 0.055 ms |
| `min_index(nan: true)` | 5.116 ms | 0.115 ms |
| `argmax` | 1.807 ms | 0.054 ms |
| `argmax(nan: true)` | 4.631 ms | 0.115 ms |
| `argmin` | 1.808 ms | 0.055 ms |
| `argmin(nan: true)` | 4.654 ms | 0.117 ms |

`DFloat`, 2^22 elements. `max` over the same array takes 0.054 ms, so the index forms now cost what the value forms cost. A 2048x2048 reduction over axis 0, which already had blocks to fill, is unchanged at 0.052 ms.

## Note

Splitting needs an `Identity` that ignores its index argument, since the second pass combines partials rather than elements. Making it ignore the index took getting the identity right, and the value mattered as much as the index:

- the identity has to lose to **any** element, so it carries the largest representable index and a tie goes to the earlier one.
- `DATA_MIN` is not the smallest float. A column of `-inf` loses to it and the identity survives with its own index. The identity is NaN for the float types, the way it is for `min` and `max` since #219: a real element beats a NaN, a NaN never beats a real element, and among NaNs the earliest index wins — which is the index numo answers when every element is NaN.
- the nan-aware forms cannot use NaN, since a NaN wins outright there and the identity would be the answer. They use `-inf` and `+inf`.

Compared against numo 0.9.2.1 over 1128 cases and all of them agree: `SFloat`, `DFloat`, `Int32` and `Int64`, lengths 4, 100 and 20000 so both sides of the split threshold, with no NaN, one NaN, a NaN first, a NaN last, every element NaN, every element `-inf`, every element `+inf`, `-inf` and `+inf` mixed, ties, `Float::MAX` and `-Float::MAX` alternating, and `INT32_MIN` throughout; then per axis over contiguous, transposed and reversed views, and over 2-D arrays with a whole column of `-inf`, `+inf` or NaN.

That last shape is the one that catches an identity that does not lose: `Cumo::DFloat[[5.0, -inf], [6.0, -inf]].max_index(axis: 0)` answers `[2, 1]`, and an identity carrying index 0 answers `[2, 0]`.

Two injected faults each fail the new test: putting the index back to 0 in the identity, and making the nan-aware identity NaN. The second needed an assertion that `nan: true` answers what the plain form does when nothing is NaN — without it the fault went undetected.
