### PR TITLE
Copy a reduction operand only when it carries an index array

### DIFF
--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -471,7 +471,10 @@ cumo_na_has_idx_p(VALUE obj)
     if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
         CumoGetNArrayView(obj, nv);
         for (; i < nv->base.ndim; ++i) {
-            if (nv->stridx[i].index) {
+            // A stride is tagged with its low bit set, so the raw union is
+            // non-null for every dimension a view has and reading it as a
+            // pointer answers true for all of them.
+            if (CUMO_SDX_IS_INDEX(nv->stridx[i])) {
                 return true;
             }
         }

--- a/ext/cumo/narray/gen/tmpl/accum_arg.c
+++ b/ext/cumo/narray/gen/tmpl/accum_arg.c
@@ -109,8 +109,11 @@ static VALUE
             <% end %>
         }
 
-        if (cumo_na_has_idx_p(self)) {
-            VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
+        // The index the kernel answers counts along the operand's memory, so
+        // it only means the same thing as the logical index when the operand is
+        // contiguous.
+        if (cumo_na_check_contiguous(self) != Qtrue) {
+            VALUE copy = cumo_na_copy(self);
             ret = cumo_na_ndloop(&ndf, 2, copy, reduce);
         } else {
             ret = cumo_na_ndloop(&ndf, 2, self, reduce);

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -118,8 +118,11 @@ static VALUE
             <% end %>
         }
 
-        if (cumo_na_has_idx_p(self)) {
-            VALUE copy = cumo_na_copy(self); // reduction does not support idx, make contiguous
+        // The index the kernel answers counts along the operand's memory, so
+        // it only means the same thing as the logical index when the operand is
+        // contiguous.
+        if (cumo_na_check_contiguous(self) != Qtrue) {
+            VALUE copy = cumo_na_copy(self);
             ret = cumo_na_ndloop(&ndf, 2, copy, reduce);
         } else {
             ret = cumo_na_ndloop(&ndf, 2, self, reduce);

--- a/ext/cumo/narray/gen/tmpl/sort_index.c
+++ b/ext/cumo/narray/gen/tmpl/sort_index.c
@@ -141,8 +141,11 @@ static VALUE
     if (kernel) {
         ndf.func = <%=c_iter%>_kernel;
         ndf.flag |= CUMO_NDF_INDEXER_LOOP;
-        if (cumo_na_has_idx_p(self)) {
-            self = cumo_na_copy(self); // the indexer loop does not support idx, make contiguous
+        // The index the kernel writes counts along the operand's memory, so it
+        // only means the same thing as the logical index when the operand is
+        // contiguous.
+        if (cumo_na_check_contiguous(self) != Qtrue) {
+            self = cumo_na_copy(self);
         }
         return cumo_na_ndloop3(&ndf, 0, 3, self, idx, reduce);
     }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4338,6 +4338,40 @@ class NArrayTest < Test::Unit::TestCase
     assert_reductions(big.transpose, "3000x33 transpose", axes: [[0], [1]])
   end
 
+  test "a reduction over a strided view does not copy the operand" do
+    # In a child, or blocks another test left in the pool serve the copy and it
+    # does not show up in total_bytes.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(1024, 1024).seq
+      a.transpose.sum(axis: -1)
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      before = pool.total_bytes
+      a.transpose.sum(axis: -1)
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    assert_operator(Integer(out), :<, 1024 * 1024 * 4)
+  end
+
+  test "a reduction answering an index copies a strided view" do
+    # The index the kernel answers counts along memory, so a strided operand
+    # would answer an index into the base rather than into the view.
+    a = Cumo::Int32.new(6, 5).seq
+    v = a[true, 1..3]
+    assert_equal([15, 16, 17], v.max_index(axis: 0).to_a)
+    assert_equal([2, 5, 8, 11, 14, 17], v.max_index(axis: 1).to_a)
+  end
+
   test "copy of an RObject view stays on the host" do
     # RObject data is host memory, so it must not take the kernel path
     a = Cumo::RObject.cast([[1, 2, 3], [4, 5, 6], [7, 8, 9]])


### PR DESCRIPTION
## Summary

Every reduction over a view copied the whole operand into a contiguous array first, including views the reduction addresses perfectly well. `sum` of a transposed 8192x8192 `SFloat` goes from 7.00 to 0.64 ms, which is what the same reduction on the base array costs.

## Problem

`cumo_na_has_idx_p` reads `nv->stridx[i].index` and takes it as a pointer. `cumo_stridx_t` is a union and a stride is stored with its low bit set, `((s) << 1) | 0x1`, so the raw value is non-zero for every dimension a view has, stride 0 included. The predicate answered true for every view. `Cumo::NArray.debug = true` on `v.sum(axis: -1)` shows two `cumo_ndfunc_t` where the base array shows one, for a full-range view as much as for a transpose.

The callers of it read "make contiguous, the reduction does not support idx". With the predicate corrected, only a view that really carries an index array copies:

```
                       ndfunc  before  after
base                        1       1
a[true, true]               2       1
a.transpose                 2       1
a[0...256, true]            2       1
a[(0...512) % 2, true]      2       1
a[[3, 1, 2], true]          2       2
```

Measured on an RTX 5070 Ti Laptop, `SFloat`:

| | before | after |
|---|---|---|
| `a.transpose.sum(axis: -1)`, 8192x8192 | 7.003 ms | 0.642 ms |
| `a.sum(axis: 0)`, the same reduction | 0.660 ms | 0.654 ms |
| `a.transpose.sum(axis: -1)`, 2048x2048 | 0.343 ms | 0.012 ms |

## Note

`max_index`, `min_index`, `argmax`, `argmin` and `sort_index` answer an index that counts along the operand's memory, so it only means the same thing as the logical index when the operand is contiguous. Those kept copying, and now test contiguity rather than the corrected predicate: `Cumo::Int32.new(6, 5).seq[true, 1..3].max_index(axis: 0)` stays `[15, 16, 17]`, which is what Numo answers, instead of the `[25, 26, 27]` that dropping the copy would give.

The new test measures the pool from a child process. In-process it is order dependent: blocks another test left free serve the copy, and `total_bytes` does not move.
