### PR TITLE
Pass a numeric on the left of an operator to the kernel instead of a 0-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 def_id "cast"
+def_id "_pending_scalar", "pending_scalar"
 def_id "mulsum"
 def_id "to_a"
 if is_complex

--- a/ext/cumo/narray/gen/tmpl/allocate.c
+++ b/ext/cumo/narray/gen/tmpl/allocate.c
@@ -1,3 +1,7 @@
+<% if !is_object && !is_bit %>
+void cumo_<%=type_name%>_new_dim0_kernel_launch(dtype *ptr, dtype x);
+<% end %>
+
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
@@ -33,6 +37,21 @@ static VALUE
             rb_gc_adjust_memory_usage(sizeof(dtype) * na->size);
             <% end %>
         }
+        <% if !is_object && !is_bit %>
+        // A scalar cast lazily kept its value on the Ruby side; giving it
+        // memory is where it reaches the device.
+        {
+            VALUE num = rb_attr_get(self, cumo_id_pending_scalar);
+            if (!NIL_P(num)) {
+                rb_ivar_set(self, cumo_id_pending_scalar, Qnil);
+                cumo_<%=type_name%>_new_dim0_kernel_launch((dtype*)CUMO_NA_DATA_PTR(na), m_num_to_data(num));
+                // Callers that read on the host synchronize before they ask for
+                // the pointer, which is before this fill was even launched.
+                CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("allocate", "<%=type_name%>");
+                cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            }
+        }
+        <% end %>
         break;
     case CUMO_NARRAY_VIEW_T:
         rb_funcall(CUMO_NA_VIEW_DATA(na), rb_intern("allocate"), 0);

--- a/ext/cumo/narray/gen/tmpl/binary.c
+++ b/ext/cumo/narray/gen/tmpl/binary.c
@@ -11,7 +11,7 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
 //<% if %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero, int scalar_is_left);
 //<% end %>
 <% end %>
 
@@ -134,6 +134,27 @@ static void
 //<% if !is_object and %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
 // The operand is a Ruby numeric, so it rides in through opt_ptr instead of
 // being cast to a 0-dimensional array, which costs a kernel launch to fill.
+// A numeric on the left arrives the same way, by way of coerce.
+static void
+<%=c_iter%>_s_left(cumo_na_loop_t *const lp)
+{
+    dtype x = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    //<% if is_int and %w[div mod].include? name %>
+    int *divzero = cumo_cuda_runtime_error_flag_new();
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,x,&a3,&indexer,divzero,1);
+    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
+    if (cumo_cuda_runtime_error_flag_get(divzero)) {
+        lp->err_type = rb_eZeroDivError;
+    }
+    //<% else %>
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,x,&a3,&indexer,0,1);
+    //<% end %>
+}
+
 static void
 <%=c_iter%>_s(cumo_na_loop_t *const lp)
 {
@@ -144,13 +165,13 @@ static void
 
     //<% if is_int and %w[div mod].include? name %>
     int *divzero = cumo_cuda_runtime_error_flag_new();
-    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,divzero);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,divzero,0);
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
     if (cumo_cuda_runtime_error_flag_get(divzero)) {
         lp->err_type = rb_eZeroDivError;
     }
     //<% else %>
-    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,0);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,y,&a3,&indexer,0,0);
     //<% end %>
 }
 //<% end %>
@@ -160,6 +181,25 @@ static VALUE
 <%=c_func%>_self(VALUE self, VALUE other)
 {
     //<% if !is_object and %w[add sub mul div mod bit_and bit_or bit_xor left_shift right_shift copysign].include?(name) %>
+    {
+        // coerce hands a numeric on the left over as a 0-dimensional array that
+        // has not reached the device yet, so its value is still here to be read.
+        // Only such an operand carries it, and looking for it on every array is
+        // more than the lookup is worth.
+        cumo_narray_t *na_self;
+        VALUE num = Qnil;
+        CumoGetNArray(self, na_self);
+        if (CUMO_NA_NDIM(na_self) == 0) {
+            num = rb_attr_get(self, cumo_id_pending_scalar);
+        }
+        if (!NIL_P(num) && CumoIsNArray(other)) {
+            dtype x = m_num_to_data(num);
+            cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+            cumo_ndfunc_arg_out_t aout_s[1] = {{cT,0}};
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout_s };
+            return cumo_na_ndloop3(&ndf_s, &x, 1, other);
+        }
+    }
     if (rb_obj_is_kind_of(other, rb_cNumeric)) {
         dtype y = m_num_to_data(other);
         cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};

--- a/ext/cumo/narray/gen/tmpl/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/binary_kernel.cu
@@ -14,7 +14,8 @@
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
 //<% if has_scalar %>
 // A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
-// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// which would cost a whole kernel launch of its own to fill. It reaches the
+// left side through coerce, so use_scalar says which side it is on. It is the
 // same for every thread, so the branch costs nothing.
 __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int* divzero, dtype sv, int use_scalar)
 {
@@ -22,9 +23,14 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
-        dtype y = use_scalar ? sv : *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        dtype x, y;
+        switch (use_scalar) {
+        case 1:  x = *(dtype*)(p1); y = sv; break;
+        case 2:  x = sv; y = *(dtype*)(p1); break;
+        default: x = *(dtype*)(p1); y = *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        }
         cumo_check_intdivzero(y);
-        *(dtype*)(p3) = m_<%=name%>(*(dtype*)(p1),y);
+        *(dtype*)(p3) = m_<%=name%>(x,y);
     }
 }
 //<% else %>
@@ -67,11 +73,11 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
     <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,divzero,sv,0);
 }
 
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero, int scalar_is_left)
 {
     cumo_na_iarray_t a2;
     memset(&a2, 0, sizeof(cumo_na_iarray_t));
-    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&a2,a3,indexer,divzero,sv,1);
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&a2,a3,indexer,divzero,sv,scalar_is_left ? 2 : 1);
 }
 //<% else %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int* divzero)

--- a/ext/cumo/narray/gen/tmpl/cast.c
+++ b/ext/cumo/narray/gen/tmpl/cast.c
@@ -15,14 +15,20 @@ static VALUE
 {
     VALUE v;
     cumo_narray_t *na;
+    //<% if is_object || is_bit %>
     dtype x;
+    //<% end %>
 
     if (rb_obj_class(obj)==cT) {
         return obj;
     }
     if (RTEST(rb_obj_is_kind_of(obj,rb_cNumeric))) {
+        //<% if is_object || is_bit %>
         x = m_num_to_data(obj);
         return <%=type_name%>_new_dim0(x);
+        //<% else %>
+        return <%=type_name%>_new_dim0_lazy(obj);
+        //<% end %>
     }
     if (RTEST(rb_obj_is_kind_of(obj,rb_cArray))) {
         return <%=find_tmpl("cast_array").c_func%>(obj);

--- a/ext/cumo/narray/gen/tmpl/cond_binary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_binary.c
@@ -1,6 +1,6 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer);
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer, int scalar_is_left);
 <% end %>
 
 static void
@@ -43,7 +43,8 @@ static void
 
 <% unless type_name == 'robject' %>
 // A Ruby numeric operand rides in through opt_ptr instead of being cast to a
-// 0-dimensional array, which costs a kernel launch to fill.
+// 0-dimensional array, which costs a kernel launch to fill. A numeric on the
+// left arrives the same way, by way of coerce.
 static void
 <%=c_iter%>_s(cumo_na_loop_t *const lp)
 {
@@ -52,7 +53,18 @@ static void
     cumo_na_bit_iarray_t a3 = cumo_na_make_bit_iarray(&lp->args[1]);
     cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer,0);
+}
+
+static void
+<%=c_iter%>_s_left(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_bit_iarray_t a3 = cumo_na_make_bit_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer,1);
 }
 <% end %>
 
@@ -66,6 +78,24 @@ static VALUE
     <% else %>
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
 
+    {
+        // coerce hands a numeric on the left over as a 0-dimensional array that
+        // has not reached the device yet, so its value is still here to be read.
+        // Only such an operand carries it, and looking for it on every array is
+        // more than the lookup is worth.
+        cumo_narray_t *na_self;
+        VALUE num = Qnil;
+        CumoGetNArray(self, na_self);
+        if (CUMO_NA_NDIM(na_self) == 0) {
+            num = rb_attr_get(self, cumo_id_pending_scalar);
+        }
+        if (!NIL_P(num) && CumoIsNArray(other)) {
+            dtype sv = m_num_to_data(num);
+            cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+            cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+            return cumo_na_ndloop3(&ndf_s, &sv, 1, other);
+        }
+    }
     if (rb_obj_is_kind_of(other, rb_cNumeric)) {
         dtype sv = m_num_to_data(other);
         cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};

--- a/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
@@ -1,14 +1,20 @@
 <% unless type_name == 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
 // A Ruby numeric operand rides in as sv rather than as a 0-dimensional array,
-// which would cost a whole kernel launch of its own to fill. use_scalar is the
+// which would cost a whole kernel launch of its own to fill. It reaches the
+// left side through coerce, so use_scalar says which side it is on. It is the
 // same for every thread, so the branch costs nothing.
 __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype y = use_scalar ? sv : *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        dtype v = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+        dtype x, y;
+        switch (use_scalar) {
+        case 1:  x = v; y = sv; break;
+        case 2:  x = sv; y = v; break;
+        default: x = v; y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+        }
         CUMO_BIT_DIGIT b = (m_<%=name%>(x,y)) ? 1:0;
         CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a3, &indexer), b);
     }
@@ -39,10 +45,10 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
     <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
 }
 
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer)
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer, int scalar_is_left)
 {
     cumo_na_iarray_t unused;
     memset(&unused, 0, sizeof(cumo_na_iarray_t));
-    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,scalar_is_left ? 2 : 1);
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/new_dim0.c
+++ b/ext/cumo/narray/gen/tmpl/new_dim0.c
@@ -2,6 +2,23 @@
 void <%="cumo_#{c_func(:nodef)}_kernel_launch"%>(dtype *ptr, dtype x);
 <% end %>
 
+<% if !is_object && !is_bit %>
+// The value stays a Ruby numeric until something reads the array, because
+// filling one element on the device costs a whole kernel launch. An operand
+// cast this way is usually consumed by the very next operator, which takes the
+// value from here instead and never makes it reach the device at all.
+static VALUE
+<%=c_func(:nodef)%>_lazy(VALUE num)
+{
+    VALUE v;
+
+    m_num_to_data(num); // raises for a value the element cannot hold, as filling it did
+    v = cumo_na_new(cT, 0, NULL);
+    rb_ivar_set(v, cumo_id_pending_scalar, num);
+    return v;
+}
+<% end %>
+
 static VALUE
 <%=c_func(:nodef)%>(dtype x)
 {

--- a/ext/cumo/narray/gen/tmpl/pow.c
+++ b/ext/cumo/narray/gen/tmpl/pow.c
@@ -1,7 +1,8 @@
 <% unless type_name == 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int scalar_is_left);
+void <%="cumo_#{c_iter}_int32_s_left_kernel_launch"%>(dtype sv_base, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 void <%="cumo_#{c_iter}_int32_s_kernel_launch"%>(cumo_na_iarray_t* a1, int32_t sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer);
 <% end %>
 
@@ -86,7 +87,30 @@ static void
     cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
     cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer);
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer,0);
+}
+
+// The base is the numeric one when it came in through coerce.
+static void
+<%=c_iter%>_s_left(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_s_kernel_launch"%>(&a1,sv,&a3,&indexer,1);
+}
+
+static void
+<%=c_iter%>_int32_s_left(cumo_na_loop_t *const lp)
+{
+    dtype sv = *(dtype*)(lp->opt_ptr);
+    cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[0]);
+    cumo_na_iarray_t a3 = cumo_na_make_iarray(&lp->args[1]);
+    cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
+
+    <%="cumo_#{c_iter}_int32_s_left_kernel_launch"%>(sv,&a2,&a3,&indexer);
 }
 
 static void
@@ -118,7 +142,29 @@ static VALUE
     //<% if type_name != 'robject' %>
     {
         cumo_ndfunc_arg_in_t ain_s[1] = {{cT,0}};
+        cumo_ndfunc_arg_in_t ain_i_s[1] = {{cumo_cInt32,0}};
+        // coerce hands a numeric base over as a 0-dimensional array that has
+        // not reached the device yet, so its value is still here to be read.
+        // Only such an operand carries it, and looking for it on every array is
+        // more than the lookup is worth.
+        cumo_narray_t *na_self;
+        VALUE num = Qnil;
+        CumoGetNArray(self, na_self);
+        if (CUMO_NA_NDIM(na_self) == 0) {
+            num = rb_attr_get(self, cumo_id_pending_scalar);
+        }
 
+        if (!NIL_P(num) && CumoIsNArray(other)) {
+            dtype sv = m_num_to_data(num);
+            if (rb_obj_is_kind_of(other, cumo_cInt32)) {
+                cumo_ndfunc_t ndf_i_s = { <%=c_iter%>_int32_s_left, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_i_s, aout };
+                return cumo_na_ndloop3(&ndf_i_s, &sv, 1, other);
+            }
+            {
+                cumo_ndfunc_t ndf_s = { <%=c_iter%>_s_left, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };
+                return cumo_na_ndloop3(&ndf_s, &sv, 1, other);
+            }
+        }
         if (FIXNUM_P(other)) {
             int32_t sv = NUM2INT32(other);
             cumo_ndfunc_t ndf_i_s = { <%=c_iter%>_int32_s, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 1, 1, ain_s, aout };

--- a/ext/cumo/narray/gen/tmpl/pow_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/pow_kernel.cu
@@ -9,19 +9,25 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
-        dtype y = use_scalar ? sv : *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
-        *(dtype*)(p3) = m_pow(*(dtype*)(p1), y);
+        dtype v = *(dtype*)(p1);
+        dtype x, y;
+        switch (use_scalar) {
+        case 1:  x = v; y = sv; break;
+        case 2:  x = sv; y = v; break;
+        default: x = v; y = *(dtype*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        }
+        *(dtype*)(p3) = m_pow(x, y);
     }
 }
 
-__global__ void <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int32_t sv, int use_scalar)
+__global__ void <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_iarray_t a3, cumo_na_indexer_t indexer, int32_t sv, int use_scalar, dtype sv_base)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
         cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
         char* p1 = cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
         char* p3 = cumo_na_iarray_at_dim<%=idim%>(&a3, &indexer);
-        int32_t y = use_scalar ? sv : *(int32_t*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
-        *(dtype*)(p3) = m_pow_int(*(dtype*)(p1), y);
+        int32_t y = use_scalar == 1 ? sv : *(int32_t*)(cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer));
+        *(dtype*)(p3) = use_scalar == 2 ? m_pow_int(sv_base, y) : m_pow_int(*(dtype*)(p1), y);
     }
 }
 <% end %>
@@ -50,25 +56,25 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t*
     <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,a2,a3,indexer,sv,0);
 }
 
-void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+void <%="cumo_#{c_iter}_s_kernel_launch"%>(cumo_na_iarray_t* a1, dtype sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int scalar_is_left)
 {
     cumo_na_iarray_t unused;
     memset(&unused, 0, sizeof(cumo_na_iarray_t));
-    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
+    <%="cumo_#{c_iter}_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,scalar_is_left ? 2 : 1);
 }
 
-static void <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int32_t sv, int use_scalar)
+static void <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer, int32_t sv, int use_scalar, dtype sv_base)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        <%="cumo_#{c_iter}_int32_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar,sv_base);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_int32_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        <%="cumo_#{c_iter}_int32_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar,sv_base);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();
@@ -76,13 +82,26 @@ static void <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(cumo_na_iarray_t* a1, cu
 
 void <%="cumo_#{c_iter}_int32_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
-    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,a2,a3,indexer,0,0);
+    dtype sv_base;
+    memset(&sv_base, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,a2,a3,indexer,0,0,sv_base);
 }
 
 void <%="cumo_#{c_iter}_int32_s_kernel_launch"%>(cumo_na_iarray_t* a1, int32_t sv, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
 {
     cumo_na_iarray_t unused;
+    dtype sv_base;
     memset(&unused, 0, sizeof(cumo_na_iarray_t));
-    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1);
+    memset(&sv_base, 0, sizeof(dtype));
+    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(a1,&unused,a3,indexer,sv,1,sv_base);
+}
+
+// The base is the numeric one when it came in through coerce, and the exponent
+// is the Int32 array.
+void <%="cumo_#{c_iter}_int32_s_left_kernel_launch"%>(dtype sv_base, cumo_na_iarray_t* a2, cumo_na_iarray_t* a3, cumo_na_indexer_t* indexer)
+{
+    cumo_na_iarray_t unused;
+    memset(&unused, 0, sizeof(cumo_na_iarray_t));
+    <%="cumo_#{c_iter}_int32_kernel_dispatch"%>(&unused,a2,a3,indexer,0,2,sv_base);
 }
 <% end %>

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -24,6 +24,7 @@ static ID cumo_id_logseq;
 static ID cumo_id_eye;
 static ID cumo_id_UPCAST;
 static ID cumo_id_cast;
+static ID cumo_id_pending_scalar;
 static ID cumo_id_dup;
 static ID cumo_id_to_host;
 static ID cumo_id_bracket;
@@ -726,10 +727,12 @@ cumo_na_get_pointer_for_rw(VALUE self, int flag)
         }
         ptr = CUMO_NA_DATA_PTR(na);
         if (CUMO_NA_SIZE(na) > 0 && ptr == NULL) {
-            if (flag & READ) {
+            // A scalar cast lazily holds its value on the Ruby side, so it can
+            // still be read: allocating it is what puts the value on the device.
+            if ((flag & READ) && NIL_P(rb_attr_get(self, cumo_id_pending_scalar))) {
                 rb_raise(rb_eRuntimeError,"cannot read unallocated NArray");
             }
-            if (flag & WRITE) {
+            if (flag & (READ|WRITE)) {
                 rb_funcall(self, cumo_id_allocate, 0);
                 ptr = CUMO_NA_DATA_PTR(na);
             }
@@ -749,7 +752,11 @@ cumo_na_get_pointer_for_rw(VALUE self, int flag)
             ptr = CUMO_NA_DATA_PTR(na);
             if (flag & (READ|WRITE)) {
                 if (CUMO_NA_SIZE(na) > 0 && ptr == NULL) {
-                    rb_raise(rb_eRuntimeError,"cannot read/write unallocated NArray");
+                    if (NIL_P(rb_attr_get(obj, cumo_id_pending_scalar))) {
+                        rb_raise(rb_eRuntimeError,"cannot read/write unallocated NArray");
+                    }
+                    rb_funcall(obj, cumo_id_allocate, 0);
+                    ptr = CUMO_NA_DATA_PTR(na);
                 }
             }
             return ptr;
@@ -2191,6 +2198,7 @@ Init_cumo_narray()
     cumo_id_eye             = rb_intern("eye");
     cumo_id_UPCAST          = rb_intern("UPCAST");
     cumo_id_cast            = rb_intern("cast");
+    cumo_id_pending_scalar  = rb_intern("_pending_scalar");
     cumo_id_dup             = rb_intern("dup");
     cumo_id_to_host         = rb_intern("to_host");
     cumo_id_bracket         = rb_intern("[]");

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4775,6 +4775,93 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([-2.5, -1.5, -0.5], Cumo::SFloat.new(3).seq(-2.5).to_a)
   end
 
+  test "a numeric on the left of an operator allocates only its result" do
+    # coerce cast the numeric to a 0-dimensional array, which took a whole
+    # kernel launch to fill. Measured in a child, or blocks another test left
+    # in the pool serve the allocation and total_bytes does not move.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::SFloat.new(256).seq
+      keep = []
+      100.times { keep << 0.5 * a }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      keep.clear
+      GC.start
+      pool.free_all_blocks
+      before = pool.total_bytes
+      keep = []
+      100.times { keep << 0.5 * a }
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      print pool.total_bytes - before
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    # 100 results of 1 KiB each. The 0-dimensional operand coerce built would
+    # add another 100 of the pool's 512 byte bins.
+    assert_operator(Integer(out), :<, 100 * (1024 + 512))
+  end
+
+  test "a numeric on the left answers what the same value as an array answers" do
+    [Cumo::SFloat, Cumo::DFloat, Cumo::Int32, Cumo::Int64].each do |dtype|
+      a = dtype[1, 2, 3, 4]
+      spread = dtype.new(4).fill(2)
+      assert_equal((spread + a).to_a, (2 + a).to_a, "#{dtype} 2 + a")
+      assert_equal((spread - a).to_a, (2 - a).to_a, "#{dtype} 2 - a")
+      assert_equal((spread * a).to_a, (2 * a).to_a, "#{dtype} 2 * a")
+      assert_equal((spread / a).to_a, (2 / a).to_a, "#{dtype} 2 / a")
+      assert_equal((spread % a).to_a, (2 % a).to_a, "#{dtype} 2 % a")
+      assert_equal((spread**a).to_a, (2**a).to_a, "#{dtype} 2 ** a")
+      assert_equal((spread < a).to_a, (2 < a).to_a, "#{dtype} 2 < a")
+      assert_equal((spread <= a).to_a, (2 <= a).to_a, "#{dtype} 2 <= a")
+    end
+
+    # the operand order is not commuted: a view, a 9-d shape and an index-backed
+    # view all reach the same elements
+    view = Cumo::SFloat.new(2, 3).seq(1).transpose
+    assert_equal((Cumo::SFloat.new(3, 2).fill(2.0) - view).to_a, (2.0 - view).to_a, "view")
+    idx = Cumo::SFloat.new(6).seq(1)[[3, 1, 2]]
+    assert_equal((Cumo::SFloat.new(3).fill(2.0) - idx).to_a, (2.0 - idx).to_a, "index view")
+    deep = Cumo::SFloat.new(*([2] * 9)).seq(1)
+    assert_equal((Cumo::SFloat.new(*([2] * 9)).fill(2.0) / deep).to_a.flatten,
+                 (2.0 / deep).to_a.flatten, "9-d")
+    assert_equal([], (0.5 * Cumo::SFloat.new(0)).to_a, "empty")
+
+    # dividing by an element that is zero still raises from the left
+    assert_raise(ZeroDivisionError) { 3 / Cumo::Int32[1, 0, 2] }
+    assert_raise(ZeroDivisionError) { 3 % Cumo::Int32[1, 0, 2] }
+    # and an out-of-range numeric still raises where casting it raised
+    assert_raise(RangeError) { 2**40 * Cumo::Int32[1, 2] }
+  end
+
+  test "a numeric cast to a 0-dimensional array still reads back" do
+    # the value stays a Ruby numeric until something asks for the element
+    [Cumo::SFloat, Cumo::DFloat, Cumo::Int32, Cumo::UInt8, Cumo::DComplex].each do |dtype|
+      assert_equal([3], dtype.cast(3).to_a, "#{dtype} cast(3).to_a")
+      assert_equal([3], dtype.cast(3).dup.to_a, "#{dtype} cast(3).dup")
+      assert_equal([3], Marshal.load(Marshal.dump(dtype.cast(3))).to_a, "#{dtype} marshal")
+      assert_equal([9], (dtype.cast(3) * dtype[3]).to_a, "#{dtype} cast * array")
+      assert_equal([6], (dtype.cast(3) + dtype.cast(3)).to_a, "#{dtype} cast + cast")
+      w = dtype.cast(3)
+      w.store(5)
+      assert_equal([5], w.to_a, "#{dtype} cast then store")
+      assert_not_equal("", dtype.cast(3).inspect, "#{dtype} cast.inspect")
+    end
+    assert_equal([1], Cumo::Bit.cast(1).to_a)
+    assert_equal([1.5], Cumo::RObject.cast(1.5).to_a)
+    # the range check still happens where casting it happened
+    assert_raise(RangeError) { Cumo::Int32.cast(2**40) }
+    assert_raise(RangeError) { Cumo::Int32[1, 2].coerce(2**40) }
+    assert_equal([Cumo::SFloat, Cumo::SFloat],
+                 Cumo::SFloat[1, 2].coerce(1.0).map(&:class))
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `0.5 * a` cost twice what `a * 0.5` costs. Ruby routes a numeric on the left through `coerce`, which cast it to a 0-dimensional array, and filling one element on the device is a whole kernel launch. The operator then saw two arrays and could not use the scalar path #287 added.
- `cast` now keeps a numeric on the Ruby side and gives the 0-dimensional array its memory only when something reads the element. `binary.c`, `cond_binary.c` and `pow.c` take the value from there, so an operand that came in through `coerce` never reaches the device at all.
- 256 elements, minimum of five over five alternating passes: `0.5 * a` 4.62 → 2.65 us, `2.0 - a` 4.72 → 2.75, `1.0 / a` 4.75 → 2.76, `1.5 < a` 4.80 → 2.82, `2.0 ** a` 4.70 → 2.83, `3 * i32` 4.70 → 2.83. `a * b` 2.38 → 2.36 and `a * 0.5` 2.37 → 2.37 are unchanged, and nothing moves at 4M elements.
- 499 combinations of dtype, operator and operand answer what they answered before. The left-hand forms match numo over views, a 9-d shape, an index-backed view, `ZeroDivisionError` from the left, and `RangeError` for a numeric the element cannot hold — which is still raised where casting it raised.
- `cumo.so` grows 1.7%. Bit and RObject keep the eager cast.

## Problem

The cost was in `cumo_na_coerce` (`narray.c:1337`), not in the operators. Measured apart, at 256 elements: `a * 0.5` 2.34 us, `0.5 * a` 4.46, `Cumo::SFloat.cast(0.5)` on its own 1.97, `zerodim * a` 2.34, `a * b` 2.39. Handing an already-built 0-dimensional array to the operator is as cheap as any other array, so the whole 2.1 us gap was the cast.

## Note

Reading the element of a lazily cast array synchronizes once. Host readers such as `to_a` synchronize before they ask for the pointer, which is before the fill has even been launched, so the fill has to be waited for where it happens. The operators above never take that path.

The lookup for the held value is gated on the operand being 0-dimensional, since only such an operand can carry one. The gate is not what makes any of this fast: `rb_attr_get` on an NArray that does not carry the ivar measures 1.8 ns over 50 million calls, and gating it is worth -0.02 to -0.05 us at 256 elements, inside the run-to-run spread. It is there because it says what the invariant is, not for the time.

The value is held under the instance variable name `_pending_scalar`. The leading underscore is for whoever reads the C: the name is already unreachable from Ruby, since an id without a leading `@` is not a valid instance variable name, so `instance_variables` omits it, `instance_variable_get` refuses it, `@pending_scalar` is a different id, and `Marshal` never sees it.
