### PR TITLE
Pass a numeric comparison operand to the kernel instead of a 0-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/cond_binary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_binary.c
@@ -1,5 +1,6 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
 static void
@@ -40,6 +41,21 @@ static void
     <% end %>
 }
 
+<% unless type_name == 'robject' %>
+// A Ruby numeric operand rides in through opt_ptr instead of being cast to a
+// 0-dimensional array, which costs a kernel launch to fill.
+static void
+<%=c_iter%>_s(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_bit_iarray_t a3 = cumo_na_make_bit_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+}
+<% end %>
+
 static VALUE
 <%=c_func%>_self(VALUE self, VALUE other)
 {
@@ -49,6 +65,13 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
     <% else %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+
+    if (rb_obj_is_kind_of(other, rb_cNumeric)) {
+        dtype sv = m_num_to_data(other);
+        cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+        cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+        return cumo_na_ndloop3(&ndf_s, &sv, 1, self);
+    }
     <% end %>
 
     return cumo_na_ndloop(&ndf, 2, self, other);

--- a/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
@@ -1,31 +1,48 @@
 <% unless type_name == 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer)
+// A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
+// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// same for every thread, so the branch costs nothing.
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype y = use_scalar ? sv : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         CUMO_BIT_DIGIT b = (m_<%=name%>(x,y)) ? 1:0;
         CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a3, &indexer), b);
     }
 }
 <% end %>
 
-void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer)
+static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
+}
+
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
+}
+
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4494,6 +4494,76 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(RangeError) { Cumo::Int32[1, 2]**(2**70) }
   end
 
+  test "a numeric operand compared against allocates only its result" do
+    # The operand used to be cast to a 0-dimensional array, which took a whole
+    # kernel launch to fill. Measured in a child, or blocks another test left
+    # in the pool serve the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(8192).seq
+      keep = []
+      100.times { keep << (a > 1.5) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << (a > 1.5) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 100 Bit results of 1 KiB each. A 0-dimensional operand per comparison
+    # would add another 100 of the pool's 512 byte bins.
+    assert_operator(Integer(out), :<, 100 * (1024 + 512))
+  end
+
+  test "a numeric operand answers what the same operand as an array answers" do
+    # The operand keeps the receiver's dtype either way, so the array one is a
+    # fair reference for the value the scalar one is handed.
+    comparable = [Cumo::Int8, Cumo::Int32, Cumo::Int64, Cumo::UInt8, Cumo::UInt32,
+                  Cumo::SFloat, Cumo::DFloat]
+    (comparable + [Cumo::SComplex, Cumo::DComplex]).each do |dtype|
+      ops = comparable.include?(dtype) ? %i[eq ne gt ge lt le] : %i[eq ne]
+      a = dtype[1, 2, 3, 4]
+      ops.each do |op|
+        assert_equal(a.send(op, dtype.new(4).fill(3)).to_a, a.send(op, 3).to_a,
+                     "#{dtype} #{op} 3")
+      end
+      # a 9-d shape runs past the dimension-specialised kernels
+      deep = dtype.new(*([2] * 9)).seq(1)
+      assert_equal(deep.eq(dtype.new(*([2] * 9)).fill(7)).to_a.flatten,
+                   deep.eq(7).to_a.flatten, "#{dtype} 9-d eq 7")
+    end
+
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      a = dtype[-1, 0, 1, Float::NAN, Float::INFINITY]
+      %i[eq ne gt ge lt le nearly_eq].each do |op|
+        [1.0, Float::NAN, Float::INFINITY].each do |v|
+          assert_equal(a.send(op, dtype.new(5).fill(v)).to_a, a.send(op, v).to_a,
+                       "#{dtype} #{op} #{v}")
+        end
+      end
+    end
+
+    view = Cumo::Int32.new(3, 4).seq.transpose
+    assert_equal(view.gt(Cumo::Int32.new(4, 3).fill(5)).to_a, view.gt(5).to_a)
+
+    # the operand is converted the way casting it converts it
+    assert_equal([0, 0, 0, 1], Cumo::UInt8[1, 2, 16, 255].eq(-1).to_a)
+    assert_equal([1, 1, 1, 1], Cumo::UInt8[1, 2, 16, 255].gt(256).to_a)
+    assert_raise(RangeError) { Cumo::Int32[1, 2].gt(2**40) }
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `a > 1.5` launched a kernel to fill a 0-dimensional array with `1.5` before the comparison kernel ran, so a scalar comparison cost about twice what `a > b` costs.
- A numeric operand now rides into the kernel as a scalar through `opt_ptr`, the way #287 did it for `binary.c` and #289 for `pow.c`. This covers `eq`, `ne`, `gt`, `ge`, `lt`, `le` and `nearly_eq`.
- 1024 elements, one case per process, best of 5: `SFloat > 1.5` 3.84 → 2.09 us, `SFloat.eq(1.5)` 4.05 → 2.12 us, `Int32 > 3` 3.93 → 2.12 us, `DComplex.eq(Complex(1,2))` 4.02 → 2.16 us. `a > b` stays at 2.1 us.
- The operand is converted by `m_num_to_data`, which casting it to a 0-dimensional array already called, so `UInt8 > 256`, `UInt8.eq(-1)` and the `RangeError` on `Int32 > 2**40` answer what they did before. 1494 dtype/operator/operand combinations answer the same as numo.
- `cumo.so` grows 1.1%, since the existing kernels take two more arguments rather than a second family being generated.

## Problem

`nsys` over `50.times { a > 1.5 }` counts 50 `cumo_sfloat_new_dim0_kernel` launches beside the 50 comparison kernels, while `50.times { a > b }` has none. Filling one element is 0.35 us of GPU time but a whole launch of CPU time, and at 1024 elements the comparison itself is only about as long. The new test fails on master, where the pool grows by 100 extra blocks over 100 comparisons.
