### PR TITLE
Pass a numeric exponent to the kernel instead of a 0-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/pow.c
+++ b/ext/cumo/narray/gen/tmpl/pow.c
@@ -1,6 +1,8 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_int32_s_kernel_launch"%>(cumo_na_iarray_t* a1, int32_t sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
@@ -72,6 +74,33 @@ static void
     <% end %>
 }
 
+<% unless type_name == 'robject' %>
+// A Ruby numeric exponent rides in through opt_ptr instead of being cast to a
+// 0-dimensional array, which costs a kernel launch to fill. An Integer takes
+// the int32 path the same way it does when it is cast.
+static void
+<%=c_iter%>_s(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+}
+
+static void
+<%=c_iter%>_int32_s(cumo_na_loop_t *const lp)
+{
+    int32_t sv = *(int32_t*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_int32_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+}
+<% end %>
+
 static VALUE
 <%=c_func%>_self(VALUE self, VALUE other)
 {
@@ -86,6 +115,22 @@ static VALUE
     cumo_ndfunc_t ndf_i = { <%=c_iter%>_int32, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain_i, aout };
     <% end %>
 
+    //<% if type_name != 'robject' %>
+    {
+        cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+
+        if (FIXNUM_P(other)) {
+            int32_t sv = NUM2INT32(other);
+            cumo_ndfunc_t ndf_i_s = { <%=c_iter%>_int32_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_i_s, &sv, 1, self);
+        }
+        if (rb_obj_is_kind_of(other, rb_cNumeric)) {
+            dtype sv = m_num_to_data(other);
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_s, &sv, 1, self);
+        }
+    }
+    //<% end %>
     // fixme : use na.integer?
     if (FIXNUM_P(other) || rb_obj_is_kind_of(other,cumo_cInt32)) {
         return cumo_na_ndloop(&ndf_i, 2, self, other);

--- a/ext/cumo/narray/gen/tmpl/pow_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/pow_kernel.cu
@@ -1,40 +1,74 @@
 <% unless type_name == 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+// A Ruby numeric exponent rides in as sv rather than as a 0-dimensional array,
+// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// same for every thread, so the branch costs nothing.
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
-        *(dtype*)(p3) = m_pow(*(dtype*)(p1), *(dtype*)(p2));
+        dtype y = use_scalar ? sv : *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        *(dtype*)(p3) = m_pow(*(dtype*)(p1), y);
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int32_t sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        char* p2 = cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
-        *(dtype*)(p3) = m_pow_int(*(dtype*)(p1), *(int32_t*)(p2));
+        int32_t y = use_scalar ? sv : *(int32_t*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        *(dtype*)(p3) = m_pow_int(*(dtype*)(p1), y);
     }
 }
 <% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
+}
+
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
+}
+
+static void <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int32_t sv, int use_scalar)
+{
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_int32_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
@@ -42,18 +76,13 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
 
 void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
-    switch (indexer->ndim) {
-    <% (0..opt_indexer_ndim).each do |idim| %>
-    case <%=idim%>:
-        <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
-        break;
-    <% end %>
-    default:
-        <%="cumo_#{c_iter}_int32_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
-        break;
-    }
-    cumo_cuda_runtime_check_kernel_launch();
+    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,a2,a3,indexer,0,0);
+}
+
+void <%="cumo_#{c_iter}_int32_s_kernel_launch"%>(cumo_na_iarray_t* a1, int32_t sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4429,6 +4429,71 @@ class NArrayTest < Test::Unit::TestCase
     assert_operator(Integer(out), :<, 100 * (1024 + 512))
   end
 
+  test "a numeric exponent allocates only its result" do
+    # The exponent used to be cast to a 0-dimensional array, an Int32 one for
+    # an Integer. Measured in a child, or blocks another test left in the pool
+    # serve the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(256).seq
+      keep = []
+      100.times { keep << a**2 }
+      100.times { keep << a**2.5 }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << a**2 }
+      100.times { keep << a**2.5 }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 200 results of 1 KiB each, rounded up to the pool's 512 byte bins. A
+    # 0-dimensional exponent per call would add another 200 bins.
+    assert_operator(Integer(out), :<, 200 * (1024 + 512))
+  end
+
+  test "a numeric exponent answers what the same exponent as an array answers" do
+    # Int32 as the exponent does not widen any of these, so the array operand
+    # is a fair reference for the value the scalar one is handed.
+    [Cumo::SFloat, Cumo::DFloat, Cumo::Int32, Cumo::Int64, Cumo::DComplex].each do |dtype|
+      a = dtype[1, 2, 3, 4]
+      assert_equal((a**Cumo::Int32.new(4).fill(3)).to_a, (a**3).to_a, "#{dtype} ** 3")
+      # a 9-d shape runs past the dimension-specialised kernels
+      deep = dtype.new(*([2] * 9)).seq(1)
+      assert_equal((deep**Cumo::Int32.new(*([2] * 9)).fill(2)).to_a.flatten,
+                   (deep**2).to_a.flatten, "#{dtype} 9-d ** 2")
+    end
+
+    [Cumo::SFloat, Cumo::DFloat, Cumo::DComplex].each do |dtype|
+      a = dtype[1, 2, 3, 4]
+      assert_equal((a**dtype.new(4).fill(2.5)).to_a, (a**2.5).to_a, "#{dtype} ** 2.5")
+      deep = dtype.new(*([2] * 9)).seq(1)
+      assert_equal((deep**dtype.new(*([2] * 9)).fill(0.5)).to_a.flatten,
+                   (deep**0.5).to_a.flatten, "#{dtype} 9-d ** 0.5")
+    end
+
+    # a narrower dtype keeps its own width, where an Int32 array operand widens it
+    assert_equal(Cumo::UInt8, (Cumo::UInt8[1, 2, 16, 17]**2).class)
+    assert_equal([1, 4, 0, 33], (Cumo::UInt8[1, 2, 16, 17]**2).to_a)
+    assert_equal(Complex, (Cumo::DComplex[2]**Complex(0, 1)).to_a[0].class)
+    # a Bignum exponent still falls through to the wider path
+    assert_equal([1.0, Float::INFINITY], (Cumo::SFloat[1, 2]**(2**70)).to_a)
+    assert_raise(RangeError) { Cumo::SFloat[1, 2]**(2**40) }
+    assert_raise(RangeError) { Cumo::Int32[1, 2]**(2**70) }
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

`**` with a numeric exponent now hands it to the kernel as a scalar instead of casting it to a 0-dimensional array.

- `a ** 2` 4.04 -> 2.10 us and `a ** 2.5` 3.87 -> 2.17 us on a 1024-element `SFloat` (best of 5, one case per process, before and after alternated twice)
- one launch per call instead of two, and the pow kernel's own median drops from 2432 to 640 ns because it reads no operand array
- an exponent given as an array is unchanged, and so is `RObject`

## Problem

`pow.c` declares the exponent as an operand, so `a ** 2` filled a 0-dimensional array with a kernel of its own before the pow kernel ran. nsys counts `new_dim0` once per call for every form: `a ** 2` and `a ** 2.5` on `SFloat`, `a ** 2` on `Int32`. An `Integer` exponent goes through the `Int32` variant, so `SFloat ** 2` built an `Int32` 0-dimensional array.

Both kernels take `sv` and `use_scalar` the way `binary_kernel.cu` does after #287, with `int32_t sv` for the `Int32` variant. The caller converts the exponent with the same macro the cast used (`NUM2INT32` for an `Integer`, `m_num_to_data` otherwise), so an out-of-range `Integer` still raises `RangeError` and a `Bignum` still falls through to the wider path.

## Note

Heavier kernels gain less because they were already the bottleneck: `DFloat ** 2.5` goes 4.10 -> 3.30 us and `DComplex ** 2` goes 5.85 -> 4.10 us, where the saved launch overlaps the kernel rather than adding to it.
