### PR TITLE
Run kahan_sum on the GPU

### DIFF
--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -1,4 +1,4 @@
-<% indexer_ops = %w[sum prod min max ptp var stddev mean rms] %>
+<% indexer_ops = %w[sum prod min max ptp var stddev mean rms kahan_sum] %>
 <% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
 <% unless type_name == 'robject' %>
@@ -12,7 +12,7 @@ void cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(cumo_na_reduction_arg_t
 static void
 <%=c_iter%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    <% if type_name == 'robject' || name == 'kahan_sum' %>
+    <% if type_name == 'robject' %>
     {
         size_t   n;
         char    *p1, *p2;
@@ -40,8 +40,6 @@ static void
     }
     <% else %>
     {
-        // TODO(sonots): How to compute Kahan summation algorithm in parallel?
-        // TODO(sonots): Implement nan CUDA version
         cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 1);
         cumo_<%=type_name%>_<%=name%><%=nan%>_kernel_launch(&arg);
     }

--- a/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/complex_accum_kernel.cu
@@ -139,6 +139,39 @@ struct cumo_<%=type_name%>_rms_nan_impl {
     __device__ rtype MapOut(SumAndCount accum) { return r_sqrt(accum.sum / accum.n); }
 };
 
+<% if is_double_precision %>
+// Kahan-Babuska-Neumaier per component. See the real version for why the
+// compensation term is what lets a tree combine partials at all.
+struct cumo_<%=type_name%>_kahan_sum_impl {
+    struct SumAndComp {
+        dtype sum;
+        dtype comp;
+    };
+    __device__ SumAndComp Identity(int64_t /*index*/) { return {m_zero, m_zero}; }
+    __device__ SumAndComp MapIn(dtype in, int64_t /*index*/) { return {in, m_zero}; }
+    __device__ void Reduce(SumAndComp next, SumAndComp& accum) {
+        dtype t = c_add(accum.sum, next.sum);
+        rtype cr = (fabs(CUMO_REAL(accum.sum)) >= fabs(CUMO_REAL(next.sum)))
+                 ? (CUMO_REAL(accum.sum) - CUMO_REAL(t)) + CUMO_REAL(next.sum)
+                 : (CUMO_REAL(next.sum) - CUMO_REAL(t)) + CUMO_REAL(accum.sum);
+        rtype ci = (fabs(CUMO_IMAG(accum.sum)) >= fabs(CUMO_IMAG(next.sum)))
+                 ? (CUMO_IMAG(accum.sum) - CUMO_IMAG(t)) + CUMO_IMAG(next.sum)
+                 : (CUMO_IMAG(next.sum) - CUMO_IMAG(t)) + CUMO_IMAG(accum.sum);
+        CUMO_REAL(accum.comp) += CUMO_REAL(next.comp) + cr;
+        CUMO_IMAG(accum.comp) += CUMO_IMAG(next.comp) + ci;
+        accum.sum = t;
+    }
+    __device__ dtype MapOut(SumAndComp accum) { return c_add(accum.sum, accum.comp); }
+};
+
+struct cumo_<%=type_name%>_kahan_sum_nan_impl : cumo_<%=type_name%>_kahan_sum_impl {
+    __device__ SumAndComp MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {m_zero, m_zero}; }
+        return {in, m_zero};
+    }
+};
+<% end %>
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -207,3 +240,15 @@ void cumo_<%=type_name%>_rms_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_nan_impl>(*arg, cumo_<%=type_name%>_rms_nan_impl{});
 }
+<% if is_double_precision %>
+
+void cumo_<%=type_name%>_kahan_sum_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_kahan_sum_impl>(*arg, cumo_<%=type_name%>_kahan_sum_impl{});
+}
+
+void cumo_<%=type_name%>_kahan_sum_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_kahan_sum_nan_impl>(*arg, cumo_<%=type_name%>_kahan_sum_nan_impl{});
+}
+<% end %>

--- a/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/float_accum_kernel.cu
@@ -113,6 +113,38 @@ struct cumo_<%=type_name%>_rms_nan_impl {
     __device__ rtype MapOut(SumAndCount accum) { return m_sqrt(accum.sum / accum.n); }
 };
 
+<% if is_double_precision %>
+// Kahan-Babuska-Neumaier. The compensation term is what makes this associative:
+// a partial carries the running sum and everything that sum has lost, and two
+// partials combine by adding what their own addition loses to both. numo folds
+// the correction back into the sum each step, which a tree cannot do, so the
+// last digits differ; the error against an exact sum is not worse.
+struct cumo_<%=type_name%>_kahan_sum_impl {
+    struct SumAndComp {
+        dtype sum;
+        dtype comp;
+    };
+    __device__ SumAndComp Identity(int64_t /*index*/) { return {m_zero, m_zero}; }
+    __device__ SumAndComp MapIn(dtype in, int64_t /*index*/) { return {in, m_zero}; }
+    __device__ void Reduce(SumAndComp next, SumAndComp& accum) {
+        dtype t = accum.sum + next.sum;
+        dtype c = (fabs(accum.sum) >= fabs(next.sum))
+                ? (accum.sum - t) + next.sum
+                : (next.sum - t) + accum.sum;
+        accum.comp += next.comp + c;
+        accum.sum = t;
+    }
+    __device__ dtype MapOut(SumAndComp accum) { return accum.sum + accum.comp; }
+};
+
+struct cumo_<%=type_name%>_kahan_sum_nan_impl : cumo_<%=type_name%>_kahan_sum_impl {
+    __device__ SumAndComp MapIn(dtype in, int64_t /*index*/) {
+        if (!not_nan(in)) { return {m_zero, m_zero}; }
+        return {in, m_zero};
+    }
+};
+<% end %>
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -161,3 +193,15 @@ void cumo_<%=type_name%>_rms_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
 {
     cumo_reduce_split<dtype, rtype, cumo_<%=type_name%>_rms_nan_impl>(*arg, cumo_<%=type_name%>_rms_nan_impl{});
 }
+<% if is_double_precision %>
+
+void cumo_<%=type_name%>_kahan_sum_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_kahan_sum_impl>(*arg, cumo_<%=type_name%>_kahan_sum_impl{});
+}
+
+void cumo_<%=type_name%>_kahan_sum_nan_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, dtype, cumo_<%=type_name%>_kahan_sum_nan_impl>(*arg, cumo_<%=type_name%>_kahan_sum_nan_impl{});
+}
+<% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4329,6 +4329,55 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
 
+  test "kahan_sum keeps what a plain sum loses, in parallel" do
+    nan = Float::NAN
+    flat = lambda do |v|
+      v = v.to_a if v.respond_to?(:ndim)
+      v = v.first while v.is_a?(Array) && v.size == 1
+      v
+    end
+    rel_err = lambda do |v, exact|
+      ((Rational(flat.call(v)) - exact) / exact).abs
+    end
+
+    # one huge term and many tiny ones, which a sequential plain sum drops
+    n = 100_000
+    src = [1e16] + Array.new(n - 1) { 1.0 }
+    exact = Rational(10**16) + (n - 1)
+    a = Cumo::DFloat.cast(src)
+    assert(rel_err.call(a.kahan_sum, exact) < 1e-15,
+           "kahan_sum error #{rel_err.call(a.kahan_sum, exact).to_f}")
+
+    # values spread widely enough that the tree a plain sum walks loses digits
+    spread = Array.new(n) { |i| ((i * 2_654_435_761) % 1_000_003) / 1_000_003.0 - 0.5 }
+    b = Cumo::DFloat.cast(spread)
+    exact_spread = spread.map { |v| Rational(v) }.sum
+    assert(rel_err.call(b.kahan_sum, exact_spread) < rel_err.call(b.sum, exact_spread),
+           "kahan_sum #{rel_err.call(b.kahan_sum, exact_spread).to_f} should beat " \
+           "the plain sum #{rel_err.call(b.sum, exact_spread).to_f}")
+
+    # skipping NaN, and answering what the plain form does when there is none
+    with_nan = Cumo::DFloat.cast([1e16, nan, 1.0, 2.0, nan, 3.0])
+    kept = Cumo::DFloat.cast([1e16, 1.0, 2.0, 3.0])
+    assert_equal(flat.call(kept.kahan_sum), flat.call(with_nan.kahan_sum(nan: true)))
+    assert_equal(flat.call(kept.kahan_sum), flat.call(kept.kahan_sum(nan: true)))
+    assert_equal(0.0, flat.call(Cumo::DFloat.cast([nan] * 8).kahan_sum(nan: true)))
+
+    # a reduce axis long enough to be split across blocks, over a view
+    base = Cumo::DFloat.new(4, 30_000).seq + 1
+    [base, base[true, 29_999.step(0, -1)], base.transpose].each_with_index do |v, i|
+      [0, 1].each do |ax|
+        assert_in_delta(0, (v.kahan_sum(axis: ax) - v.sum(axis: ax)).abs.max, 1e-3,
+                        "view #{i} axis #{ax}")
+      end
+    end
+
+    c = Cumo::DComplex.cast(src.map { |x| Complex(x, -x) })
+    got = flat.call(c.kahan_sum)
+    assert(((Rational(got.real) - exact) / exact).abs < 1e-15, "complex real part")
+    assert(((Rational(got.imag) + exact) / exact).abs < 1e-15, "complex imaginary part")
+  end
+
   test "the index reductions answer the earliest extreme, and the first NaN with nan" do
     nan = Float::NAN
     inf = Float::INFINITY


### PR DESCRIPTION
## Summary

- Give `kahan_sum` a `ReductionImpl` carrying the compensation term, so it runs on the GPU like every other reduction instead of on the host.
- 2^22 `DFloat` elements 31.91 -> 0.19 ms, `DComplex` 38.43 -> 0.37 ms, a 2048x2048 reduction over axis 0 51.76 -> 0.18 ms.
- The answer is unchanged: all 72 cases compared against numo 0.9.2.1 agree to 15 significant digits.

## Problem

`accum.c` excluded `kahan_sum` from the kernel path by name, so it synchronized and then walked the array on the host, one element at a time. It was the last reduction to do so, and the slowest thing in `gen/tmpl/accum.c` by two orders of magnitude:

| op | before | after |
|---|---|---|
| `DFloat#kahan_sum` | 31.910 ms | 0.188 ms |
| `DFloat#kahan_sum(nan: true)` | 31.927 ms | 0.209 ms |
| `DComplex#kahan_sum` | 38.426 ms | 0.369 ms |
| `kahan_sum(axis: 0)` on 2048x2048 | 51.756 ms | 0.182 ms |

A plain `DFloat#sum` over the same 2^22 elements takes 0.038 ms, so `kahan_sum` now costs about five times a plain sum rather than eight hundred.

numo folds the correction back into the running sum at every step, which a tree cannot do. The accumulator here is Kahan-Babuska-Neumaier instead: a partial carries its running sum and everything that sum has lost, and two partials combine by adding what their own addition loses to both. That is what makes the merge associative.

## Note

The compensation is what buys the accuracy, and it is worth showing rather than asserting. Against an exact rational sum of the same values, relative error at 2^22 elements:

| input | numo `kahan_sum` | this `kahan_sum` | this `sum` |
|---|---|---|---|
| `1e16` then 1.0 repeated | 1.000e-16 | 1.000e-16 | 3.100e-15 |
| `1/(i+1)` | 2.528e-17 | 2.528e-17 | 1.375e-16 |
| values spread over `[-0.5, 0.5]` | 1.265e-16 | 7.593e-17 | 2.033e-11 |
| magnitudes over 10 decades | 8.341e-17 | 8.341e-17 | 2.747e-16 |

It is as accurate as numo's sequential Kahan on every input measured, and better on one of them. Comparing the values rather than the errors, all 72 cases agree with numo to 15 significant digits: `DFloat` and `DComplex`, lengths 5, 1000 and 100000, with no NaN, some NaN and every element NaN, both with and without `nan: true`, then per axis over contiguous, transposed and reversed views.

Two injected faults each fail the new test: dropping the compensation term, which leaves a plain tree sum, and letting the nan-aware form take NaN through `MapIn`.

With this, nothing in `gen/tmpl/accum.c` runs on the host any more except `Cumo::RObject`, and the two TODOs that asked for it are gone.
