### PR TITLE
Fix an over-read of pooling_backward's y and gy

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -63,6 +63,23 @@ cumo_cuda_cudnn_check_output(VALUE out, VALUE type, size_t ndim, size_t *shape)
     }
 }
 
+// An input array is read through a descriptor built from another operand, so
+// cuDNN reads whatever length that descriptor claims rather than the length the
+// array really has. A non-contiguous one is copied before it is read, so unlike
+// an output it does not have to be contiguous here.
+static inline void
+cumo_cuda_cudnn_check_input(VALUE in, VALUE type, size_t ndim, size_t *shape)
+{
+    cumo_narray_t *na;
+
+    CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE(in, type);
+    CumoGetNArray(in, na);
+    CUMO_CUDA_CUDNN_CHECK_DIM_EQ((size_t)(na->ndim), ndim);
+    for (size_t idim = 0; idim < ndim; ++idim) {
+        CUMO_CUDA_CUDNN_CHECK_SIZE_EQ(na->shape[idim], shape[idim]);
+    }
+}
+
 void
 cumo_cuda_cudnn_check_status(cudnnStatus_t status);
 

--- a/ext/cumo/narray/gen/tmpl/pooling_backward.c
+++ b/ext/cumo/narray/gen/tmpl/pooling_backward.c
@@ -77,6 +77,21 @@ static VALUE
 
     x_shape = nx->shape;
 
+    {
+        // y and gy are both read through y_desc, which is built from y's shape
+        // and this class's dtype, so neither one's own length ever reaches
+        // cuDNN. Require both to be the pooling output of x.
+        size_t *y_shape = ALLOCA_N(size_t, ndim + 2);
+        y_shape[0] = x_shape[0];
+        y_shape[1] = x_shape[1];
+        for (size_t i = 0; i < ndim; ++i) {
+            y_shape[i + 2] = cumo_cuda_cudnn_GetConvOutDim(
+                    x_shape[i + 2], int_kernel_size[i], int_stride[i], int_pad[i]);
+        }
+        cumo_cuda_cudnn_check_input(y, cT, ndim + 2, y_shape);
+        cumo_cuda_cudnn_check_input(gy, cT, ndim + 2, y_shape);
+    }
+
     if (gx == Qnil) {
         gx = cumo_na_new(cT, ndim + 2, x_shape);
     }

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -566,6 +566,22 @@ class CUDNNTest < Test::Unit::TestCase
         assert { @x.max_pool_backward(y, gy, @ksize, gx: gx).equal?(gx) }
       end
 
+      test "max_pool_backward checks y and gy #{dtype}" do
+        # both are read through a descriptor built from y's shape and this
+        # class's dtype, so cuDNN never learns how long either one is
+        other = dtype == Cumo::SFloat ? Cumo::DFloat : Cumo::SFloat
+        y = @x.max_pool(@ksize)
+        gy = dtype.ones(*y.shape)
+        assert_raise(Cumo::NArray::ShapeError) { @x.max_pool_backward(y, dtype.ones(1), @ksize) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.max_pool_backward(dtype.ones(1), gy, @ksize) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.max_pool_backward(dtype.ones(*@x_shape), dtype.ones(*@x_shape), @ksize) }
+        assert_raise(TypeError) { @x.max_pool_backward(y, other.ones(*y.shape), @ksize) }
+        assert_raise(TypeError) { @x.max_pool_backward(other.ones(*y.shape), gy, @ksize) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.avg_pool_backward(y, dtype.ones(1), @ksize) }
+        # a y and gy of the pooling output shape still go through
+        assert { @x.max_pool_backward(y, gy, @ksize).sum.to_f == y.size }
+      end
+
       test "conv(y:), conv_transpose(y:) and conv_grad_w(gw:) #{dtype}" do
         assert_raise(Cumo::NArray::ShapeError) { @x.conv(@w, y: dtype.zeros(1)) }
         y = @x.conv(@w)


### PR DESCRIPTION

## Summary

* Require `y` and `gy` to be this class's dtype and to have the pooling output shape of `x`, which is what `y_desc` claims they are
* Add `cumo_cuda_cudnn_check_input`, the input-side counterpart of `cumo_cuda_cudnn_check_output` without the contiguity requirement, since inputs are copied by `cumo_na_as_contiguous_array` before they are read

## Problem

* Only `x` was checked. `y` and `gy` reached `cudnnPoolingBackward` as raw device pointers, both read through the single `y_desc` built from `y`'s shape and this class's dtype, so neither one's own length ever reached cuDNN
* `compute-sanitizer` reports the out-of-bounds read directly: a one-element `gy` where 16 elements are read gives `Invalid __global__ read of size 8 bytes ... 1 bytes after the nearest allocation of size 8 bytes`, with `dfloat_pooling_backward in pooling_backward.c:104` in the host backtrace. A same-shaped `SFloat` `gy` is read as doubles and runs 64 bytes past its 64-byte buffer
* What it reads comes back to the caller. With `x` of `[1,1,64,64]` and a one-element `gy`, `gx` returned 961 non-zero elements holding the contents of fifteen unrelated `DFloat` arrays allocated next to it
* `pooling_backward.c` was the only cuDNN entry point leaving an input operand unchecked; `conv.c`, `conv_transpose.c`, `conv_grad_w.c`, `batch_norm.c` and `batch_norm_backward.c` all check theirs. PR #269 closed the write side here by checking `gx`

## Note

* `avg_pool_backward` shares the function and is covered by the same checks
* `compute-sanitizer` now reports `0 errors` for the legitimate call, and the fifteen arrays no longer reach `gx` because the call raises instead
* Removing the two checks fails the new test on both dtypes
