### PR TITLE
Fix a SIGFPE from a stride of zero in conv and pooling

### DIFF
--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -27,7 +27,12 @@ cumo_cuda_cudnn_GetConvOutDim(
         size_t stride,
         size_t pad) {
     int64_t numerator;
-    assert(stride > 0);
+
+    // ruby.h defines NDEBUG, so the assert this used to carry never ran and a
+    // stride of zero reached the division below as a SIGFPE
+    if (stride == 0) {
+        rb_raise(rb_eArgError, "stride must be positive");
+    }
     // if (cover_all) {
     //     numerator = in_dim + pad * 2 - kernel_size + stride - 1;
     // } else {
@@ -49,7 +54,12 @@ cumo_cuda_cudnn_GetConvTransposeOutDim(
     // if (cover_all) {
     //     return stride * (in_dim - 1) + kernel_size - stride + 1 - 2 * pad;
     // }
-    int64_t out_size = stride * (in_dim - 1) + kernel_size - 2 * pad;
+    int64_t out_size;
+
+    if (stride == 0) {
+        rb_raise(rb_eArgError, "stride must be positive");
+    }
+    out_size = stride * (in_dim - 1) + kernel_size - 2 * pad;
     if (out_size < 0) {
         rb_raise(rb_eRuntimeError, "Output size should be positive.");
     }

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -554,6 +554,37 @@ class CUDNNTest < Test::Unit::TestCase
       end
     end
 
+    sub_test_case "a stride of zero" do
+      setup do
+        @x = dtype.new(1, 1, 8, 8).seq
+        @w = dtype.new(1, 1, 2, 2).seq
+        @max = Cumo::CUDA::CUDNN::CUDNN_POOLING_MAX
+      end
+
+      # ruby.h defines NDEBUG, so the assert that used to guard the division in
+      # GetConvOutDim never ran and the process took a SIGFPE instead
+      test "the conv entry points reject it #{dtype}" do
+        assert_raise(ArgumentError) { @x.conv(@w, stride: 0) }
+        assert_raise(ArgumentError) { @x.conv_transpose(@w, stride: 0) }
+        assert_raise(ArgumentError) { @x.conv_grad_w(@x.conv(@w), @w.shape, stride: 0) }
+      end
+
+      test "the pooling entry points reject it #{dtype}" do
+        assert_raise(ArgumentError) { @x.pooling_forward(@max, 0) }
+        assert_raise(ArgumentError) { @x.pooling_forward(@max, 2, stride: 0) }
+        assert_raise(ArgumentError) { @x.max_pool(0) }
+        assert_raise(ArgumentError) { @x.avg_pool(0) }
+        y = @x.pooling_forward(@max, 2)
+        assert_raise(ArgumentError) { @x.pooling_backward(@max, y, dtype.ones(*y.shape), 2, stride: 0) }
+      end
+
+      test "a positive stride still goes through #{dtype}" do
+        assert { @x.conv(@w, stride: 2).shape == [1, 1, 4, 4] }
+        assert { @x.conv_transpose(@w, stride: 2).shape == [1, 1, 16, 16] }
+        assert { @x.pooling_forward(@max, 2).shape == [1, 1, 4, 4] }
+      end
+    end
+
     sub_test_case "given output arrays" do
       setup do
         @x_shape = [2, 3, 5, 3]


### PR DESCRIPTION

## Summary

* Raise `ArgumentError` on a zero stride in `cumo_cuda_cudnn_GetConvOutDim` and `cumo_cuda_cudnn_GetConvTransposeOutDim`, replacing an assert that never ran
* Add tests over the six entry points that reach them

## Problem

* `stride:` and `kernel_size` arrive through `cumo_cuda_cudnn_get_int_ary` unchecked, and `GetConvOutDim` divides by the stride. The only guard was `assert(stride > 0)`, and `ruby.h` defines `NDEBUG` (`RUBY_NDEBUG` is 1), so it compiled to nothing
* The division then raises `#DE` and the process takes a `SIGFPE`, which Ruby cannot rescue. `x.conv(w, stride: 0)`, `x.conv_transpose(w, stride: 0)`, `x.conv_grad_w(y, shape, stride: 0)`, `x.pooling_forward(mode, 0)`, `x.max_pool(0)`, `x.avg_pool(0)` and `x.pooling_backward(mode, y, gy, 2, stride: 0)` all ended in exit 136
* `pooling_forward(mode, 0)` reaches it without naming a stride at all, since `stride` defaults to a copy of `kernel_size`

## Note

* Only zero is fatal. A negative stride or pad reaches cuDNN and comes back as `CUDNN_STATUS_BAD_PARAM`, a stride past `int` raises `RangeError`, and a zero `kernel_size` with a positive stride is `CUDNN_STATUS_BAD_PARAM` too
* There is one division in the whole cuDNN layer, so the guard in `GetConvOutDim` covers all six entry points; `GetConvTransposeOutDim` takes the same guard so `conv_transpose` raises where the stride is first used rather than at the consistency check below it
* Neutralising the guard does not fail the new tests, it core-dumps the runner, which is the defect
