### PR TITLE
Check the cuDNN header and version, not just the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Cumo (pronounced "koomo") is a CUDA-aware, GPU-optimized numerical library that 
 * Ruby 3.0 or later
 * NVIDIA GPU Compute Capability 3.5 (Kepler) or later
 * CUDA 11.0 or later
+* cuDNN 8.0 or later (optional, for the cuDNN features)
 
 ## Preparation
 

--- a/ext/cumo/extconf.rb
+++ b/ext/cumo/extconf.rb
@@ -164,7 +164,36 @@ have_library('nvrtc')
 have_library('cublas')
 # have_library('cusolver')
 # have_library('curand')
-if have_library('cudnn') # TODO(sonots): cuDNN version check
+
+# cuDNN 8 is the first release that supports CUDA 11, which cumo requires.
+CUDNN_MIN_MAJOR = 8
+
+def have_cudnn?
+  unless have_header('cudnn.h')
+    message("cuDNN header not found; building without cuDNN features\n")
+    return false
+  end
+  ok = checking_for("cuDNN #{CUDNN_MIN_MAJOR} or later") do
+    try_compile(<<-SRC)
+#include <cudnn.h>
+#if CUDNN_MAJOR < #{CUDNN_MIN_MAJOR}
+#error "cuDNN is too old"
+#endif
+int main(void) { return 0; }
+    SRC
+  end
+  unless ok
+    message("cuDNN is older than #{CUDNN_MIN_MAJOR}.0; building without cuDNN features\n")
+    return false
+  end
+  unless have_library('cudnn')
+    message("cuDNN library not found; building without cuDNN features\n")
+    return false
+  end
+  true
+end
+
+if have_cudnn?
   $CFLAGS << " -DCUDNN_FOUND"
   $CXXFLAGS << " -DCUDNN_FOUND"
 end


### PR DESCRIPTION
## Summary

- Require `cudnn.h` and cuDNN 8 or later before defining `CUDNN_FOUND`, which is what the `TODO(sonots): cuDNN version check` next to `have_library('cudnn')` asked for.
- Say which of the three checks failed, so a build without cuDNN features is diagnosable from the extconf output.
- Note the cuDNN requirement in the README next to the CUDA one.

## Problem

`have_library('cudnn')` links a conftest that includes only `ruby.h`, so it passes on a machine that has `libcudnn.so` but not the development header. `CUDNN_FOUND` is then defined and the build dies later:

```
include/cumo/cuda/cudnn.h:6:10: fatal error: cudnn.h: No such file or directory
    6 | #include <cudnn.h>
```

I reproduced this by hiding `/usr/include/cudnn*.h` in a mount namespace while leaving `/usr/lib/libcudnn.so` in place: `have_library('cudnn')` still returned true. Splitting the runtime and development packages, or setting `LIBRARY_PATH` without `CPATH`, gets a user there — and the README's cuDNN setup asks for exactly those two variables separately.

The version was never checked at all, so a cuDNN too old for the API in `cuda/cudnn_impl.cpp` would fail the same way, deep in the build.

`have_library` now runs last, so a cuDNN that is rejected does not add `-lcudnn` to the link line either.

## Note

The floor is cuDNN 8 because that is the first release supporting CUDA 11, which the README already requires, and because CI builds against cuDNN 8 (CUDA 11.8) and cuDNN 9 (CUDA 12.6, 12.8, 13.2). Nothing older is tested.

Checked on cuDNN 9.25 / CUDA 13.3: the normal path still reports `checking for cuDNN 8 or later... yes` and `rake test` gives 1560 tests, 0 failures. Raising the floor to 10, and hiding the header, each disable cuDNN with their own message and leave `-DCUDNN_FOUND` and `-lcudnn` out of the Makefile.
