### PR TITLE
Raise instead of asserting on the gy shape in conv_grad_w

### DIFF
--- a/ext/cumo/narray/gen/tmpl/conv_grad_w.c
+++ b/ext/cumo/narray/gen/tmpl/conv_grad_w.c
@@ -94,18 +94,22 @@ static VALUE
     CUMO_CUDA_CUDNN_CHECK_DIM_EQ(sizet_w_shape[0], ngy->shape[1]);
     CUMO_CUDA_CUDNN_CHECK_DIM_EQ(sizet_w_shape[1], nx->shape[1]);
 
-#if !defined(NDEBUG)
     {
-        // shape check of gy
+        // cuDNN rejects a gy of the wrong spatial size with CUDNN_STATUS_BAD_PARAM,
+        // which does not say which dimension is wrong. This check was an assert,
+        // so a release build said nothing at all.
         size_t *y_shape = ngy->shape;
         size_t *x_shape = nx->shape;
         for (size_t i = 0; i < ndim; ++i) {
-            // TODO: raise
-            assert(y_shape[i + 2] == cumo_cuda_cudnn_GetConvOutDim(
-                    x_shape[i + 2], sizet_w_shape[i + 2], int_stride[i], int_pad[i]));
+            size_t out_dim = cumo_cuda_cudnn_GetConvOutDim(
+                    x_shape[i + 2], sizet_w_shape[i + 2], int_stride[i], int_pad[i]);
+            if (y_shape[i + 2] != out_dim) {
+                rb_raise(cumo_na_eShapeError,
+                        "gy_shape[%d]:%d does not match with the convolution output size %d",
+                        (int)(i + 2), (int)y_shape[i + 2], (int)out_dim);
+            }
         }
     }
-#endif
 
     x_cont = cumo_na_as_contiguous_array(x);
     gy_cont = cumo_na_as_contiguous_array(gy);

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -495,6 +495,28 @@ class CUDNNTest < Test::Unit::TestCase
       end
     end
 
+    sub_test_case "conv_grad_w gy shape" do
+      setup do
+        @x = dtype.ones(2, 3, 10, 7)
+        @w_shape = [2, 3, 2, 3]
+      end
+
+      test "the spatial size of gy has to be the convolution output size #{dtype}" do
+        assert { @x.conv_grad_w(dtype.ones(2, 2, 9, 5), @w_shape).shape == @w_shape }
+        [[2, 2, 8, 5], [2, 2, 12, 5], [2, 2, 9, 4]].each do |shape|
+          e = assert_raise(Cumo::NArray::ShapeError) { @x.conv_grad_w(dtype.ones(*shape), @w_shape) }
+          assert { e.message.include?("does not match with the convolution output size") }
+        end
+      end
+
+      test "a stride that does not divide evenly takes the floor #{dtype}" do
+        x = dtype.ones(2, 3, 10, 10)
+        w_shape = [2, 3, 2, 2]
+        assert { x.conv_grad_w(dtype.ones(2, 2, 3, 3), w_shape, stride: 3).shape == w_shape }
+        assert_raise(Cumo::NArray::ShapeError) { x.conv_grad_w(dtype.ones(2, 2, 4, 4), w_shape, stride: 3) }
+      end
+    end
+
     sub_test_case "given output arrays" do
       setup do
         @x_shape = [2, 3, 5, 3]


### PR DESCRIPTION
## Summary

- Raise `ShapeError` naming the dimension when `gy`'s spatial size is not the convolution output size, instead of leaving the check to an `assert` that a release build compiles out.
- Add 4 tests; all of them fail on master.

## Problem

`conv_grad_w` checked `gy`'s spatial size against `cumo_cuda_cudnn_GetConvOutDim` inside `#if !defined(NDEBUG)`, with `// TODO: raise` above the `assert`. A release build defines `NDEBUG`, so the block did nothing and the code read as if it validated when it did not.

cuDNN does reject a wrong `gy`, so this was never a way to corrupt anything — but what it says is `CUDNN_STATUS_BAD_PARAM (error=2000)`, which names neither the operand nor the dimension:

```ruby
x = Cumo::SFloat.ones(2, 3, 10, 7)
x.conv_grad_w(Cumo::SFloat.ones(2, 2, 9, 4), [2, 3, 2, 3])
# before: Cumo::CUDA::CUDNNError: CUDNN_STATUS_BAD_PARAM (error=2000)
# after:  Cumo::NArray::ShapeError: gy_shape[3]:4 does not match with the convolution output size 5
```

The case worth naming is a stride that does not divide evenly, where the output size is the floor and a caller carrying a `cover_all` habit passes the ceiling:

```ruby
x = Cumo::SFloat.ones(2, 3, 10, 10)
x.conv_grad_w(Cumo::SFloat.ones(2, 2, 4, 4), [2, 3, 2, 2], stride: 3)
# gy_shape[2]:4 does not match with the convolution output size 3
```

## Note

`assert` is now used in `gen/tmpl/alloc_func.c` only, where it guards an invariant rather than an argument.

This was one of the 13 cuDNN-layer TODOs left after the audit in #274. It is the only one of them that reads as a check and is not one.
