### PR TITLE
Fix at() reading the accumulator as the subscript on a reversed view

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -682,7 +682,7 @@ cumo_na_index_at_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
 
 void cumo_na_index_at_naview_index_index_index_add_kernel_launch(size_t *idx, size_t *idx1, size_t *idx2, uint64_t n);
 void cumo_na_index_at_naview_index_index_beg_step_add_kernel_launch(size_t *idx, size_t *idx1, size_t beg, ssize_t step, uint64_t n);
-void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, ssize_t s1, size_t last, uint64_t n);
+void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, size_t *idx1, ssize_t s1, size_t last, uint64_t n);
 
 static void
 cumo_na_index_at_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
@@ -747,10 +747,12 @@ cumo_na_index_at_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
                 }
                 na2->offset -= last * stride1;
                 if (i==ndim-1) {
+                    // index aliases q[ndim-1].idx, so the accumulator still
+                    // holds the subscript here and is the right thing to read
                     cumo_na_index_aref_naview_index_stride_last_kernel_launch(index, stride1, last, size);
                     q[i].idx = NULL;
                 } else {
-                    cumo_na_index_at_naview_index_stride_last_add_kernel_launch(index, stride1, last, size);
+                    cumo_na_index_at_naview_index_stride_last_add_kernel_launch(index, q[i].idx, stride1, last, size);
                 }
             } else {
                 if (i==ndim-1) {

--- a/ext/cumo/narray/index_kernel.cu
+++ b/ext/cumo/narray/index_kernel.cu
@@ -77,10 +77,10 @@ __global__ void cumo_na_index_at_naview_index_index_beg_step_add_kernel(size_t *
     }
 }
 
-__global__ void cumo_na_index_at_naview_index_stride_last_add_kernel(size_t *idx, ssize_t s1, size_t last, uint64_t n)
+__global__ void cumo_na_index_at_naview_index_stride_last_add_kernel(size_t *idx, size_t *idx1, ssize_t s1, size_t last, uint64_t n)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        idx[i] += (last - idx[i]) * s1;
+        idx[i] += (last - idx1[i]) * s1;
     }
 }
 
@@ -164,11 +164,11 @@ void cumo_na_index_at_naview_index_index_beg_step_add_kernel_launch(size_t *idx,
     cumo_cuda_runtime_check_kernel_launch();
 }
 
-void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, ssize_t s1, size_t last, uint64_t n)
+void cumo_na_index_at_naview_index_stride_last_add_kernel_launch(size_t *idx, size_t *idx1, ssize_t s1, size_t last, uint64_t n)
 {
     size_t grid_dim = cumo_get_grid_dim(n);
     size_t block_dim = cumo_get_block_dim(n);
-    cumo_na_index_at_naview_index_stride_last_add_kernel<<<grid_dim, block_dim>>>(idx, s1, last, n);
+    cumo_na_index_at_naview_index_stride_last_add_kernel<<<grid_dim, block_dim>>>(idx, idx1, s1, last, n);
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -133,6 +133,19 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.at([-1]) == [11] }
         assert { a.view.at([-1]) == [11] }
 
+        # a reversed view takes the negative-stride path, where the accumulator
+        # was read in place of the subscript for every dimension but the last
+        b = dtype.new(4, 5).seq
+        [b, b.reverse(0), b.reverse(1), b.reverse, b.transpose.reverse(0)].each_with_index do |v, i|
+          rows = v.to_a
+          assert(v.at([1, 2], [0, 1]).to_a == [rows[1][0], rows[2][1]], "at on view #{i}")
+        end
+        c = b.reverse(0)
+        c.at([1, 2], [0, 1]).store(99)
+        assert { c.to_a[1][0] == 99 }
+        assert { c.to_a[2][1] == 99 }
+        assert { b.to_a.flatten.count(99) == 2 }
+
         assert { a[(0..-1).each] == [1, 2, 3, 5, 7, 11] }
         assert { a[(0...-1).each] == [1, 2, 3, 5, 7] }
 


### PR DESCRIPTION

## Summary

* Pass the subscript array to `cumo_na_index_at_naview_index_stride_last_add_kernel` and read it there, the way the positive-stride sibling already does
* Add a regression test that walks `at` over a plain array and four kinds of reversed view

## Problem

* The negative-stride branch launched the kernel without `q[i].idx`, so it did `idx[i] += (last - idx[i]) * s1` against the accumulator instead of the subscript. `index` aliases `q[ndim-1].idx`, so this is right for the last dimension and wrong for every one before it
* `Cumo::DFloat.new(4, 5).seq.reverse(0).at([1, 2], [0, 1])` answered `[15.0, 0.0]` where Numo answers `[10.0, 6.0]`, and segfaulted in 8 of 10 runs. `8 + (3 - 8) * 40` is `-192`, which wraps as a `size_t`, so the second element addresses far in front of the buffer
* Writing through the same view (`.store(99)`) gave `an illegal memory access` from the device in 2 of 3 runs
* `compute-sanitizer` reports nothing for the read, which happens on the host

## Note

* The other three branches are fine: `index <- index` and the positive `index <- step` both pass their subscript, and `step <- step` builds the offset from `beg` and `step` without one
* Restoring the old expression fails the new assertions on all ten dtypes
