### PR TITLE
Emit indexer accessors up to eight dimensions

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -221,7 +221,7 @@ cumo_na_make_reduction_arg(cumo_na_loop_t* lp_user, int out_arg)
 
 #endif  // #ifndef __CUDACC__
 
-#define CUMO_NA_INDEXER_OPTIMIZED_NDIM 4
+#define CUMO_NA_INDEXER_OPTIMIZED_NDIM 8
 
 #ifdef __CUDACC__
 
@@ -247,6 +247,10 @@ cumo_na_indexer_set_dim##NDIM(cumo_na_indexer_t* indexer, uint64_t i) { \
     } \
 }
 
+CUMO_NA_INDEXER_SET(8)
+CUMO_NA_INDEXER_SET(7)
+CUMO_NA_INDEXER_SET(6)
+CUMO_NA_INDEXER_SET(5)
 CUMO_NA_INDEXER_SET(4)
 CUMO_NA_INDEXER_SET(3)
 CUMO_NA_INDEXER_SET(2)
@@ -280,6 +284,10 @@ cumo_na_iarray_at_dim##NDIM(cumo_na_iarray_t* iarray, cumo_na_indexer_t* indexer
     return ptr; \
 }
 
+CUMO_NA_IARRAY_AT(8)
+CUMO_NA_IARRAY_AT(7)
+CUMO_NA_IARRAY_AT(6)
+CUMO_NA_IARRAY_AT(5)
 CUMO_NA_IARRAY_AT(4)
 CUMO_NA_IARRAY_AT(3)
 CUMO_NA_IARRAY_AT(2)
@@ -313,6 +321,10 @@ cumo_na_bit_iarray_at_dim##NDIM(cumo_na_bit_iarray_t* iarray, cumo_na_indexer_t*
     return pos; \
 }
 
+CUMO_NA_BIT_IARRAY_AT(8)
+CUMO_NA_BIT_IARRAY_AT(7)
+CUMO_NA_BIT_IARRAY_AT(6)
+CUMO_NA_BIT_IARRAY_AT(5)
 CUMO_NA_BIT_IARRAY_AT(4)
 CUMO_NA_BIT_IARRAY_AT(3)
 CUMO_NA_BIT_IARRAY_AT(2)
@@ -354,6 +366,10 @@ cumo_na_bit_iarray_stridx_at_dim##NDIM(cumo_na_bit_iarray_stridx_t* iarray, cumo
     return pos; \
 }
 
+CUMO_NA_BIT_IARRAY_STRIDX_AT(8)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(7)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(6)
+CUMO_NA_BIT_IARRAY_STRIDX_AT(5)
 CUMO_NA_BIT_IARRAY_STRIDX_AT(4)
 CUMO_NA_BIT_IARRAY_STRIDX_AT(3)
 CUMO_NA_BIT_IARRAY_STRIDX_AT(2)
@@ -401,6 +417,10 @@ cumo_na_iarray_stridx_at_dim##NDIM(cumo_na_iarray_stridx_t* iarray, cumo_na_inde
     return ptr; \
 }
 
+CUMO_NA_IARRAY_STRIDX_AT(8)
+CUMO_NA_IARRAY_STRIDX_AT(7)
+CUMO_NA_IARRAY_STRIDX_AT(6)
+CUMO_NA_IARRAY_STRIDX_AT(5)
 CUMO_NA_IARRAY_STRIDX_AT(4)
 CUMO_NA_IARRAY_STRIDX_AT(3)
 CUMO_NA_IARRAY_STRIDX_AT(2)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -36,6 +36,20 @@ class NArrayTest < Test::Unit::TestCase
       assert { dtype < Cumo::NArray }
     end
 
+    # A permutation that leaves no pair of axes ndloop can merge, so the kernel
+    # sees the full ndim and picks the accessor for it.
+    test "#{dtype}, a view permuted past the optimized indexer ndim" do
+      (5..8).each do |nd|
+        shape = Array.new(nd) { |i| i.even? ? 2 : 3 }
+        perm = (1...nd).step(2).to_a + (0...nd).step(2).to_a
+        v = dtype.new(*shape).seq.transpose(*perm)
+        assert { !v.contiguous? }
+        assert { v.dup.to_a == v.to_a }
+        assert { (v + v).to_a == (v.dup + v.dup).to_a }
+        assert { (-v).to_a == (-v.dup).to_a }
+      end
+    end
+
     test "#{dtype}[]" do
       a = dtype[]
 


### PR DESCRIPTION
## Summary

A kernel operand whose merged dimension count exceeds `CUMO_NA_INDEXER_OPTIMIZED_NDIM` falls back to the generic indexer and runs about 40x slower. The constant was 4; this raises it to 8.

## Problem

`cumo_na_indexer_set_dim` loops to a runtime `indexer->ndim`, so `indexer->index[]` cannot be register-allocated and spills to local memory. The `_dimN` variants have a compile-time bound, unroll, and keep it in registers. Every kernel launcher switches on `indexer->ndim` with cases up to `CUMO_NA_INDEXER_OPTIMIZED_NDIM` and a generic default.

ndloop merges adjacent axes before the kernel sees them, so this only bites when a permutation leaves no mergeable pair. On `[16, 16, 16, 32, 32]`, `Cumo::NArray.debug = true` reports `user.ndim` of 3 for `[1, 0, 2, 3, 4]` and 2 for `[2, 3, 4, 0, 1]`, but 5 for `[2, 0, 3, 1, 4]` and for the full reversal.

`dup` of a 16 MiB `SFloat` view under a permutation with no mergeable pair, in GB/s, on an RTX 5070 Ti Laptop (sm_120, CUDA 13.3):

| ndim | before | after |
|---|---|---|
| 5 | 7.9 | 391 |
| 6 | 9.7 | 307 |
| 7 | 8.7 | 266 |
| 8 | 9.5 | 274 |

Elementwise operations move the same way. The "after" column varies about 20% run to run; the "before" column does not. A contiguous operand is unaffected at any ndim, 427 GB/s before and after, because contiguity collapses to one dimension.

## Note

`cumo.so` grows from 42.6 to 53.1 MB and a clean build from 74 to 85 s. Raising the constant to `CUMO_NA_MAX_DIMENSION` (12) removes the cliff altogether, at 64.6 MB and 97 s; 8 is where a permutation with no mergeable pair stops being a shape anyone writes.

Reductions do not move: `reduce_kernel.h` addresses through `axes_are_flat` and `axes_offset` instead of the indexer, and `sum(axis: -1)` on the same views stays at 4-5 GB/s before and after.
