### PR TITLE
Avoid signed overflow when pow_int negates a negative exponent

### DIFF
--- a/ext/cumo/include/cumo/types/complex_kernel.h
+++ b/ext/cumo/include/cumo/types/complex_kernel.h
@@ -363,7 +363,7 @@ __host__ __device__ static inline dtype c_pow(dtype x, dtype y)
 }
 
 /* only internal use (called by c_pow_int) */
-__host__ __device__ static inline dtype c_pow_positive_int(dtype x, int p)
+__host__ __device__ static inline dtype c_pow_positive_int(dtype x, unsigned int p)
 {
     dtype z = c_one();
     if (p==2) {return c_square(x);}
@@ -377,13 +377,15 @@ __host__ __device__ static inline dtype c_pow_positive_int(dtype x, int p)
     return z;
 }
 
+// The magnitude is taken in unsigned, since -p overflows for INT_MIN and the
+// wrapped negative would shift down to -1 and loop for ever.
 __host__ __device__ static inline dtype c_pow_int(dtype x, int p)
 {
     if (p<0) {
-        x = c_pow_positive_int(x,-p);
+        x = c_pow_positive_int(x,-(unsigned int)p);
         return c_reciprocal(x);
     } else {
-        return c_pow_positive_int(x,p);
+        return c_pow_positive_int(x,(unsigned int)p);
     }
 }
 

--- a/ext/cumo/include/cumo/types/float_macro_kernel.h
+++ b/ext/cumo/include/cumo/types/float_macro_kernel.h
@@ -123,7 +123,7 @@ extern double pow(double, double);
 #define m_frexp(x,exp) frexp(x,exp)
 
 /* only internal use (called by pow_int) */
-__host__ __device__ static inline dtype pow_positive_int(dtype x, int p)
+__host__ __device__ static inline dtype pow_positive_int(dtype x, unsigned int p)
 {
     dtype r=1;
     switch(p) {
@@ -133,7 +133,7 @@ __host__ __device__ static inline dtype pow_positive_int(dtype x, int p)
     case 3: return x*x*x;
     case 4: x=x*x; return x*x;
     }
-    if (p>64) return pow(x,p);
+    if (p>64) return pow(x,(double)p);
     while (p) {
         if (p&1) r *= x;
         x *= x;
@@ -142,10 +142,12 @@ __host__ __device__ static inline dtype pow_positive_int(dtype x, int p)
     return r;
 }
 
+// The magnitude is taken in unsigned, since -p overflows for INT_MIN and the
+// wrapped negative would shift down to -1 and loop for ever.
 __host__ __device__ static inline dtype pow_int(dtype x, int p)
 {
-    if (p<0) return 1/pow_positive_int(x, -p);
-    return pow_positive_int(x, p);
+    if (p<0) return 1/pow_positive_int(x, -(unsigned int)p);
+    return pow_positive_int(x, (unsigned int)p);
 }
 
 __host__ __device__ static inline dtype f_seq(dtype x, dtype y, double c)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4733,6 +4733,59 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([0, 0, 9, 64], (Cumo::UInt8[1, 2, 3, 4]**Cumo::Int32[-2, -1, 2, 3]).to_a)
   end
 
+  test "a float or complex array raised to the INT_MIN power answers instead of spinning" do
+    # -p overflows for INT32_MIN and the wrapped negative shifts down to -1, so
+    # pow_positive_int would never leave its loop. pow_int takes the magnitude
+    # in unsigned now. This runs in a child for the same reason as the unsigned
+    # test above: a spinning kernel only stops for SIGKILL.
+    script = <<~'RUBY'
+      require "cumo/narray"
+      out = [Cumo::SFloat[0.5, 1.0, 2.0]**(-2**31),
+             Cumo::DFloat[0.5, 1.0, 2.0]**(-2**31),
+             Cumo::SFloat[0.5, 1.0, 2.0]**(-2**31 + 1),
+             Cumo::DFloat[0.5, 1.0, 2.0]**(-2**31 + 1)].map { |v| v.to_a.join(",") }
+      # the complex path overflows the same way and only has to finish
+      (Cumo::SComplex[Complex(0.5, 0)]**(-2**31)).to_a
+      (Cumo::DComplex[Complex(0.5, 0)]**(-2**31)).to_a
+      print out.join("|")
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    r, w = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, "-I#{lib}", "-e", script, out: w, err: File::NULL)
+    w.close
+    reader = Thread.new { r.read }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    until Process.waitpid(pid, Process::WNOHANG)
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+        reader.kill
+        flunk("a float power of INT_MIN did not finish in 60 seconds")
+      end
+      sleep 0.05
+    end
+    # 0.5 ** -2**31 overflows to infinity and 2.0 ** -2**31 underflows to zero
+    assert_equal((["Infinity,1.0,0.0"] * 4).join("|"), reader.value)
+  end
+
+  test "the exponents around the INT_MIN power are unchanged" do
+    [Cumo::SFloat, Cumo::DFloat].each do |klass|
+      a = klass[0.5, 1.0, 2.0]
+      assert_equal([1.0, 1.0, 1.0], (a**0).to_a, "#{klass} ** 0")
+      assert_equal([0.5, 1.0, 2.0], (a**1).to_a, "#{klass} ** 1")
+      assert_equal([0.25, 1.0, 4.0], (a**2).to_a, "#{klass} ** 2")
+      assert_equal([0.125, 1.0, 8.0], (a**3).to_a, "#{klass} ** 3")
+      assert_equal([0.0625, 1.0, 16.0], (a**4).to_a, "#{klass} ** 4")
+      assert_equal([32.0, 1.0, 0.03125], (a**-5).to_a, "#{klass} ** -5")
+      # past 64 the exponent reaches pow() as a double either way
+      assert_equal([2.0**-100, 1.0, 2.0**100], (a**100).to_a, "#{klass} ** 100")
+      assert_equal([2.0**100, 1.0, 2.0**-100], (a**-100).to_a, "#{klass} ** -100")
+    end
+    assert_in_delta(1.1**100, (Cumo::SFloat[1.1]**100).to_a[0], 1.0, "SFloat ** 100")
+    assert_in_delta(1.1**100, (Cumo::DFloat[1.1]**100).to_a[0], 1e-9, "DFloat ** 100")
+    assert_equal(2.0**-100, (Cumo::DComplex[Complex(0.5, 0)]**100).to_a[0].real, "DComplex ** 100")
+  end
+
   test "seq wraps an out-of-range start the way fill and cast do" do
     # f_seq answers a double for the integer types, and the device saturates an
     # out-of-range double, so a negative start collapsed to zero.


### PR DESCRIPTION

## Summary

* Take the exponent's magnitude in `unsigned int` in `pow_int` and `c_pow_int`, so `INT32_MIN` no longer relies on `-p` overflowing
* Add regression tests for `** (-2**31)` on the float and complex types, in a child with a deadline like the unsigned-power test

## Problem

* `-p` is undefined behaviour at `INT32_MIN`, and the wrapped negative shifts down to `-1`, so `while (p)` in `pow_positive_int` / `c_pow_positive_int` never ends
* This build does not hang: nvcc compiles the overflow into an unsigned compare (`ISETP.GT.U32` against 64) and an unsigned conversion (`I2F.F64.U32`), so the float path escapes through `pow()` and answers correctly, and the complex path gets a logical shift (`SHF.R.U32.HI`) that terminates
* A standalone `.cu` holding the same two functions hangs at both `-O0` and `-O3`, and `Numo::DComplex ** (-2**31)` hangs while `Numo::DFloat ** (-2**31)` answers with the sign of the exponent flipped, so the loop is one code-generation decision away

## Note

* Every other exponent is unchanged, `p > 64` included: the exponent reaches `pow()` as a double either way, so `SFloat` keeps the same values it had
* The tests pass on this toolchain before the change as well as after, since the current answers are already correct; they do fail if the negation is dropped, or if the exponent is narrowed back to `int` for the `pow()` call, which are the two ways of getting the unsigned handling wrong
* Editing a `*_kernel.h` needs `rake clean compile`: the `.cu` rules do not track the header, so an incremental build keeps the old kernels
