### PR TITLE
Pass a numeric operand to the kernel instead of a 0-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -10,6 +10,9 @@
 
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
+//<% if %w[add sub mul div].include?(name) %>
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
+//<% end %>
 <% end %>
 
 static void
@@ -127,11 +130,44 @@ static void
     }
     <% end %>
 }
+
+//<% if !is_object and %w[add sub mul div].include?(name) %>
+// The operand is a Ruby numeric, so it rides in through opt_ptr instead of
+// being cast to a 0-dimensional array, which costs a kernel launch to fill.
+static void
+<%=c_iter%>_s(cumo_na_loop_t *const lp)
+{
+    dtype y = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    //<% if is_int and %w[div mod].include? name %>
+    int *divzero = cumo_cuda_runtime_error_flag_new();
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,divzero);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    if (cumo_cuda_runtime_error_flag_get(divzero)) {
+        lp->err_type = rb_eZeroDivError;
+    }
+    //<% else %>
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,0);
+    //<% end %>
+}
+//<% end %>
 #undef check_intdivzero
 
 static VALUE
 <%=c_func%>_self(VALUE self, VALUE other)
 {
+    //<% if !is_object and %w[add sub mul div].include?(name) %>
+    if (rb_obj_is_kind_of(other, rb_cNumeric)) {
+        dtype y = m_num_to_data(other);
+        cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+        cumo_ndfunc_arg_out_t aout_s[1] = {{cT,0}};
+        cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout_s };
+        return cumo_na_ndloop3(&ndf_s, &y, 1, self);
+    }
+    //<% end %>
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
     <% if type_name == 'robject' %>

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -10,7 +10,7 @@
 
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
-//<% if %w[add sub mul div].include?(name) %>
+//<% if %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
 void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
 //<% end %>
 <% end %>
@@ -131,7 +131,7 @@ static void
     <% end %>
 }
 
-//<% if !is_object and %w[add sub mul div].include?(name) %>
+//<% if !is_object and %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
 // The operand is a Ruby numeric, so it rides in through opt_ptr instead of
 // being cast to a 0-dimensional array, which costs a kernel launch to fill.
 static void
@@ -159,7 +159,7 @@ static void
 static VALUE
 <%=c_func%>_self(VALUE self, VALUE other)
 {
-    //<% if !is_object and %w[add sub mul div].include?(name) %>
+    //<% if !is_object and %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
     if (rb_obj_is_kind_of(other, rb_cNumeric)) {
         dtype y = m_num_to_data(other);
         cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -10,7 +10,7 @@
 #define cumo_check_intdivzero(y) {}
 //<% end %>
 
-//<% has_scalar = %w[add sub mul div].include?(name) %>
+//<% has_scalar = %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
 //<% if has_scalar %>
 // A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -10,7 +10,24 @@
 #define cumo_check_intdivzero(y) {}
 //<% end %>
 
+//<% has_scalar = %w[add sub mul div].include?(name) %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+//<% if has_scalar %>
+// A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
+// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// same for every thread, so the branch costs nothing.
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int* divzero, dtype sv, int use_scalar)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        dtype y = use_scalar ? sv : *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        cumo_check_intdivzero(y);
+        *(dtype*)(p3) = m_<%=name%>(*(dtype*)(p1),y);
+    }
+}
+//<% else %>
 __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int* divzero)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
@@ -22,8 +39,41 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
         *(dtype*)(p3) = m_<%=name%>(*(dtype*)(p1),*(dtype*)(p2));
     }
 }
+//<% end %>
 <% end %>
 
+//<% if has_scalar %>
+static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero, dtype sv, int use_scalar)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,divzero,sv,use_scalar);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,divzero,sv,use_scalar);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)
+{
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,divzero,sv,0);
+}
+
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)
+{
+    cumo_na_iarray_t a2;
+    memset(&a2, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&a2,a3,indexer,divzero,sv,1);
+}
+//<% else %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
@@ -40,5 +90,6 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
     }
     cumo_cuda_runtime_check_kernel_launch();
 }
+//<% end %>
 #undef cumo_check_intdivzero
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4371,10 +4371,24 @@ class NArrayTest < Test::Unit::TestCase
     assert_operator(Integer(out), :<, 100 * (1024 + 512))
   end
 
-  test "an integer divided by a numeric zero still raises" do
+  test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }
+    assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] % 0 }
     assert_equal([0, 1, 1], (Cumo::Int32[1, 2, 3] / 2).to_a)
+    assert_equal([1, 0, 1], (Cumo::Int32[1, 2, 3] % 2).to_a)
+  end
+
+  test "the operators that take a numeric operand answer what Numo answers" do
+    ints = Cumo::Int32[7, 3, 100]
+    assert_equal([5, 1, 4], (ints & 5).to_a)
+    assert_equal([7, 7, 101], (ints | 5).to_a)
+    assert_equal([2, 6, 97], (ints ^ 5).to_a)
+    assert_equal([28, 12, 400], (ints << 2).to_a)
+    assert_equal([1, 0, 25], (ints >> 2).to_a)
+    floats = Cumo::SFloat[7, -3, 100]
+    assert_equal([-7, -3, -100], floats.copysign(-1).to_a)
+    assert_equal([7, 3, 100], floats.copysign(1).to_a)
   end
 
   test "a reduction over a strided view does not copy the operand" do

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4338,6 +4338,45 @@ class NArrayTest < Test::Unit::TestCase
     assert_reductions(big.transpose, "3000x33 transpose", axes: [[0], [1]])
   end
 
+  test "an arithmetic operator with a numeric operand allocates only its result" do
+    # A numeric operand used to be cast to a 0-dimensional array, which took a
+    # whole kernel launch to fill. Measured in a child, or blocks another test
+    # left in the pool serve the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(256).seq
+      keep = []
+      100.times { keep << a + 1.5 }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << a + 1.5 }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 100 results of 1 KiB each, rounded up to the pool's 512 byte bins. A
+    # 0-dimensional operand per operation would add another 100 bins.
+    assert_operator(Integer(out), :<, 100 * (1024 + 512))
+  end
+
+  test "an integer divided by a numeric zero still raises" do
+    assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
+    assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }
+    assert_equal([0, 1, 1], (Cumo::Int32[1, 2, 3] / 2).to_a)
+  end
+
   test "a reduction over a strided view does not copy the operand" do
     # In a child, or blocks another test left in the pool serve the copy and it
     # does not show up in total_bytes.


### PR DESCRIPTION
## Summary

`a + 1.5` launched two kernels where `a + b` launches one: the numeric operand was cast to a 0-dimensional array, and filling that array is a kernel launch of its own. Every operator this template generates now hands the value to the kernel as an argument. `a + 1.5` on 768 `SFloat` goes from 4.00 to 2.14 us, which is what `a + b` costs.

## Problem

`<type>_add_self` runs `cumo_na_ndloop` with `ain[1] = {cT, 0}`, so ndloop casts the `Float` through `<type>_new_dim0`, which allocates a one-element array and writes it with `cumo_<type>_new_dim0_kernel`. Confirmed with nsys: `100.times { a + b }` is 100 kernels, `100.times { a + 1.5 }` is 200.

`add`, `sub`, `mul`, `div`, `mod`, the bitwise operators, the shifts and `copysign` now take a second path when the operand is a `Numeric`: an ndfunc with one input that carries the value in `opt_ptr`, and a launcher that passes it to the kernel. The kernel gained a `dtype sv` and a `use_scalar` argument rather than a second family of kernels, and `use_scalar` is the same for every thread so the branch costs nothing.

| | before | after |
|---|---|---|
| `a + 1.5`, 768 `SFloat` | 4.00 us | 2.14 us |
| `a + 1.5`, 65536 `SFloat` | 4.22 us | 2.42 us |
| `a + b`, for comparison | 2.03 us | 2.03 us |
| kernels per `a + 1.5` | 2 | 1 |

On a GPT-2 124M decode step (narray-gpt2, RTX 5070 Ti Laptop) that is 787 -> 750 kernel launches per token and 381.2 -> 394.1 tokens/sec, best of 3 with the three runs at 0.168-0.177 s before and 0.162-0.166 s after.

`cumo.so` grows from 53.05 to 54.16 MB, 2.1%.

## Note

Checked against Numo on 618 cases: 12 dtypes x `+` `-` `*` `/` x 8 scalars (integers, negatives, zero, floats, a `Rational`, and `2**40` for the narrow integer types), plus a column view, a transpose, `inplace` and a 0-dimensional receiver, and then `%` on every real dtype, the bitwise operators and the shifts on every integer dtype, and `copysign` on the floats. All identical. Integer division or modulo by a scalar zero still raises `ZeroDivisionError`, which the scalar iterator carries the same error flag for.

`pow`, the comparisons, `clip` (two per call) and the two-argument `Numo::NMath` functions still launch a `new_dim0` kernel of their own. Each comes from a template of its own, so each is the same piece of work again.
