### PR TITLE
Add fiddle to the Gemfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
             curl \
             git \
             build-essential \
+            libffi-dev \
             ruby-full \
             ruby-dev \
             ccache

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'extconf_compile_commands_json'
+gem 'fiddle'
 gem 'rake-compiler'
 gem 'test-unit'
 gem 'yard'


### PR DESCRIPTION
## Summary

`fiddle` is not a default gem on Ruby 4.0 any more, so `bundle exec rake test` fails on it.

## Problem

`test/cuda/memory_pool_test.rb` spawns a child process that calls `cuCtxDestroy` through `fiddle`. Under `bundle exec` the child inherits `RUBYOPT=-rbundler/setup`, and on Ruby 4.0 that turns `require "fiddle"` into a `LoadError`:

```
cannot load such file -- fiddle (LoadError)
```

The child then writes nothing and the parent reports `<"ok"> expected but was `<"">`. Running the same file as `ruby -Ilib -Itest test/cuda/memory_pool_test.rb` passes, because outside bundler `fiddle` still resolves as a bundled gem, which is what hid this.

With `fiddle` in the Gemfile, `bundle exec rake test` is back to 1560 tests, 22861 assertions, 0 failures.

## Note

The CI image carries no `ffi.h`, so bundler resolving `fiddle` to 1.1.8 fails to build its extension with `checking for ffi.h... no`. Reproduced in `ubuntu:24.04` with the same `ruby-full` 3.2.3 the workflow installs, where `apt-get install libffi-dev` is enough for `gem install fiddle -v 1.1.8` to succeed, so the workflow now installs it.
