### PR TITLE
Document every method that returns a 0-dimensional NArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,30 @@ a = xm::DFloat.new(3,5).seq
 
 ### Incompatibility With Numo
 
-The following methods behave incompatibly with Numo by default for performance reasons:
-
-* `extract`
-* `[]`
-* `count_true`
-* `count_false`
-
-Numo returns a Ruby numeric object for 0-dimensional NArray, while Cumo returns the 0-dimensional NArray instead of a Ruby numeric object.
+Numo returns a Ruby numeric object wherever a result is 0-dimensional, while Cumo returns the 0-dimensional NArray itself.
 Cumo differs in this way to avoid synchronization and minimize CPU ⇄ GPU data transfer.
 
+The methods affected are:
+
+* `[]` and `extract`
+* `count_true` and `count_false`
+* reductions down to a single value: `sum`, `prod`, `mean`, `stddev`, `var`, `rms`, `min`, `max`, `ptp`, `minmax`, `median`, `mulsum`, `dot`, `inner`
+* index reductions: `max_index`, `min_index`, `argmax`, `argmin`
+
+A 0-dimensional `Cumo::Bit` is truthy even when it holds 0, because Ruby treats every object but `nil` and `false` as true.
+Comparing two scalars therefore takes the wrong branch without raising anything:
+
+```ruby
+a = Cumo::SFloat[5.0]
+a[0] < 1.0                  #=> Cumo::Bit#shape=[] holding 0
+(a[0] < 1.0) ? :yes : :no   #=> :yes, where Numo gives :no
+```
+
+`assert_operator(a[0], :<, 1.0)` passes for the same reason, so a test suite written for Numo can stay green against Cumo while asserting nothing.
+Read the value back to the host before branching on it, or run under `compatible_mode`.
+
 Set the `CUMO_COMPATIBLE_MODE` environment variable to `ON` to force Numo NArray compatibility (for worse performance).
+Running a Numo test suite that way keeps its assertions meaningful.
 
 You may enable or disable `compatible_mode` as:
 
@@ -126,6 +139,11 @@ You can also use the following methods which behave like Numo's NArray methods. 
 * `aref_cpu(*idx)`
 * `count_true_cpu`
 * `count_false_cpu`
+
+```ruby
+a.aref_cpu(0) < 1.0         #=> false
+(a[0] < 1.0).extract_cpu    #=> 0
+```
 
 ### Select a GPU device ID
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ You can also use the following methods which behave like Numo's NArray methods. 
 * `count_false_cpu`
 
 ```ruby
-a.aref_cpu(0) < 1.0         #=> false
-(a[0] < 1.0).extract_cpu    #=> 0
+a.aref_cpu(0) < 1.0   #=> false in either mode
+Float(a.sum)          #=> 7.0 in either mode
 ```
+
+They are methods on an NArray, so chaining one onto a result that `compatible_mode` has already turned into a Ruby object, as in `a.sum.extract_cpu`, raises `NoMethodError` while the mode is on.
+`Kernel#Float` and `Kernel#Integer` read either representation, so they are what code meant to run in both modes wants.
 
 ### Select a GPU device ID
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Float(a.sum)          #=> 7.0 in either mode
 ```
 
 They are methods on an NArray, so chaining one onto a result that `compatible_mode` has already turned into a Ruby object, as in `a.sum.extract_cpu`, raises `NoMethodError` while the mode is on.
-`Kernel#Float` and `Kernel#Integer` read either representation, so they are what code meant to run in both modes wants.
+`Kernel#Float` and `Kernel#Integer` read either representation, and read Numo's too, so they are what code that runs against both libraries wants.
 
 ### Select a GPU device ID
 

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -82,6 +82,18 @@ class CumoTest < Test::Unit::TestCase
     end
   end
 
+  def test_kernel_conversions_read_a_result_in_either_mode
+    [true, false].each do |compatible|
+      compatible ? Cumo.enable_compatible_mode : Cumo.disable_compatible_mode
+      a = Cumo::DFloat[5, 2]
+      assert_equal(7.0, Float(a.sum))
+      assert_equal(0, Integer(a.max_index))
+      assert_equal(false, a.aref_cpu(0) < 1.0)
+      assert_equal(2, (a > 1).count_true_cpu)
+      assert_equal(5.0, Cumo::DFloat.cast(5.0).extract_cpu)
+    end
+  end
+
   def test_minmax_returns_zero_dimensional_narrays_without_compatible_mode
     Cumo.disable_compatible_mode
     min, max = Cumo::DFloat[3, 1, 7].minmax

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -35,6 +35,53 @@ class CumoTest < Test::Unit::TestCase
     assert_equal(Integer, a.argmax.class)
   end
 
+  ZERO_DIMENSIONAL_FLOATS = {
+    aref: -> { Cumo::DFloat[3, 1, 7][1] },
+    extract: -> { Cumo::DFloat.cast(7.0).extract },
+    sum: -> { Cumo::DFloat[3, 1, 7].sum },
+    prod: -> { Cumo::DFloat[3, 1, 7].prod },
+    mean: -> { Cumo::DFloat[3, 1, 7].mean },
+    stddev: -> { Cumo::DFloat[3, 1, 7].stddev },
+    var: -> { Cumo::DFloat[3, 1, 7].var },
+    rms: -> { Cumo::DFloat[3, 1, 7].rms },
+    min: -> { Cumo::DFloat[3, 1, 7].min },
+    max: -> { Cumo::DFloat[3, 1, 7].max },
+    ptp: -> { Cumo::DFloat[3, 1, 7].ptp },
+    median: -> { Cumo::DFloat[3, 1, 7].median },
+    mulsum: -> { Cumo::DFloat[3, 1, 7].mulsum(Cumo::DFloat[1, 1, 1]) },
+    dot: -> { Cumo::DFloat[3, 1, 7].dot(Cumo::DFloat[1, 1, 1]) },
+    inner: -> { Cumo::DFloat[3, 1, 7].inner(Cumo::DFloat[1, 1, 1]) },
+  }.freeze
+
+  ZERO_DIMENSIONAL_INTEGERS = {
+    max_index: -> { Cumo::DFloat[3, 1, 7].max_index },
+    min_index: -> { Cumo::DFloat[3, 1, 7].min_index },
+    argmax: -> { Cumo::DFloat[3, 1, 7].argmax },
+    argmin: -> { Cumo::DFloat[3, 1, 7].argmin },
+    count_true: -> { (Cumo::DFloat[3, 1, 7] > 2).count_true },
+    count_false: -> { (Cumo::DFloat[3, 1, 7] > 2).count_false },
+    bit_aref: -> { (Cumo::DFloat[3, 1, 7] > 2)[1] },
+  }.freeze
+
+  def test_compatible_mode_extracts_every_documented_method
+    Cumo.enable_compatible_mode
+    ZERO_DIMENSIONAL_FLOATS.each do |name, block|
+      assert_instance_of(Float, block.call, name)
+    end
+    ZERO_DIMENSIONAL_INTEGERS.each do |name, block|
+      assert_instance_of(Integer, block.call, name)
+    end
+  end
+
+  def test_every_documented_method_stays_zero_dimensional_without_compatible_mode
+    Cumo.disable_compatible_mode
+    (ZERO_DIMENSIONAL_FLOATS.merge(ZERO_DIMENSIONAL_INTEGERS)).each do |name, block|
+      result = block.call
+      assert_kind_of(Cumo::NArray, result, name)
+      assert_equal(0, result.ndim, name)
+    end
+  end
+
   def test_minmax_returns_zero_dimensional_narrays_without_compatible_mode
     Cumo.disable_compatible_mode
     min, max = Cumo::DFloat[3, 1, 7].minmax


### PR DESCRIPTION
## Summary

The Numo incompatibility section of the README lists four methods where it should list twenty-two, and says nothing about the branch a 0-dimensional `Cumo::Bit` takes.

## Problem

`extract`, `[]`, `count_true` and `count_false` are named, but every reduction down to a single value (`sum`, `prod`, `mean`, `stddev`, `var`, `rms`, `min`, `max`, `ptp`, `minmax`, `median`, `mulsum`, `dot`, `inner`) and every index reduction (`max_index`, `min_index`, `argmax`, `argmin`) return a 0-dimensional NArray in exactly the same way.

The consequence that costs the most is unnamed. A 0-dimensional `Cumo::Bit` is truthy even when it holds 0, because Ruby treats every object but `nil` and `false` as true:

```ruby
a = Cumo::SFloat[5.0]
a[0] < 1.0                  #=> Cumo::Bit#shape=[] holding 0
(a[0] < 1.0) ? :yes : :no   #=> :yes, where Numo gives :no
```

`assert_operator(a[0], :<, 1.0)` passes for the same reason, so a test suite written for Numo can stay green against Cumo while asserting nothing. No Ruby object other than `nil` and `false` can be made falsy, so documenting it is the only lever there is.

`test/cumo_test.rb` now pins the whole list in both modes, which doubles as a check that `compatible_mode` still covers every method the README names.

The escape hatches get a correction too: `extract_cpu` is a method on an NArray, so `a.sum.extract_cpu` raises once `compatible_mode` has turned `a.sum` into a `Float`. `Kernel#Float` and `Kernel#Integer` read either representation.

## Note

Checked against numo-narray-alt 0.11.2 on all twenty-two: `Cumo.enable_compatible_mode` returns the same Ruby class Numo does for each one.
