### PR TITLE
Fix []= writing through a frozen view

### DIFF
--- a/ext/cumo/narray/gen/tmpl/aset.c
+++ b/ext/cumo/narray/gen/tmpl/aset.c
@@ -48,6 +48,14 @@ static VALUE
     if (argc==0) {
         <%=c_func.sub(/_aset/,"_store")%>(self, argv[argc]);
     } else {
+        // The store goes to a view derived by cumo_na_aref_main, whose data
+        // object is the root rather than self, so the frozen check inside
+        // cumo_na_get_pointer_for_rw never reaches self. Numo has a scalar
+        // subscript path that writes through self and raises there; cumo has
+        // none, since the element write has to happen on the device.
+        if (OBJ_FROZEN(self)) {
+            rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+        }
         nd = cumo_na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
         a = cumo_na_aref_main(argc, argv, self, 0, nd, pos);
         <%=c_func.sub(/_aset/,"_store")%>(a, argv[argc]);

--- a/ext/cumo/narray/gen/tmpl_bit/aset.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aset.c
@@ -36,6 +36,14 @@ static VALUE
     if (argc==0) {
         <%=c_func.sub(/_aset/,"_store")%>(self, argv[argc]);
     } else {
+        // The store goes to a view derived by cumo_na_aref_main, whose data
+        // object is the root rather than self, so the frozen check inside
+        // cumo_na_get_pointer_for_rw never reaches self. Numo has a scalar
+        // subscript path that writes through self and raises there; cumo has
+        // none, since the element write has to happen on the device.
+        if (OBJ_FROZEN(self)) {
+            rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+        }
         nd = cumo_na_get_result_dimension(self, argc, argv, 1, &pos);
         a = cumo_na_aref_main(argc, argv, self, 0, nd, pos);
         <%=c_func.sub(/_aset/,"_store")%>(a, argv[argc]);

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -205,4 +205,22 @@ class BitTest < Test::Unit::TestCase
     a[0...64].store([(0...64)])
     assert_equal(0, a[64].to_a.first)
   end
+
+  test "[]= on a frozen view raises whatever the subscript is" do
+    # the store goes to a view derived from self, whose data object is the
+    # root, so the check inside get_pointer_for_rw never reaches self
+    a = Cumo::Bit.new(5).fill(0)
+    v = a[1..3]
+    v.freeze
+    assert_raise(RuntimeError) { v[0] = 1 }
+    assert_raise(RuntimeError) { v[0..1] = 1 }
+    assert_raise(RuntimeError) { v[[0, 1]] = 1 }
+    assert_raise(RuntimeError) { v.store(1) }
+    assert_equal([0, 0, 0, 0, 0], a.to_a)
+    # and still writes when nothing is frozen
+    w = a[1..3]
+    w[0] = 1
+    w[1..2] = 1
+    assert_equal([0, 1, 1, 1, 0], a.to_a)
+  end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1113,6 +1113,38 @@ class NArrayTest < Test::Unit::TestCase
       assert { at == [[0, 2, 3], [4, 4, 6]] }
     end
 
+    sub_test_case "#{dtype}, frozen" do
+      test "[]= on a frozen view raises whatever the subscript is" do
+        # the store goes to a view derived from self, whose data object is the
+        # root, so the check inside get_pointer_for_rw never reaches self
+        a = dtype.new(5).seq
+        v = a[1..3]
+        v.freeze
+        assert_raise(RuntimeError) { v[0] = 9 }
+        assert_raise(RuntimeError) { v[0..1] = 9 }
+        assert_raise(RuntimeError) { v[[0, 1]] = 9 }
+        assert_raise(RuntimeError) { v[true] = 9 }
+        assert_raise(RuntimeError) { v.store(9) }
+        assert { a == dtype.new(5).seq }
+      end
+
+      test "[]= on a frozen array raises too" do
+        a = dtype.new(5).seq
+        a.freeze
+        assert_raise(RuntimeError) { a[0] = 9 }
+        assert_raise(RuntimeError) { a[0..1] = 9 }
+        assert { a == dtype.new(5).seq }
+      end
+
+      test "[]= still writes when nothing is frozen" do
+        a = dtype.new(5).seq
+        v = a[1..3]
+        v[0] = 9
+        v[1..2] = 8
+        assert { a == dtype[0, 9, 8, 8, 4] }
+      end
+    end
+
     sub_test_case "#{dtype}.from_binary" do
       test "frozen string" do
         shape = [2, 5]


### PR DESCRIPTION

## Summary

* Raise on `[]=` when the receiver is frozen, in both the numeric and the `Cumo::Bit` template
* Add tests over a frozen view, a frozen array and an unfrozen one

## Problem

* `[]=` stores into a view derived by `cumo_na_aref_main`, and a derived view's data object is the root rather than the receiver, so the `OBJ_FROZEN` checks inside `cumo_na_get_pointer_for_rw` never see the frozen view in the middle
* `a = dtype.new(5).seq; v = a[1..3]; v.freeze; v[0] = 9` wrote 9 and left `v.frozen?` true. A read-only handle passed to another object was not read-only
* Numo raises for a scalar subscript because it writes through the receiver in that case; cumo has no such path, since the element write has to happen on the device, so every subscript went through the derived view

## Note

* `store` and `fill` already raised: they pass the receiver itself as the overwrite argument
* Numo lets a range or array subscript through as well, and so does `inplace` on a frozen view; both are in code cumo shares, so they are left to upstream
* Neutralising the check fails 12 assertions in `narray_test.rb` and 1 in `bit_test.rb`
