### PR TITLE
Build two GPU architectures in CI instead of every one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,17 @@ jobs:
           - cuda_version: "11.8.0"
             cudnn_suffix: "cudnn8"
             ubuntu_version: "ubuntu22.04"
+            cuda_arch: "arch=compute_35,code=sm_35 arch=compute_90,code=sm_90"
 
           - cuda_version: "12.6.3"
             cudnn_suffix: "cudnn"
             ubuntu_version: "ubuntu24.04"
+            cuda_arch: "arch=compute_50,code=sm_50 arch=compute_90,code=sm_90"
 
           - cuda_version: "12.8.1"
             cudnn_suffix: "cudnn"
             ubuntu_version: "ubuntu24.04"
+            cuda_arch: "arch=compute_50,code=sm_50 arch=compute_120,code=sm_120"
 
           # Disable CUDA 12.9.x it causes build error in CUDA macros
           # Ref. https://github.com/NVIDIA/cccl/issues/4967
@@ -36,6 +39,7 @@ jobs:
           - cuda_version: "13.2.1"
             cudnn_suffix: "cudnn"
             ubuntu_version: "ubuntu24.04"
+            cuda_arch: "arch=compute_75,code=sm_75 arch=compute_121,code=sm_121"
 
     container:
       image: nvidia/cuda:${{ matrix.cuda_version }}-${{ matrix.cudnn_suffix }}-devel-${{ matrix.ubuntu_version }}
@@ -74,6 +78,11 @@ jobs:
         run: bundle install
 
       - name: Compile Cumo (Build check)
+        env:
+          # Two architectures, the oldest and the newest the CUDA version
+          # supports. Without this, mkmf-cu finds no nvidia-smi and builds every
+          # architecture in its list, which is minutes of nvcc per job.
+          CUMO_NVCC_GENERATE_CODE: ${{ matrix.cuda_arch }}
         run: |
           export CUDA_PATH=/usr/local/cuda
           export CPATH=/usr/local/cuda/include:${CPATH}

--- a/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
+++ b/3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb
@@ -40,7 +40,9 @@ module MakeMakefileCuda
       s = MakeMakefileCuda::Nvcc.generate(argv)
       cmd = "nvcc #{s}"
       if ENV['CUMO_NVCC_GENERATE_CODE']
-        cmd << " --generate-code=#{ENV['CUMO_NVCC_GENERATE_CODE']}"
+        ENV['CUMO_NVCC_GENERATE_CODE'].split.each do |code|
+          cmd << " --generate-code=#{code}"
+        end
       else
         capability = nil
         if find_executable('nvidia-smi')

--- a/README.md
+++ b/README.md
@@ -223,7 +223,14 @@ ln -sf "$HOME/opt/ccache/bin/ccache" "$HOME/opt/ccache/bin/nvcc"
 bundle exec env CUMO_NVCC_GENERATE_CODE=arch=compute_60,code=sm_60 rake compile
 ```
 
+Separate the entries with a space to build for more than one architecture:
+
+```
+bundle exec env CUMO_NVCC_GENERATE_CODE="arch=compute_75,code=sm_75 arch=compute_121,code=sm_121" rake compile
+```
+
 This is useful even on development because it makes it possible to skip JIT compilation of PTX to cubin during runtime.
+Without it, and without an `nvidia-smi` to read the local compute capability from, the build covers every architecture the CUDA version supports.
 
 ### Run tests with gdb
 


### PR DESCRIPTION
## Summary

CI builds every GPU architecture the CUDA version supports, so a job that took 8 minutes before PR #284 now takes about 50. This pins each matrix entry to two architectures, the oldest and the newest that CUDA version supports.

## Problem

`mkmf-cu` reads the local compute capability from `nvidia-smi` and builds that one architecture. There is no GPU on a CI runner, so it falls through to the full list in `3rd_party/mkmf-cu/lib/mkmf-cu/cli.rb`, 11 architectures for CUDA 13 and up to 16 for 12.9. PR #284 raised the number of kernel variants each template emits from 5 to 9, and that multiplies against the architecture count.

Measured locally with a clean build of the same tree (RTX 5070 Ti Laptop, CUDA 13.3):

| architectures | build | cumo.so |
|---|---|---|
| 1 (`sm_120`, what a machine with a GPU gets) | 85 s | 53 MB |
| 2 (`sm_75` + `sm_121`) | 193 s | 123 MB |
| 11 (what CI gets) | 636 s | 582 MB |

CI runs `rake compile` and `rake build_ctest` and executes no kernel, so the architectures only have to compile. Keeping the oldest and the newest covers the two ends where architecture-specific compile errors turn up, such as `atomicAdd(double*)` needing `sm_60`, while the CUDA 11.8 / 12.6 / 12.8 / 13.2 matrix is untouched.

`CUMO_NVCC_GENERATE_CODE` now takes more than one entry, separated by spaces. A single entry behaves as before.

## Note

Verified that the default path is unchanged: with the variable unset the build still reads `nvidia-smi` and emits one `--generate-code`, and `rake test` is 1583 tests, 23145 assertions, 0 failures.
