### PR TITLE
Fix an over-read and over-write of the batch norm parameters

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -63,6 +63,23 @@ cumo_cuda_cudnn_check_output(VALUE out, VALUE type, size_t ndim, size_t *shape)
     }
 }
 
+// cuDNN derives the batch-norm parameter descriptor from x with a SPATIAL mode,
+// so it reaches x's channel count in gamma, beta and the rest however the axis
+// reduced them. Normally the reduced size is the larger of the two and only
+// part of each buffer is used, but an axis that folds the channel away makes it
+// smaller, and cuDNN has no way to know.
+static inline void
+cumo_cuda_cudnn_check_reduced_size(size_t reduced_total_size, size_t x_ndim, size_t *x_shape)
+{
+    size_t channel_size = (x_ndim == 1) ? x_shape[0] : x_shape[1];
+
+    if (reduced_total_size < channel_size) {
+        rb_raise(cumo_na_eShapeError,
+                 "the axis reduces to %d, fewer than the %d channels cuDNN accesses",
+                 (int)reduced_total_size, (int)channel_size);
+    }
+}
+
 // An input array is read through a descriptor built from another operand, so
 // cuDNN reads whatever length that descriptor claims rather than the length the
 // array really has. A non-contiguous one is copied before it is read, so unlike

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -100,6 +100,8 @@ static VALUE
         cumo_cuda_cudnn_shape_t reduced_shape = cumo_cuda_cudnn_ReduceShape(x_ndim, x_shape, axis_ndim, int_axis, 1);
         size_t reduced_total_size = cumo_cuda_cudnn_GetTotalSize(&reduced_shape);
 
+        cumo_cuda_cudnn_check_reduced_size(reduced_total_size, x_ndim, x_shape);
+
         CumoGetNArray(gamma, ngamma);
         CUMO_CUDA_CUDNN_CHECK_SIZE_EQ(ngamma->size, reduced_total_size);
         CumoGetNArray(beta, nbeta);

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -89,6 +89,8 @@ static VALUE
         cumo_cuda_cudnn_shape_t reduced_shape = cumo_cuda_cudnn_ReduceShape(x_ndim, x_shape, axis_ndim, int_axis, 1);
         size_t reduced_total_size = cumo_cuda_cudnn_GetTotalSize(&reduced_shape);
 
+        cumo_cuda_cudnn_check_reduced_size(reduced_total_size, x_ndim, x_shape);
+
         CumoGetNArray(gy, ngy);
         CUMO_CUDA_CUDNN_CHECK_SIZE_EQ(nx->size, ngy->size);
 

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -70,6 +70,8 @@ static VALUE
         cumo_cuda_cudnn_shape_t reduced_shape = cumo_cuda_cudnn_ReduceShape(x_ndim, x_shape, axis_ndim, int_axis, 1);
         size_t reduced_total_size = cumo_cuda_cudnn_GetTotalSize(&reduced_shape);
 
+        cumo_cuda_cudnn_check_reduced_size(reduced_total_size, x_ndim, x_shape);
+
         CumoGetNArray(gamma, ngamma);
         CumoGetNArray(beta, nbeta);
         CumoGetNArray(mean, nmean);

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -288,6 +288,43 @@ class CUDNNTest < Test::Unit::TestCase
       end
     end
 
+    sub_test_case "batch_norm with an axis that folds the channel away" do
+      setup do
+        @x = dtype.new(8, 256).seq
+        @one = dtype.ones(1)
+        @zero = dtype.zeros(1)
+      end
+
+      # cuDNN derives its parameter descriptor from x with a SPATIAL mode and
+      # reaches 256 channels in each buffer, whatever the axis reduced them to
+      test "batch_norm rejects it #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm(@one, @zero, axis: [0, 1]) }
+        assert_raise(Cumo::NArray::ShapeError) do
+          @x.batch_norm(@one, @zero, axis: [0, 1], running_mean: @zero, running_var: @one)
+        end
+        assert_raise(Cumo::NArray::ShapeError) do
+          @x.batch_norm(@one, @zero, axis: [0, 1], mean: @zero, inv_std: @zero)
+        end
+      end
+
+      test "fixed_batch_norm and batch_norm_backward reject it #{dtype}" do
+        assert_raise(Cumo::NArray::ShapeError) do
+          @x.fixed_batch_norm(@one, @zero, @zero, @one, axis: [0, 1])
+        end
+        assert_raise(Cumo::NArray::ShapeError) do
+          @x.batch_norm_backward(@one, dtype.ones(8, 256), axis: [0, 1])
+        end
+      end
+
+      test "the same shapes with the default axis still go through #{dtype}" do
+        gamma = dtype.ones(1, 256)
+        beta = dtype.zeros(1, 256)
+        assert { @x.batch_norm(gamma, beta).shape == [8, 256] }
+        assert { @x.fixed_batch_norm(gamma, beta, beta, gamma).shape == [8, 256] }
+        assert { @x.batch_norm_backward(gamma, dtype.ones(8, 256)).first.shape == [8, 256] }
+      end
+    end
+
     sub_test_case "batch_norm_backward" do
       setup do
         @batch_size = 2


### PR DESCRIPTION

## Summary

* Require the reduced size to be at least x's channel count, which is what cuDNN reaches in `gamma`, `beta`, `running_mean`, `running_var`, `mean` and `inv_std`
* Apply it in `batch_norm`, `fixed_batch_norm` and `batch_norm_backward`, which share the check

## Problem

* The sizes are checked against `cumo_cuda_cudnn_ReduceShape(axis)`, but `cumo_cuda_cudnn_GetBatchNormMode` returns `CUDNN_BATCHNORM_SPATIAL` for an axis of one or two entries without looking at what those entries are, so `cudnnDeriveBNTensorDescriptor` builds `1 x C x 1 x 1` and cuDNN reaches C elements whatever the axis reduced them to
* `Cumo::SFloat.new(8, 256).seq.batch_norm(one, zero, axis: [0, 1])` passes a one-element `gamma` through a check that computes 1, and `compute-sanitizer` reports 91 `Invalid __global__ read of size 4 bytes`, up to 181 bytes past a four-byte allocation, at `sfloat_batch_norm in batch_norm.c:173`. `fixed_batch_norm` gives 37,452 of them
* The writes land too, with nothing raised: with `mean:` and `inv_std:` supplied and 24 arrays allocated after them, one came back with 128 of its 256 elements holding an inverse standard deviation. Under `compute-sanitizer` the kernel instead dies with `cudaErrorLaunchFailure`, which costs the CUDA context

## Note

* Validating the axis instead would break the documented call: with the default `axis: [0]` on a four-dimensional x, cuDNN reads only the first C of `gamma`, and changing `gamma` past that does not move the result, so an axis of `[0, 2, 3]` cannot be required
* Removing the check fails the new tests on both dtypes; the same shapes with the default axis go through before and after
