### PR TITLE
Take a transposed batch of matrices with the cuBLAS transpose flag

### DIFF
--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -152,6 +152,41 @@ is_c_contiguous(VALUE a)
     return cumo_na_check_contiguous(a) == Qtrue;
 }
 
+// True when the last two axes make a column-major matrix and the axes before
+// them advance by whole matrices, which is what transposing a batch of matrices
+// produces. cuBLAS takes it with CUBLAS_OP_T, where is_f_contiguous only covers
+// the single-matrix case and everything else pays for a transposed copy.
+static bool
+is_batched_f_contiguous(VALUE a)
+{
+    int i, ndim;
+    ssize_t stride;
+    cumo_narray_t *na;
+
+    if (CUMO_RNARRAY_TYPE(a) != CUMO_NARRAY_VIEW_T) return false;
+
+    CumoGetNArray(a, na);
+    ndim = CUMO_NA_NDIM(na);
+    if (ndim < 3) return false;
+
+    for (i = 0; i < ndim; ++i) {
+        if (CUMO_NA_IS_INDEX_AT(na, i)) return false;
+    }
+
+    stride = cumo_na_element_stride(a);
+    for (i = ndim - 2; i < ndim; ++i) {
+        if (CUMO_NA_SHAPE(na)[i] == 1) continue;
+        if (CUMO_NA_STRIDE_AT(na, i) != stride) return false;
+        stride *= CUMO_NA_SHAPE(na)[i];
+    }
+    for (i = ndim - 3; i >= 0; --i) {
+        if (CUMO_NA_SHAPE(na)[i] == 1) continue;
+        if (CUMO_NA_STRIDE_AT(na, i) != stride) return false;
+        stride *= CUMO_NA_SHAPE(na)[i];
+    }
+    return true;
+}
+
 // How many matrices the operand holds, i.e. the product of its batch dimensions.
 static int
 gemm_batch_count(cumo_narray_t *na)
@@ -169,11 +204,12 @@ make_gemm_layout(VALUE a)
     CumoGetNArray(a, na);
 
     if (cumo_na_debug_flag) {
-        printf("ndim==2 && f_contiguous:%d, c_contiguous:%d\n",
-                CUMO_NA_NDIM(na) == 2 && is_f_contiguous(a), is_c_contiguous(a));
+        printf("f_contiguous:%d, batched_f_contiguous:%d, c_contiguous:%d\n",
+                CUMO_NA_NDIM(na) == 2 && is_f_contiguous(a),
+                is_batched_f_contiguous(a), is_c_contiguous(a));
     }
 
-    if (CUMO_NA_NDIM(na) == 2 && is_f_contiguous(a)) {
+    if ((CUMO_NA_NDIM(na) == 2 && is_f_contiguous(a)) || is_batched_f_contiguous(a)) {
         layout.ld = ROW_SIZE(na);
         layout.trans = CUBLAS_OP_T;
         layout.a = a;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -927,6 +927,25 @@ class NArrayTest < Test::Unit::TestCase
           assert_raise(Cumo::NArray::ShapeError) { dtype.new(0, 3).gemm(dtype.new(3, 4).seq) }
           assert_raise(Cumo::NArray::ShapeError) { dtype.new(2, 0).gemm(dtype.new(0, 4)) }
         end
+        test "matrix.gemm(matrix) takes a transposed batch without a copy" do
+          a = dtype.new(2, 3, 2, 4).seq
+          b = dtype.new(2, 3, 5, 4).seq.transpose(0, 1, 3, 2)
+          assert { a.gemm(b) == a.gemm(b.dup) }
+          c = dtype.new(3, 2, 4).seq
+          d = dtype.new(3, 5, 4).seq.transpose(0, 2, 1)
+          assert { c.gemm(d) == c.gemm(d.dup) }
+        end
+        test "matrix.gemm(matrix) copies a batch that is not a matrix transpose" do
+          a = dtype.new(3, 2, 4).seq
+          # every axis reversed, so the batch axis is the innermost one
+          b = dtype.new(5, 4, 3).seq.transpose
+          assert { a.gemm(b) == a.gemm(b.dup) }
+          # rows dropped from each matrix, so the batch no longer advances by
+          # whole matrices
+          c = dtype.new(2, 2, 3, 4).seq
+          d = dtype.new(2, 2, 5, 4).seq[true, true, 0..3, true].transpose(0, 1, 3, 2)
+          assert { c.gemm(d) == c.gemm(d.dup) }
+        end
         test "matrix.gemm(matrix, c) rejects a c whose batch count differs" do
           a = dtype.new(4, 2, 3).seq
           b = dtype.new(3, 4).seq


### PR DESCRIPTION
## Summary

`gemm` materialized a contiguous copy of any operand with more than two dimensions that was not C-contiguous, including the batched transpose `k.transpose(0, 1, 3, 2)` that attention produces.

## Problem

`make_gemm_layout` only looked for `CUBLAS_OP_T` when `NDIM == 2`, so every batched operand fell to the `is_c_contiguous(a) ? a : dup` branch. The last two axes of a batched transpose are a column-major matrix and the axes before them advance by whole matrices, which is what `CUBLAS_OP_T` already expresses for one matrix.

With `Cumo::NArray.debug = true` on `q.dot(k.transpose(0, 1, 3, 2))` for `[1, 12, 64, 64]`:

```
before: f_contiguous:0, c_contiguous:0            -> transb=0, preceded by a copy
after:  batched_f_contiguous:1                    -> transb=1, no copy
```

Reversing every axis, or slicing rows out of each matrix, leaves the batch stride unequal to the matrix size and still takes the copy.

## Note

**This is not a speedup.** What it drops unconditionally is a temporary the size of the operand, 50 MB for `[1, 96, 1024, 128]` `SFloat`. On an RTX 5070 Ti Laptop (sm_120, CUDA 13.3) the isolated `[1, 12, 1024, K]` gemm runs 1.2-1.5x faster for K <= 64 and 0.70-0.97x for K >= 128, and a whole GPT-2 attention block (12 heads, head size 64) measures 0.95-1.09x, which is run-to-run noise. The 2-dimensional path already shows the same 0.80-1.07x spread against a copy, so this extends a trade-off that is already shipped rather than introducing one.
