### PR TITLE
Skip the device free for a subscript that allocated no index array

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -919,7 +919,12 @@ cumo_na_aref_md_ensure(VALUE data_value)
     cumo_na_aref_md_data_t *data = (cumo_na_aref_md_data_t*)(data_value);
     int i;
     for (i=0; i<data->ndim; i++) {
-        cumo_cuda_runtime_free((char*)(data->q[i].idx));
+        // Only a subscript that is a list of indices allocates one. The rest
+        // leave it NULL, and handing NULL over still costs a pool lookup and a
+        // driver call for every dimension of every subscript.
+        if (data->q[i].idx) {
+            cumo_cuda_runtime_free((char*)(data->q[i].idx));
+        }
     }
     if (data->q) xfree(data->q);
     return Qnil;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4862,6 +4862,28 @@ class NArrayTest < Test::Unit::TestCase
                  Cumo::SFloat[1, 2].coerce(1.0).map(&:class))
   end
 
+  test "every subscript form still answers after the null free was dropped" do
+    # aref_md handed every dimension to the device free, even the ones whose
+    # subscript is a range or true and never allocated an index array. Freeing
+    # NULL costs a pool lookup and a driver call per dimension per subscript.
+    # There is no Ruby-visible signal for the call itself, so this only pins
+    # that each form of subscript still reaches the elements it should.
+    a = Cumo::SFloat.new(4, 4).seq(1)
+    assert_equal([[1.0, 2.0], [5.0, 6.0]], a[0..1, 0..1].to_a, "range, range")
+    assert_equal(a.to_a, a[true, true].to_a, "true, true")
+    assert_equal([[6.0, 8.0], [14.0, 16.0]], a[[1, 3], [1, 3]].to_a, "index, index")
+    assert_equal([[5.0, 6.0, 7.0, 8.0], [13.0, 14.0, 15.0, 16.0]], a[[1, 3], true].to_a, "index, true")
+    assert_equal([[2.0, 4.0], [10.0, 12.0]], a[[0, 2], [1, 3]].to_a, "index, index again")
+    assert_equal([2.0, 6.0, 10.0, 14.0], a[true, 1].to_a, "true, scalar")
+    assert_equal([[1.0, 3.0], [9.0, 11.0]], a[(0..3).step(2), (0..3).step(2)].to_a, "step, step")
+    assert_equal(6.0, a[1, 1].to_a[0], "scalar, scalar")
+    deep = Cumo::SFloat.new(2, 2, 2, 2).seq(1)
+    assert_equal(deep.to_a, deep[true, true, true, true].to_a, "4-d all true")
+    assert_equal([[2.0, 4.0], [6.0, 8.0]], deep[0, true, true, 1].to_a, "4-d mixed")
+    assert_equal(deep[[1, 0], true, true, true].to_a.flatten.sort,
+                 deep.to_a.flatten.sort, "4-d index on the outer axis")
+  end
+
   test "an integer divided or reduced by a numeric zero still raises" do
     assert_raise(ZeroDivisionError) { Cumo::Int32[1, 2, 3] / 0 }
     assert_raise(ZeroDivisionError) { Cumo::Int32[[1, 2], [3, 4]][true, 0] / 0 }


### PR DESCRIPTION
## Summary

- `cumo_na_aref_md_ensure` handed every dimension of a subscript to `cumo_cuda_runtime_free`, including the dimensions whose subscript is a range, a step, a scalar or `true` — those never allocate an index array and leave the pointer NULL. Freeing NULL still costs a pool lookup and a `cudaFree` call.
- `nsys` counts one `cudaFree` per dimension per subscript, at a median of 124 ns: `a[0..31]` one, `a[true, 0..31]` two, `a[true, true, true, 0..3]` four, and `a[true, true]` two as well. `a[true, 0...32] = b` counts two the same way, since `[]=` reaches the same ensure. After the guard, zero for all of them.
- Minimum of three alternating passes, per subscript: `a[true, 0..31]` 0.363 → **0.205 us**, `a[true, true, true, 0..3]` 0.506 → **0.218 us**, `a[true, true]` 0.335 → **0.179 us**. Indexing is 1.8 to 2.3 times cheaper because the two calls it skips are a large part of what a subscript does.
- The index arrays a subscript does allocate are still freed: 20,000 `a[idx, true]` leave `MemoryPool.used_bytes` where they found it.

## Problem

Found from the other side. A session benchmarking GPT-2 on cumo noticed `cudaFree` at 172 calls per generated token with **zero** `cudaMallocManaged` against it, and a 124 ns median where a real free of a pool chunk measures 1,689 ns here. Frees without allocations and a median that fast both say the pointer was NULL.

The count is one per dimension of every subscript, so it scales with how much a program indexes rather than with how much it allocates.

## Note

There is no Ruby-visible signal for a call that neither allocates nor frees anything, so the added test only pins that each form of subscript still reaches the elements it should. The claim above rests on the `nsys` counts and the timing.
