### PR TITLE
Drop a free-list bin from the pool arena when Malloc empties it

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl.cpp
+++ b/ext/cumo/cuda/memory_pool_impl.cpp
@@ -140,7 +140,12 @@ intptr_t SingleDeviceMemoryPool::Malloc(size_t size, cudaStream_t stream_ptr) {
                 continue;
             }
             chunk = PopFromFreeList(free_list);
-            // TODO(sonots): compact_index
+            if (free_list.empty()) {
+                // An emptied bin stays in the arena otherwise, and every later
+                // search walks it. Dropping it here invalidates arena and
+                // free_list, so nothing below this loop may touch them.
+                CompactIndex(stream_ptr, false);
+            }
             break;
         }
 

--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -137,6 +137,8 @@ public:
 
     void Run() {
         TearDown(); SetUp(); TestGetRoundedSize();
+        TearDown(); SetUp(); TestMallocCompactsEmptiedBin();
+        TearDown(); SetUp(); TestMallocCompactsLastBin();
         TearDown(); SetUp(); TestGetBinIndex();
         TearDown(); SetUp(); TestGetArenaIndexWithHugeSize();
         TearDown(); SetUp(); TestMallocOnAnotherStream();
@@ -288,6 +290,51 @@ public:
         assert(arena_index_map[0] == 2);
         assert(arena_index_map[1] == 3);
         assert(arena_index_map[2] == 4);
+    }
+
+    // Malloc drops a bin it just emptied, so a later search does not walk it.
+    void TestMallocCompactsEmptiedBin() {
+        Arena& arena = pool_->GetArena(stream_ptr_);
+        ArenaIndexMap& arena_index_map = pool_->GetArenaIndexMap(stream_ptr_);
+
+        // three bins, one chunk each, none of them adjacent in memory
+        for (int k = 2; k <= 4; ++k) {
+            auto mem = std::make_shared<Memory>(kRoundSize * k);
+            auto chunk = std::make_shared<Chunk>(mem, 0, mem->size(), stream_ptr_);
+            pool_->AppendToFreeList(chunk->size(), chunk, stream_ptr_);
+        }
+        assert(arena.size() == 3);
+        assert(arena_index_map.size() == 3);
+
+        // takes the whole chunk of the middle bin, which then has nothing left
+        intptr_t ptr = pool_->Malloc(kRoundSize * 3, stream_ptr_);
+        assert(ptr != 0);
+        assert(arena.size() == 2);
+        assert(arena_index_map.size() == 2);
+        assert(arena_index_map[0] == 1);
+        assert(arena_index_map[1] == 3);
+
+        pool_->Free(ptr);
+        assert(arena.size() == 3);
+    }
+
+    // Emptying the last bin leaves no arena at all, and the pool has to carry
+    // on: the split remainder of that very allocation goes back into a new one.
+    void TestMallocCompactsLastBin() {
+        auto mem = std::make_shared<Memory>(kRoundSize * 8);
+        auto chunk = std::make_shared<Chunk>(mem, 0, mem->size(), stream_ptr_);
+        pool_->AppendToFreeList(chunk->size(), chunk, stream_ptr_);
+        assert(pool_->GetArena(stream_ptr_).size() == 1);
+
+        intptr_t ptr = pool_->Malloc(kRoundSize * 2, stream_ptr_);
+        assert(ptr != 0);
+        // the remaining 6 units are back in a free list
+        assert(pool_->GetNumFreeBlocks() == 1);
+        assert(pool_->GetFreeBytes() == kRoundSize * 6);
+
+        pool_->Free(ptr);
+        assert(pool_->GetNumFreeBlocks() == 1);
+        assert(pool_->GetFreeBytes() == kRoundSize * 8);
     }
 
     // TODO(sonots): Fix after implementing compaction


### PR DESCRIPTION
## Summary

- Drop a free-list bin from the arena when `Malloc` empties it, which is what CuPy's `_malloc` does and what the `TODO(sonots): compact_index` there asked for.
- A small allocation that has to look past 8000 emptied bins goes from 671 to 440 ns. An ordinary workload is unchanged.
- Add two cases to the C++ pool harness; both fail without the call.

## Problem

The arena is a sparse vector of free lists with `arena_index_map` naming the bin each entry belongs to. A bin is created the first time a chunk of that size is freed and never leaves, so every distinct allocation size a program has ever freed adds one entry, permanently. That costs the linear search in `Malloc` (`if (free_list.empty()) continue;`) and the `lower_bound` in `GetArenaIndex`.

The cost only shows when the bins are actually empty, which needs their chunks to be in use. Holding one chunk out of each of N bins and leaving one larger bin to satisfy the request:

| emptied bins in the arena | before | after |
|---|---|---|
| 1000 | 276.5 ns | 275.3 ns |
| 4000 | 392.3 ns | 358.4 ns |
| 8000 | 670.6 ns | 439.5 ns |

Per allocation, best of three runs of 20000 allocations. A workload whose bins stay populated does not reach `CompactIndex` at all and measures the same before and after: 266 / 286 / 288 ns against 269 / 277 / 287 ns for a fresh pool and after 2000 and 8000 distinct sizes.

## Note

`CompactIndex` swaps the arena vectors, and erases the arena entirely when the last bin goes, so the `arena` and `free_list` references the search loop holds do not survive the call. The loop breaks immediately after, and everything below re-fetches through `AppendToFreeList`; the comment says so.

`TestMallocCompactsLastBin` is there for that last case: the allocation that empties the only bin also has a remainder to put back, so the pool has to carry on with no arena.

`memory_pool_impl_test.cpp`'s other TODO, "Fix after implementing compaction" above `TestRemoveFromFreeList`, is untouched: `RemoveFromFreeList` still does not compact, and CuPy's `_remove_from_free_list` does not either.
