### PR TITLE
Fix a negative seq start collapsing to zero on the unsigned types

### DIFF
--- a/ext/cumo/narray/gen/tmpl/seq_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/seq_kernel.cu
@@ -16,7 +16,11 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = f_seq(beg,step,c+i);
+        // f_seq answers a double for the integer types, and the device
+        // saturates an out-of-range double where fill and cast wrap, so a
+        // negative start collapsed to zero. A signed 64-bit step in between
+        // keeps seq answering what they answer.
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = <% if is_int %>(dtype)(int64_t)<% end %>f_seq(beg,step,c+i);
     }
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4733,6 +4733,39 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([0, 0, 9, 64], (Cumo::UInt8[1, 2, 3, 4]**Cumo::Int32[-2, -1, 2, 3]).to_a)
   end
 
+  test "seq wraps an out-of-range start the way fill and cast do" do
+    # f_seq answers a double for the integer types, and the device saturates an
+    # out-of-range double, so a negative start collapsed to zero.
+    assert_equal([254, 255, 0, 1], Cumo::UInt8.new(4).seq(-2).to_a)
+    assert_equal([65534, 65535, 0, 1], Cumo::UInt16.new(4).seq(-2).to_a)
+    assert_equal([4294967294, 4294967295, 0, 1], Cumo::UInt32.new(4).seq(-2).to_a)
+    assert_equal([18446744073709551614, 18446744073709551615, 0, 1], Cumo::UInt64.new(4).seq(-2).to_a)
+    assert_equal([56, 57, 58], Cumo::UInt8.new(3).seq(-200).to_a)
+    # a negative step walks the same way
+    assert_equal([0, 255, 254, 253], Cumo::UInt8.new(4).seq(0, -1).to_a)
+
+    # every start seq accepts answers what fill and cast answer for it
+    [Cumo::UInt8, Cumo::UInt16, Cumo::UInt32, Cumo::UInt64,
+     Cumo::Int8, Cumo::Int16, Cumo::Int32, Cumo::Int64].each do |dtype|
+      [-2, -1, 0, 1, 3].each do |beg|
+        assert_equal(dtype.new(1).fill(beg).to_a, dtype.new(1).seq(beg).to_a, "#{dtype} seq(#{beg})")
+        assert_equal(dtype.cast(beg).to_a, dtype.new(1).seq(beg).to_a, "#{dtype} seq(#{beg}) vs cast")
+      end
+    end
+
+    # a view and a 9-d shape run the other dimension-specialised kernels
+    assert_equal([254, 0], Cumo::UInt8.new(2, 2).seq(-2)[true, 0].to_a)
+    assert_equal([254, 255, 0, 1], Cumo::UInt8.new(*([2] * 9)).seq(-2).to_a.flatten.first(4))
+
+    # the signed types and the positive overflows are unchanged
+    assert_equal([-56, -55, -54], Cumo::Int8.new(3).seq(200).to_a)
+    assert_equal([44, 45, 46], Cumo::UInt8.new(3).seq(300).to_a)
+    assert_equal([25536, 25537, 25538], Cumo::Int16.new(3).seq(-40000).to_a)
+    # the floats never go through the integer conversion
+    assert_equal([-2.5, -1.5, -0.5], Cumo::DFloat.new(3).seq(-2.5).to_a)
+    assert_equal([-2.5, -1.5, -0.5], Cumo::SFloat.new(3).seq(-2.5).to_a)
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `Cumo::UInt8.new(4).seq(-2)` answered `[0, 0, 0, 1]`. `fill(-2)` and `cast(-2)` both answer 254 for the same start, and so does numo's `seq`: `[254, 255, 0, 1]`. UInt8, UInt16, UInt32 and UInt64 were all affected.
- `f_seq` answers a `double` for the integer types, and the device saturates an out-of-range double where every other integer conversion in the library wraps. A signed 64-bit value in between restores the wrap.
- Every start that fits in a signed 64-bit integer now answers what `fill` and `cast` answer for it, over all eight integer types, and 45 combinations of dtype and start match numo where they disagreed on 8 before.
- The float types never reach the conversion, and `seq` is as fast as it was: 16 MiB Int32, minimum of five runs over three alternating passes, 71.9 → 72.5 us.

## Problem

`seq` is the only way an out-of-range value reaches an integer element at all: `fill` and `cast` raise `RangeError` first. So `Cumo::UInt8.new(5).seq(-2)` silently answered `[0, 0, 0, 1, 2]`, collapsing two distinct starts onto the same element, while every other route to the same value wrapped.

## Note

Starts outside the signed 64-bit range are still unspecified, and two of them move: `Cumo::Int32.new(3).seq(3e9)` answered `2147483647` and now answers `-1294967296`, and `seq(-3e9)` answered `-2147483648` and now answers `1294967296`. Both were, and remain, undefined behaviour in C; the new answers at least wrap the way the in-range ones do rather than collapsing distinct starts onto one value. `Int64` and `UInt64` starts past 2**63 still saturate.
