### PR TITLE
Run the NMath binary functions through the indexer loop

### DIFF
--- a/ext/cumo/narray/gen/tmpl/binary_s.c
+++ b/ext/cumo/narray/gen/tmpl/binary_s.c
@@ -1,21 +1,22 @@
 <% unless type_name == 'robject' %>
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
-void <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(char *p1, char *p3, ssize_t s1, ssize_t s3, uint64_t n, dtype sv, int scalar_is_left);
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int scalar_is_left);
 <% end %>
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char    *p1, *p2, *p3;
-    ssize_t s1, s2, s3;
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
     <% if type_name == 'robject' %>
     {
+        size_t  i;
+        char    *p1, *p2, *p3;
+        ssize_t s1, s2, s3;
         dtype x, y;
+
+        CUMO_INIT_COUNTER(lp, i);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         for (; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
@@ -25,7 +26,14 @@ static void
         }
     }
     <% else %>
-    <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,p3,s1,s2,s3,i);
+    {
+        cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+        cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
+        cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[2]);
+        cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+        <%="cumo_#{c_iter}_kernel_launch"%>(&a1,&a2,&a3,&indexer);
+    }
     <% end %>
 }
 
@@ -36,29 +44,23 @@ static void
 static void
 <%=c_iter%>_s(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char    *p1, *p3;
-    ssize_t s1, s3;
     dtype sv = *(dtype*)(lp->opt_ptr);
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p3, s3);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(p1,p3,s1,s3,i,sv,0);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,&a3,&indexer,sv,0);
 }
 
 static void
 <%=c_iter%>_s_left(cumo_na_loop_t *const lp)
 {
-    size_t  i;
-    char    *p1, *p3;
-    ssize_t s1, s3;
     dtype sv = *(dtype*)(lp->opt_ptr);
-    CUMO_INIT_COUNTER(lp, i);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p3, s3);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(p1,p3,s1,s3,i,sv,1);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,&a3,&indexer,sv,1);
 }
 <% end %>
 
@@ -74,8 +76,11 @@ static VALUE
 {
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cT,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    <% if type_name == 'robject' %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP, 2, 1, ain, aout };
-    //<% if type_name != 'robject' %>
+    <% else %>
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+
     {
         cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
         int n1 = RTEST(rb_obj_is_kind_of(a1, rb_cNumeric));
@@ -83,16 +88,17 @@ static VALUE
 
         if (!n1 && n2) {
             dtype sv = m_num_to_data(a2);
-            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP, 1, 1, ain_s, aout };
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
             return cumo_na_ndloop3(&ndf_s, &sv, 1, a1);
         }
         if (n1 && !n2) {
             dtype sv = m_num_to_data(a1);
-            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP, 1, 1, ain_s, aout };
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
             return cumo_na_ndloop3(&ndf_s, &sv, 1, a2);
         }
     }
-    //<% end %>
+    <% end %>
+
     return cumo_na_ndloop(&ndf, 2, a1, a2);
 }
 

--- a/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_s_kernel.cu
@@ -1,39 +1,53 @@
 <% unless type_name == 'robject' %>
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
 // A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
 // which would cost a whole kernel launch of its own to fill. Either side of a
 // module function can be the numeric one, so use_scalar says which side sv is
 // on. It is the same for every thread, so the branch costs nothing.
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n, dtype sv, int use_scalar)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1+(i*s1));
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         dtype y;
         switch (use_scalar) {
         case 1:  y = sv; break;
         case 2:  y = x; x = sv; break;
-        default: y = *(dtype*)(p2+(i*s2));
+        default: y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
         }
-        *(dtype*)(p3+(i*s3)) = m_<%=name%>(x,y);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer) = m_<%=name%>(x,y);
     }
 }
+<% end %>
 
-static void <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n, dtype sv, int use_scalar)
+static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n,sv,use_scalar);
+    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
+    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
     dtype sv;
     memset(&sv, 0, sizeof(dtype));
-    <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(p1,p2,p3,s1,s2,s3,n,sv,0);
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
 }
 
-void <%="cumo_#{c_iter}_s_stride_kernel_launch"%>(char *p1, char *p3, ssize_t s1, ssize_t s3, uint64_t n, dtype sv, int scalar_is_left)
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int scalar_is_left)
 {
-    <%="cumo_#{c_iter}_stride_kernel_dispatch"%>(p1,NULL,p3,s1,0,s3,n,sv,scalar_is_left ? 2 : 1);
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,scalar_is_left ? 2 : 1);
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4638,6 +4638,52 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(Cumo::NArray::CastError) { Cumo::DFloat::Math.atan2("x", Cumo::DFloat[1.0]) }
   end
 
+  test "NMath binary functions on views that ndloop cannot flatten" do
+    # same shape of view the unary tests use: before the indexer loop each of
+    # these ran one kernel per row of the view
+    rows = 40
+    cols = 12
+    xs = Array.new(rows * cols) { |i| ((i % 9) - 4).to_f }
+    a = Cumo::DFloat.cast(xs).reshape(rows, cols)
+    grid = (0...rows).map { |r| xs[r * cols, cols] }
+    idx = Array.new(rows) { |i| ((i * 7) + 3) % rows }
+
+    views = [
+      [:flat, ->(m) { m }, grid],
+      [:colslice, ->(m) { m[true, 2...(cols - 1)] }, grid.map { |row| row[2...(cols - 1)] }],
+      [:transpose, :transpose.to_proc, grid.transpose],
+      [:idxview, ->(m) { m[idx, true] }, idx.map { |i| grid[i] }]
+    ]
+
+    fm = Cumo::DFloat::Math
+    views.each do |label, slice, want|
+      v = slice.call(a)
+      spread = Cumo::DFloat.new(*v.shape).fill(1.5)
+      # the scalar operand reads the same elements the array one does
+      assert_equal(fm.atan2(v, spread).to_a, fm.atan2(v, 1.5).to_a, "atan2 #{label}, numeric right")
+      assert_equal(fm.atan2(spread, v).to_a, fm.atan2(1.5, v).to_a, "atan2 #{label}, numeric left")
+      assert_equal(fm.hypot(spread, v).to_a, fm.hypot(1.5, v).to_a, "hypot #{label}, numeric left")
+
+      got = fm.atan2(v, 1.5).to_a
+      back = fm.atan2(1.5, v).to_a
+      hyp = fm.hypot(v, 1.5).to_a
+      want.each_with_index do |row, r|
+        row.each_with_index do |x, c|
+          assert_in_delta(Math.atan2(x, 1.5), got[r][c], 1e-12, "atan2 #{label} #{r},#{c}")
+          assert_in_delta(Math.atan2(1.5, x), back[r][c], 1e-12, "atan2 reversed #{label} #{r},#{c}")
+          assert_in_delta(Math.hypot(x, 1.5), hyp[r][c], 1e-12, "hypot #{label} #{r},#{c}")
+        end
+      end
+    end
+
+    # a 9-d shape runs past the dimension-specialised kernels
+    ys = Array.new(512) { |i| ((i % 7) - 3).to_f }
+    b = Cumo::DFloat.cast(ys).reshape(*([2] * 9))
+    got = fm.atan2(b, 1.5).to_a.flatten
+    ys.each_with_index { |x, i| assert_in_delta(Math.atan2(x, 1.5), got[i], 1e-12, "atan2 9-d #{i}") }
+    assert_equal(fm.atan2(b, Cumo::DFloat.new(*([2] * 9)).fill(1.5)).to_a.flatten, got, "atan2 9-d, numeric right")
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `binary_s.c` was the last elementwise template still on the plain stride loop: `unary_s.c` moved to `CUMO_NDF_INDEXER_LOOP` but its two-operand sibling did not. Without that flag ndloop hands a non-contiguous operand to the iterator one row at a time, so a view costs one kernel launch per row.
- `Cumo::DFloat::Math.atan2(a.transpose, 1.5)` launched **256 kernels** for a 256x256 view and now launches 1.
- 1024x1024 DFloat, minimum of 3 alternating passes: transposed `atan2(v, 1.5)` **2.06 → 0.19 ms**, `atan2(v, w)` 2.18 → 0.19 ms, `atan2(1.5, v)` 2.03 → 0.19 ms, an index-backed view 0.60 → 0.19 ms. Contiguous and single-stride operands are unchanged to three digits, and so are the 1024-element scalar calls of #291.
- The cheaper functions gain most, since the launch was the whole cost: transposed `ldexp` 1.74 → 0.03 ms, SFloat `atan2` 1.35 → 0.03 ms.
- 282 combinations of operand type, side, view shape and dtype answer bit for bit what they answered before. `cumo.so` grows 0.61% for the dimension-specialised kernels.

## Problem

`Cumo::NMath.exp(a.transpose)` costs the same as `exp(a)`, because `unary_s` was converted, but `atan2(a.transpose, 1.5)` cost 11 times its contiguous form. The new test is the two-operand counterpart of "unary operations on views that ndloop cannot flatten"; making the kernel read element 0 instead of the indexed one fails it on the second assertion.
