### PR TITLE
Drop the contiguity assert the cuDNN descriptors do not need

### DIFF
--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -76,7 +76,8 @@ cumo_cuda_cudnn_CreateTensorDescriptor(
     int ndim = (int)(na->ndim);
     size_t *shape = na->shape;
 
-    assert(cumo_na_check_contiguous(a) == Qtrue);
+    // only the shape is read: the descriptor is NCHW and the caller passes the
+    // contiguous copy, so a non-contiguous a still describes what is read
     status = cudnnCreateTensorDescriptor(desc);
     if (status != CUDNN_STATUS_SUCCESS) return status;
 
@@ -133,7 +134,7 @@ cumo_cuda_cudnn_CreateFilterDescriptor(
     ndim = (int)(na->ndim);
     shape = na->shape;
 
-    assert(cumo_na_check_contiguous(a) == Qtrue);
+    // only the shape is read, as in CreateTensorDescriptor above
     status = cudnnCreateFilterDescriptor(desc);
     if (status != CUDNN_STATUS_SUCCESS) return status;
 

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -554,6 +554,39 @@ class CUDNNTest < Test::Unit::TestCase
       end
     end
 
+    sub_test_case "a non-contiguous input" do
+      setup do
+        @x = dtype.new(1, 1, 8, 8).seq
+        @max = Cumo::CUDA::CUDNN::CUDNN_POOLING_MAX
+      end
+
+      # y and gy are copied before they are read, so a strided one is allowed;
+      # this pins that, not the copy itself. cuDNN recomputes the argmax from x
+      # and never reads y's values, so no assertion here can see a wrong y.
+      test "pooling_backward takes a strided y #{dtype}" do
+        y = @x.pooling_forward(@max, 2)
+        pad = dtype.zeros(1, 1, 4, 8)
+        pad[true, true, true, 0...4] = y
+        y_strided = pad[true, true, true, 0...4]
+        assert { !y_strided.contiguous? }
+        gy = dtype.new(1, 1, 4, 4).seq(1)
+        gx = @x.pooling_backward(@max, y_strided, gy, 2)
+        assert { gx == @x.pooling_backward(@max, y, gy, 2) }
+        assert { gx.to_a.flatten.count { |v| v != 0 } == y.size }
+      end
+
+      test "pooling_backward takes a strided gy #{dtype}" do
+        y = @x.pooling_forward(@max, 2)
+        pad = dtype.zeros(1, 1, 4, 8)
+        pad[true, true, true, 0...4] = dtype.new(1, 1, 4, 4).seq(1)
+        gy_strided = pad[true, true, true, 0...4]
+        assert { !gy_strided.contiguous? }
+        gx = @x.pooling_backward(@max, y, gy_strided, 2)
+        assert { gx == @x.pooling_backward(@max, y, dtype.new(1, 1, 4, 4).seq(1), 2) }
+        assert { gx.to_a.flatten.count { |v| v != 0 } == y.size }
+      end
+    end
+
     sub_test_case "a stride of zero" do
       setup do
         @x = dtype.new(1, 1, 8, 8).seq


### PR DESCRIPTION

## Summary

* Remove `assert(cumo_na_check_contiguous(a) == Qtrue)` from `CreateTensorDescriptor` and `CreateFilterDescriptor`, and say in a comment why contiguity is not required
* Add tests that `pooling_backward` takes a strided `y` and a strided `gy`

## Problem

* Both functions read `na->ndim` and `na->shape` and nothing else, so the descriptor they build describes the contiguous copy the caller actually passes whichever layout the argument has
* `ruby.h` defines `NDEBUG`, so neither assert ever ran. They stated a requirement the code does not have, and `pooling_backward` passes an argument that can be strided
* Measured: `pooling_backward` through a strided `y` answers the same gradient as through the contiguous one, with the same 16 non-zero elements

## Note

* cuDNN recomputes the argmax from `x` and never reads `y`'s values: zeroing `y` or reversing it leaves the gradient unchanged. So the `y` test pins that a strided `y` is accepted, not that it is read correctly, and the comment says so
* The `gy` test does bite: dropping its contiguous copy fails it on both dtypes
* The three `returned_algo_count` and three `ReduceShape` asserts are left alone; they state invariants that hold, and an out-of-range, negative, unsorted or over-long `axis:` already comes back as an exception
