### PR TITLE
Fix a UInt64 seq start past 2**63 clamping to INT64_MAX

### DIFF
--- a/ext/cumo/narray/gen/tmpl/seq_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/seq_kernel.cu
@@ -16,11 +16,19 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+<% if type_name == 'uint64' %>
+        // UInt64 is the one type the signed 64-bit step cannot carry on its
+        // own: it wraps a negative start the way fill and cast do, but clamps
+        // everything from 2**63 up, which UInt64 holds exactly.
+        seq_data_t v = f_seq(beg,step,c+i);
+        *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = v < 0 ? (dtype)(int64_t)v : (dtype)v;
+<% else %>
         // f_seq answers a double for the integer types, and the device
         // saturates an out-of-range double where fill and cast wrap, so a
         // negative start collapsed to zero. A signed 64-bit step in between
         // keeps seq answering what they answer.
         *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer) = <% if is_int %>(dtype)(int64_t)<% end %>f_seq(beg,step,c+i);
+<% end %>
     }
 }
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4753,6 +4753,15 @@ class NArrayTest < Test::Unit::TestCase
       end
     end
 
+    # UInt64 holds everything from 2**63 up exactly, and fill and cast answer
+    # those starts exactly, so seq has to as well
+    [2**63, 2**63 + 2**53, 2**64 - 2048].each do |beg|
+      assert_equal(Cumo::UInt64.new(1).fill(beg).to_a, Cumo::UInt64.new(1).seq(beg).to_a,
+                   "UInt64 seq(#{beg})")
+      assert_equal(Cumo::UInt64.cast(beg).to_a, Cumo::UInt64.new(1).seq(beg).to_a,
+                   "UInt64 seq(#{beg}) vs cast")
+    end
+
     # a view and a 9-d shape run the other dimension-specialised kernels
     assert_equal([254, 0], Cumo::UInt8.new(2, 2).seq(-2)[true, 0].to_a)
     assert_equal([254, 255, 0, 1], Cumo::UInt8.new(*([2] * 9)).seq(-2).to_a.flatten.first(4))


### PR DESCRIPTION
## Summary

- #294 widened every integer `seq` start through a signed 64-bit value. That fixed the negative starts but clamps everything from 2**63 up, which UInt64 holds exactly: `Cumo::UInt64.new(1).seq(2**63)` answers 9223372036854775807 where `fill(2**63)` and `cast(2**63)` both answer 9223372036854775808. That is the invariant #294 set out to establish, so this restores it.
- UInt64 is the only type that needs both halves — a negative start only survives the signed step, and 2**63 and up only survive unsigned. Every other integer type keeps the single conversion #294 added.
- 45 starts across the eight integer types and 9 wide starts now match numo exactly, `[2**63, 2**64)` included.
- The select costs UInt64 about 40 us per 16 MiB (72 → 111 us, minimum of five over three alternating passes). Every other dtype is unchanged, Int32 included at 72.6 us either way. Hoisting the decision out of the loop was measured too and came out worse, at 219 us.

## Problem

`seq` is the only way a value out of an integer element's range reaches it — `fill` and `cast` raise `RangeError` first — so it is the one place the three have to be checked against each other. #294 checked them for the negative starts and missed the top half of UInt64, where `fill` and `cast` answer exactly and `seq` no longer did. The added assertions fail on #294 as merged.
