### PR TITLE
Pass numeric clip bounds to the kernel instead of 0-dimensional arrays

### DIFF
--- a/ext/cumo/narray/gen/tmpl/clip.c
+++ b/ext/cumo/narray/gen/tmpl/clip.c
@@ -1,7 +1,10 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv_min, dtype sv_max, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_min_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_min_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_max_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_max_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
@@ -122,6 +125,45 @@ static void
     <% end %>
 }
 
+<% unless type_name == 'robject' %>
+// A Ruby numeric bound rides in through opt_ptr instead of being cast to a
+// 0-dimensional array, which costs a kernel launch to fill. With both bounds
+// numeric the caller rejects min > max itself, so the kernel needs no error
+// flag and the loop no longer synchronizes to read one.
+static void
+<%=c_iter%>_s(cumo_na_loop_t *const lp)
+{
+    dtype *sv = (dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a4 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv[0],sv[1],&a4,&indexer);
+}
+
+static void
+<%=c_iter%>_min_s(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_min_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+}
+
+static void
+<%=c_iter%>_max_s(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_max_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+}
+<% end %>
+
 /*
   Clip array elements by [min,max].
   If either of min or max is nil, one side is clipped.
@@ -165,6 +207,31 @@ static VALUE
     cumo_ndfunc_t ndf_min = { <%=c_iter%>_min, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
     cumo_ndfunc_t ndf_max = { <%=c_iter%>_max, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
     cumo_ndfunc_t ndf_both = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 3, 1, ain, aout };
+
+    {
+        cumo_ndfunc_arg_in_t ain_s[1] = {{Qnil,0}};
+        int min_s = RTEST(min) && rb_obj_is_kind_of(min, rb_cNumeric);
+        int max_s = RTEST(max) && rb_obj_is_kind_of(max, rb_cNumeric);
+
+        if (min_s && max_s) {
+            dtype sv[2];
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            sv[0] = m_num_to_data(min);
+            sv[1] = m_num_to_data(max);
+            if (m_gt(sv[0],sv[1])) {rb_raise(cumo_na_eOperationError,"min is greater than max");}
+            return cumo_na_ndloop3(&ndf_s, sv, 1, self);
+        }
+        if (min_s && !RTEST(max)) {
+            dtype sv = m_num_to_data(min);
+            cumo_ndfunc_t ndf_min_s = { <%=c_iter%>_min_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_min_s, &sv, 1, self);
+        }
+        if (max_s && !RTEST(min)) {
+            dtype sv = m_num_to_data(max);
+            cumo_ndfunc_t ndf_max_s = { <%=c_iter%>_max_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_max_s, &sv, 1, self);
+        }
+    }
     <% end %>
 
     if (RTEST(min)) {

--- a/ext/cumo/narray/gen/tmpl/clip_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/clip_kernel.cu
@@ -1,54 +1,89 @@
 <% unless type_name == 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_iarray_t a4, cumo_na_indexer_t indexer, int* invalid)
+// A Ruby numeric bound rides in as sv rather than as a 0-dimensional array,
+// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// same for every thread, so the branches cost nothing, and it also says the
+// caller already compared the two bounds, so invalid is never written.
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_iarray_t a4, cumo_na_indexer_t indexer, int* invalid, dtype sv_min, dtype sv_max, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype min = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
-        dtype max = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
+        dtype min = use_scalar ? sv_min : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype max = use_scalar ? sv_max : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
         // Leaving the element unwritten keeps a scalar min > max, where every
         // element takes this branch, from touching the output before it raises.
-        if (m_gt(min,max)) { *invalid = 1; continue; }
+        if (!use_scalar && m_gt(min,max)) { *invalid = 1; continue; }
         if (m_lt(x,min)) { x = min; }
         if (m_gt(x,max)) { x = max; }
         *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a4, &indexer) = x;
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype min = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype min = use_scalar ? sv : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer) = m_lt(x,min) ? min : x;
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype max = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype max = use_scalar ? sv : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer) = m_gt(x,max) ? max : x;
     }
 }
 <% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid)
+static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid, dtype sv_min, dtype sv_max, int use_scalar)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid,sv_min,sv_max,use_scalar);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*a4,*indexer,invalid,sv_min,sv_max,use_scalar);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer, int* invalid)
+{
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,a4,indexer,invalid,sv,sv,0);
+}
+
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv_min, dtype sv_max, cumo_na_iarray_t* a4, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,&unused,a4,indexer,0,sv_min,sv_max,1);
+}
+
+static void <%="cumo_#{c_iter}_min_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_min_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
@@ -56,16 +91,30 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
 
 void <%="cumo_#{c_iter}_min_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_min_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
+}
+
+void <%="cumo_#{c_iter}_min_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_min_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
+}
+
+static void <%="cumo_#{c_iter}_max_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
+{
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_min_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_min_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_max_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
@@ -73,18 +122,15 @@ void <%="cumo_#{c_iter}_min_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarra
 
 void <%="cumo_#{c_iter}_max_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
-    switch (indexer->ndim) {
-    <% (0..opt_indexer_ndim).each do |idim| %>
-    case <%=idim%>:
-        <%="cumo_#{c_iter}_max_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
-        break;
-    <% end %>
-    default:
-        <%="cumo_#{c_iter}_max_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
-        break;
-    }
-    cumo_cuda_runtime_check_kernel_launch();
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_max_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
+}
+
+void <%="cumo_#{c_iter}_max_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_max_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -722,6 +722,30 @@ class NArrayTest < Test::Unit::TestCase
           assert_raise(Cumo::NArray::OperationError) { a.inplace.clip(6, 3) }
           assert { a == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] }
         end
+
+        # A numeric bound is now converted by the caller and handed to the
+        # kernel, where it used to be cast to a 0-dimensional array.
+        test "a numeric bound answers what the same bound as an array answers" do
+          a = dtype[0..9]
+          assert { a.clip(1.5, 7.5) == a.clip(dtype.new(10).fill(1.5), dtype.new(10).fill(7.5)) }
+          assert { a.clip(1.5, nil) == a.clip(dtype.new(10).fill(1.5), nil) }
+          assert { a.clip(nil, 7.5) == a.clip(nil, dtype.new(10).fill(7.5)) }
+        end
+
+        test "a numeric bound reaches a shape past the optimized indexer ndim" do
+          a = dtype.new(*([2] * 9)).seq
+          assert { a.clip(1, 2) == a.clip(dtype.new(*([2] * 9)).fill(1), dtype.new(*([2] * 9)).fill(2)) }
+          assert { a.clip(1, nil) == a.clip(dtype.new(*([2] * 9)).fill(1), nil) }
+        end
+
+        if [Cumo::SFloat, Cumo::DFloat].include?(dtype)
+          test "a NaN bound answers what the same bound as an array answers" do
+            a = dtype[0..5]
+            nan = dtype.new(6).fill(Float::NAN)
+            assert { a.clip(Float::NAN, 4) == a.clip(nan, 4) }
+            assert { a.clip(1, Float::NAN) == a.clip(1, nan) }
+          end
+        end
       end
     end
 
@@ -4368,6 +4392,40 @@ class NArrayTest < Test::Unit::TestCase
     omit("memory pool is disabled") if out == "no-pool"
     # 100 results of 1 KiB each, rounded up to the pool's 512 byte bins. A
     # 0-dimensional operand per operation would add another 100 bins.
+    assert_operator(Integer(out), :<, 100 * (1024 + 512))
+  end
+
+  test "clip with numeric bounds allocates only its result" do
+    # Each numeric bound used to be cast to a 0-dimensional array, and reading
+    # the flag that reported min > max synchronized with the device on top of
+    # that. Measured in a child, or blocks another test left in the pool serve
+    # the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(256).seq
+      keep = []
+      100.times { keep << a.clip(1.0, 200.0) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << a.clip(1.0, 200.0) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 100 results of 1 KiB each, rounded up to the pool's 512 byte bins. Two
+    # 0-dimensional bounds per call would add another 200 bins.
     assert_operator(Integer(out), :<, 100 * (1024 + 512))
   end
 


### PR DESCRIPTION
## Summary

`clip` with numeric bounds now hands them to the kernel as scalars instead of casting each one to a 0-dimensional array, and compares two numeric bounds on the host so the loop no longer synchronizes to read the `min > max` flag.

- `clip(1.0, 2.0)` 9.77 -> 2.15 us, `clip(1.0, nil)` 4.15 -> 2.03 us on a 1024-element `SFloat` (best of 5, one case per process)
- the launch count per call drops from 3 to 1, and the clip kernel's own median from 2368 to 576 ns because it reads no operand array
- bounds given as arrays are unchanged, and so is `RObject`

## Problem

`clip` declares both bounds as `cT` operands, so `a.clip(1.0, 2.0)` filled two 0-dimensional arrays with a kernel each before the clip kernel ran. On top of that the two-sided form allocates an error flag for `min > max` and reads it back through `cumo_cuda_runtime_error_flag_get`, which calls `cudaDeviceSynchronize`. Three launches and a full device synchronization for one elementwise operation.

When both bounds are numeric the caller can compare them itself, so the flag is not needed at all. The kernels take `use_scalar` the way `binary_kernel.cu` does after #287; `!use_scalar` guards the flag write, so the scalar path provably never dereferences it.

## Note

A mixed call such as `clip(1.0, arr)` keeps the old path. It was measured with the scalar operand routed through the new kernel too, and the gain was inside the noise (6.74 -> 6.56 us): one bound is still an array, so the per-element `min > max` check and its synchronization remain and absorb the launch that would have been saved. The extra iterators were dropped rather than carried for no effect.
