### PR TITLE
Fix the inverted status check in CreateBNTensorDescriptor

### DIFF
--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -555,7 +555,7 @@ cumo_cuda_cudnn_CreateBNTensorDescriptor(
 {
     cudnnStatus_t status = CUDNN_STATUS_SUCCESS;
     status = cudnnCreateTensorDescriptor(desc);
-    if (status == CUDNN_STATUS_SUCCESS) return status;
+    if (status != CUDNN_STATUS_SUCCESS) return status;
 
     status = cudnnDeriveBNTensorDescriptor(*desc, x_desc, mode);
     return status;

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -160,11 +160,8 @@ static VALUE
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_ERROR;
 
-    status = cudnnCreateTensorDescriptor(&bn_desc);
-    if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_ERROR;
-
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
-    status = cudnnDeriveBNTensorDescriptor(bn_desc, x_desc, mode);
+    status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_ERROR;
     // TODO: bn_desc may return another type, and may need to cast gamma, beta, mean, var
 

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -145,11 +145,8 @@ static VALUE
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_BACKWARD_ERROR;
 
-    status = cudnnCreateTensorDescriptor(&bn_desc);
-    if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_BACKWARD_ERROR;
-
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
-    status = cudnnDeriveBNTensorDescriptor(bn_desc, x_desc, mode);
+    status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_BACKWARD_ERROR;
     // TODO: bn_desc may return another type, and may need to cast gamma, gy, mean, var
 

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -109,11 +109,8 @@ static VALUE
     status = cumo_cuda_cudnn_CreateTensorDescriptor(&x_desc, x_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto FIXED_BATCH_NORM_ERROR;
 
-    status = cudnnCreateTensorDescriptor(&bn_desc);
-    if (status != CUDNN_STATUS_SUCCESS) goto FIXED_BATCH_NORM_ERROR;
-
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
-    status = cudnnDeriveBNTensorDescriptor(bn_desc, x_desc, mode);
+    status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto FIXED_BATCH_NORM_ERROR;
     // TODO: bn_desc may return another type, and may need to cast gamma, beta, mean, var
 


### PR DESCRIPTION

## Summary

* `cumo_cuda_cudnn_CreateBNTensorDescriptor` returned as soon as `cudnnCreateTensorDescriptor` succeeded, so `cudnnDeriveBNTensorDescriptor` never ran; the comparison is now the other way round
* Call it from `batch_norm`, `fixed_batch_norm` and `batch_norm_backward`, which each held their own copy of the two calls

## Problem

* `if (status == CUDNN_STATUS_SUCCESS) return status;` leaves the descriptor created but underived, so the helper only did what its name says when the first call failed
* Nothing called it, which is why the tests never saw it. The three templates duplicated the pair inline and were correct
* Restoring the inverted comparison now fails 28 assertions in `test/cudnn_test.rb`, where before the change it failed none

## Note

* No behaviour change: the helper does what the three copies did, and the whole suite passes unchanged
