### PR TITLE
Pass a numeric NMath operand to the kernel instead of a 0-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/tmpl/binary_s.c
+++ b/ext/cumo/narray/gen/tmpl/binary_s.c
@@ -1,5 +1,6 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(char *p1, char *p3, ssize_t s1, ssize_t s3, uint64_t n, dtype sv, int scalar_is_left);
 <% end %>
 
 static void
@@ -28,6 +29,39 @@ static void
     <% end %>
 }
 
+<% unless type_name == 'robject' %>
+// A Ruby numeric operand rides in through opt_ptr instead of being cast to a
+// 0-dimensional array, which costs a kernel launch to fill. Either side of a
+// module function can be the numeric one, so there is an iterator for each.
+static void
+<%=c_iter%>_s(cumo_na_loop_t *const lp)
+{
+    size_t  i;
+    char    *p1, *p3;
+    ssize_t s1, s3;
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    CUMO_INIT_COUNTER(lp, i);
+    CUMO_INIT_PTR(lp, 0, p1, s1);
+    CUMO_INIT_PTR(lp, 1, p3, s3);
+
+    <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(p1,p3,s1,s3,i,sv,0);
+}
+
+static void
+<%=c_iter%>_s_left(cumo_na_loop_t *const lp)
+{
+    size_t  i;
+    char    *p1, *p3;
+    ssize_t s1, s3;
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    CUMO_INIT_COUNTER(lp, i);
+    CUMO_INIT_PTR(lp, 0, p1, s1);
+    CUMO_INIT_PTR(lp, 1, p3, s3);
+
+    <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(p1,p3,s1,s3,i,sv,1);
+}
+<% end %>
+
 /*
   Calculate <%=name%>(a1,a2).
   @overload <%=name%>(a1,a2)
@@ -41,5 +75,24 @@ static VALUE
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
+    //<% if type_name != 'robject' %>
+    {
+        cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+        int n1 = RTEST(rb_obj_is_kind_of(a1, rb_cNumeric));
+        int n2 = RTEST(rb_obj_is_kind_of(a2, rb_cNumeric));
+
+        if (!n1 && n2) {
+            dtype sv = m_num_to_data(a2);
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_s, &sv, 1, a1);
+        }
+        if (n1 && !n2) {
+            dtype sv = m_num_to_data(a1);
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_s, &sv, 1, a2);
+        }
+    }
+    //<% end %>
     return cumo_na_ndloop(&ndf, 2, a1, a2);
 }
+

--- a/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
@@ -1,16 +1,39 @@
 <% unless type_name == 'robject' %>
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+// A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
+// which would cost a whole kernel launch of its own to fill. Either side of a
+// module function can be the numeric one, so use_scalar says which side sv is
+// on. It is the same for every thread, so the branch costs nothing.
+__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        *(dtype*)(p3+(i*s3)) = m_<%=name%>(*(dtype*)(p1+(i*s1)),*(dtype*)(p2+(i*s2)));
+        dtype x = *(dtype*)(p1+(i*s1));
+        dtype y;
+        switch (use_scalar) {
+        case 1:  y = sv; break;
+        case 2:  y = x; x = sv; break;
+        default: y = *(dtype*)(p2+(i*s2));
+        }
+        *(dtype*)(p3+(i*s3)) = m_<%=name%>(x,y);
     }
+}
+
+static void <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n, dtype sv, int use_scalar)
+{
+    size_t grid_dim = cumo_get_grid_dim(n);
+    size_t block_dim = cumo_get_block_dim(n);
+    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n,sv,use_scalar);
+    cumo_cuda_runtime_check_kernel_launch();
 }
 
 void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
-    cumo_cuda_runtime_check_kernel_launch();
+    dtype sv;
+    memset(&sv, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(p1,p2,p3,s1,s2,s3,n,sv,0);
+}
+
+void <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(char *p1, char *p3, ssize_t s1, ssize_t s3, uint64_t n, dtype sv, int scalar_is_left)
+{
+    <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(p1,NULL,p3,s1,0,s3,n,sv,scalar_is_left ? 2 : 1);
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4564,6 +4564,80 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(RangeError) { Cumo::Int32[1, 2].gt(2**40) }
   end
 
+  test "a numeric NMath operand allocates only its result" do
+    # The operand used to be cast to a 0-dimensional array, which took a whole
+    # kernel launch to fill. Measured in a child, or blocks another test left
+    # in the pool serve the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      m = Cumo::DFloat::Math
+      a = Cumo::DFloat.new(128).seq(1)
+      keep = []
+      100.times { keep << m.atan2(a, 1.5) }
+      100.times { keep << m.atan2(1.5, a) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << m.atan2(a, 1.5) }
+      100.times { keep << m.atan2(1.5, a) }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 200 results of 1 KiB each. A 0-dimensional operand per call would add
+    # another 200 of the pool's 512 byte bins.
+    assert_operator(Integer(out), :<, 200 * (1024 + 512))
+  end
+
+  test "a numeric NMath operand answers what the same operand as an array answers" do
+    # Either side of a module function can be the numeric one, so both are
+    # compared against the same value spread over an array.
+    [Cumo::SFloat, Cumo::DFloat].each do |dtype|
+      m = dtype::Math
+      a = dtype[1.0, -2.0, 0.5, 3.5]
+      spread = dtype.new(4).fill(1.5)
+      %i[atan2 hypot ldexp].each do |op|
+        assert_equal(m.send(op, a, spread).to_a, m.send(op, a, 1.5).to_a, "#{dtype} #{op}(arr, 1.5)")
+        assert_equal(m.send(op, spread, a).to_a, m.send(op, 1.5, a).to_a, "#{dtype} #{op}(1.5, arr)")
+      end
+
+      view = dtype.new(3, 4).seq(1).transpose
+      assert_equal(m.atan2(view, dtype.new(4, 3).fill(1.5)).to_a, m.atan2(view, 1.5).to_a, "#{dtype} view")
+      assert_equal(m.atan2(dtype.new(4, 3).fill(1.5), view).to_a, m.atan2(1.5, view).to_a, "#{dtype} view, reversed")
+
+      deep = dtype.new(*([2] * 9)).seq(1)
+      assert_equal(m.hypot(deep, dtype.new(*([2] * 9)).fill(1.5)).to_a.flatten,
+                   m.hypot(deep, 1.5).to_a.flatten, "#{dtype} 9-d")
+    end
+
+    # nan and the infinities reach the kernel as themselves
+    a = Cumo::DFloat[1.0, -2.0, Float::NAN, Float::INFINITY]
+    [Float::NAN, Float::INFINITY, -Float::INFINITY, 0.0].each do |v|
+      spread = Cumo::DFloat.new(4).fill(v)
+      assert_equal(Cumo::DFloat::Math.atan2(a, spread).to_a.map(&:to_s),
+                   Cumo::DFloat::Math.atan2(a, v).to_a.map(&:to_s), "atan2(arr, #{v})")
+      assert_equal(Cumo::DFloat::Math.atan2(spread, a).to_a.map(&:to_s),
+                   Cumo::DFloat::Math.atan2(v, a).to_a.map(&:to_s), "atan2(#{v}, arr)")
+    end
+
+    # two numerics still take the two-operand path
+    assert_equal(Cumo::DFloat, Cumo::DFloat::Math.atan2(1.0, 2.0).class)
+    assert_in_delta(Math.atan2(1.0, 2.0), Cumo::DFloat::Math.atan2(1.0, 2.0).to_a[0], 1e-15)
+    assert_raise(Cumo::NArray::CastError) { Cumo::DFloat::Math.atan2(Cumo::DFloat[1.0], "x") }
+    assert_raise(Cumo::NArray::CastError) { Cumo::DFloat::Math.atan2("x", Cumo::DFloat[1.0]) }
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `Cumo::NMath.atan2(a, 1.5)` cast the `1.5` to a 0-dimensional array, which took a kernel launch of its own to fill one element, so it cost about twice what `atan2(a, b)` costs.
- These are module functions, so either side can be the numeric one. Both now ride into the kernel as a scalar through `opt_ptr`, with an iterator per side. This is the last of the templates that cast a scalar, after #287, #288, #289 and #290.
- 1024 elements, one case per process, best of 5: `atan2(a, 1.5)` 3.98 → 2.11 us, `atan2(1.5, a)` 3.81 → 2.03 us, `hypot(a, 1.5)` 3.76 → 2.14 us, `ldexp(a, 3)` 3.74 → 2.10 us, and through `Cumo::NMath` 4.10 → 2.25 us. `atan2(a, b)` stays at 2.1 us.
- 282 combinations of operand type, side, view shape and dtype answer bit for bit what they answered before, `atan2`, `hypot` and `ldexp` over SFloat and DFloat.
- `cumo.so` grows 0.04%, since the existing kernel takes two more arguments rather than a second one being generated.

## Problem

`nsys` over 250 calls with a numeric operand counts 250 `new_dim0` launches beside the 250 `atan2` kernels, and none for `atan2(a, b)`. Filling one element is 0.38 us of GPU time but a whole launch of CPU time, which at 1024 elements is as long as the function itself. At 4M elements nothing moves either way: `atan2` is the cost there. The new test fails on master, where the pool grows by 200 extra blocks over 200 calls.
