### PR TITLE
Cover the Int32 array exponent in the INT_MIN power test

### DIFF
--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4736,17 +4736,24 @@ class NArrayTest < Test::Unit::TestCase
   test "a float or complex array raised to the INT_MIN power answers instead of spinning" do
     # -p overflows for INT32_MIN and the wrapped negative shifts down to -1, so
     # pow_positive_int would never leave its loop. pow_int takes the magnitude
-    # in unsigned now. This runs in a child for the same reason as the unsigned
-    # test above: a spinning kernel only stops for SIGKILL.
+    # in unsigned now. The exponent reaches it three ways: as a Fixnum, as an
+    # Int32 array, and as an Int32 array against a numeric base through coerce.
+    # This runs in a child for the same reason as the unsigned test above: a
+    # spinning kernel only stops for SIGKILL.
     script = <<~'RUBY'
       require "cumo/narray"
+      int_min = Cumo::Int32[-2**31, -2**31, -2**31]
       out = [Cumo::SFloat[0.5, 1.0, 2.0]**(-2**31),
              Cumo::DFloat[0.5, 1.0, 2.0]**(-2**31),
              Cumo::SFloat[0.5, 1.0, 2.0]**(-2**31 + 1),
-             Cumo::DFloat[0.5, 1.0, 2.0]**(-2**31 + 1)].map { |v| v.to_a.join(",") }
+             Cumo::DFloat[0.5, 1.0, 2.0]**(-2**31 + 1),
+             Cumo::SFloat[0.5, 1.0, 2.0]**int_min,
+             Cumo::DFloat[0.5, 1.0, 2.0]**int_min].map { |v| v.to_a.join(",") }
+      out << (0.5**Cumo::Int32[-2**31, 1, 2]).to_a.join(",")
       # the complex path overflows the same way and only has to finish
       (Cumo::SComplex[Complex(0.5, 0)]**(-2**31)).to_a
       (Cumo::DComplex[Complex(0.5, 0)]**(-2**31)).to_a
+      (Cumo::DComplex[Complex(0.5, 0)]**Cumo::Int32[-2**31]).to_a
       print out.join("|")
     RUBY
     lib = File.expand_path("../lib", __dir__)
@@ -4765,7 +4772,7 @@ class NArrayTest < Test::Unit::TestCase
       sleep 0.05
     end
     # 0.5 ** -2**31 overflows to infinity and 2.0 ** -2**31 underflows to zero
-    assert_equal((["Infinity,1.0,0.0"] * 4).join("|"), reader.value)
+    assert_equal(((["Infinity,1.0,0.0"] * 6) << "Infinity,0.5,0.25").join("|"), reader.value)
   end
 
   test "the exponents around the INT_MIN power are unchanged" do


### PR DESCRIPTION

## Summary

* Raise an array to `Cumo::Int32[-2**31]` as well as to the Fixnum `-2**31`, and to it from a numeric base through `coerce`, so all three entry points into `pow_int` are covered
* Add the same for `Cumo::DComplex`, which only has to finish

## Problem

* `pow_self` dispatches on `FIXNUM_P(other) || rb_obj_is_kind_of(other, cumo_cInt32)`, so an `Int32` array reaches `pow_int` as well, and a numeric base with one reaches it through `coerce`. The test PR #299 added only walked the Fixnum path
* The three converge on the same inlined `pow_int`, so this is dispatch coverage rather than a second implementation; what it guards is a change that reaches one entry point and not the others

## Note

* Narrowing the exponent back to `int` for the `pow()` call breaks all three: the Fixnum pair, the `Int32` array pair and the coerced one all answer with the sign of the exponent flipped, while the `-2**31 + 1` pair in the same test stays correct
