### PR TITLE
Fix an over-write of a non-contiguous inplace c in gemm

### DIFF
--- a/ext/cumo/narray/gen/tmpl/gemm.c
+++ b/ext/cumo/narray/gen/tmpl/gemm.c
@@ -413,6 +413,13 @@ static VALUE
             rb_raise(cumo_na_eShapeError,"batch count of c=%d must equal to %d",
                     gemm_batch_count(nc), batch);
         }
+        // a and b are duplicated when they are not contiguous, but c is written
+        // in place, and cuBLAS writes it as ldc=n stridec=m*n from its offset
+        // whatever strides it really has. Only an inplace c reaches here
+        // uncopied, so this is the one operand that has to be turned away.
+        if (!is_c_contiguous(c)) {
+            rb_raise(cumo_na_eShapeError, "c must be contiguous");
+        }
     }
 
     <%=c_iter%>(a, b, c, &g);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -965,6 +965,27 @@ class NArrayTest < Test::Unit::TestCase
           assert_raise(Cumo::NArray::ShapeError) { dtype.new(0, 3).gemm(dtype.new(3, 4).seq) }
           assert_raise(Cumo::NArray::ShapeError) { dtype.new(2, 0).gemm(dtype.new(0, 4)) }
         end
+        test "matrix.gemm(matrix) rejects an inplace c that is not contiguous" do
+          a = dtype.new(4, 4).seq
+          b = dtype.new(4, 4).seq
+          # cuBLAS writes c as ldc=n stridec=m*n from its offset whatever
+          # strides it really has, so a non-contiguous one runs off the end of
+          # the allocation and over whatever the pool put next to it
+          assert_raise(Cumo::NArray::ShapeError) { a.gemm(b, dtype.new(4, 4).seq.reverse.inplace) }
+          assert_raise(Cumo::NArray::ShapeError) { a.gemm(b, dtype.new(4, 4).seq.transpose.inplace) }
+          base = dtype.new(4, 2).seq
+          assert_raise(Cumo::NArray::ShapeError) do
+            dtype.new(8, 3).seq.gemm(dtype.new(3, 2).seq, base[[0] * 8, true].inplace!)
+          end
+          # a contiguous c goes through, inplace or not, and a non-contiguous
+          # one that is not inplace is copied before it is written
+          c = dtype.zeros(4, 4).inplace
+          assert { a.gemm(b, c).equal?(c) }
+          assert { c == a.gemm(b) }
+          assert { a.gemm(b, dtype.zeros(4, 4)) == a.gemm(b) }
+          assert { a.gemm(b, dtype.new(4, 4).seq.reverse) == a.gemm(b) }
+        end
+
         test "matrix.gemm(matrix) takes a transposed batch without a copy" do
           a = dtype.new(2, 3, 2, 4).seq
           b = dtype.new(2, 3, 5, 4).seq.transpose(0, 1, 3, 2)


### PR DESCRIPTION

## Summary

* Require `c` to be contiguous, the way `cumo_cuda_cudnn_check_output` does for the cuDNN outputs
* Add a regression test over the four gemm dtypes

## Problem

* `a` and `b` are duplicated when they are not contiguous (`make_gemm_layout`), but `c` is only checked for row size, column size and batch count. cuBLAS then writes it as `ldc=n` `stridec=m*n` from its offset whatever strides it really has
* `c = dtype.new(64, 64).seq.reverse.inplace` puts the offset at the last element, and `compute-sanitizer` reports `Invalid __global__ write of size 8 bytes ... 2,041 bytes after the nearest allocation of size 32,768 bytes`, with `cublasDgemmStridedBatched` and `dfloat_gemm` in the host backtrace
* It corrupts whatever the pool put next to it, with nothing raised: with sixteen `DFloat` arrays allocated after `c`, eight came back overwritten, one of them in all 512 of its elements
* An index-backed view (`base[[0] * 8, true].inplace!`) does not run off the allocation, but reading the result back segfaults

## Note

* Only an inplace `c` reaches the call uncopied, so a non-contiguous `c` that is not inplace was already safe and still is
* `compute-sanitizer` reports `0 errors` for a contiguous `c` after the change, and removing the check fails the new test on all four dtypes
