### PR TITLE
Count bits a word at a time instead of one atomicAdd per element

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/bit_count.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_count.c
@@ -1,8 +1,7 @@
 #undef int_t
 #define int_t uint64_t
 
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, size_t *idx1, uint64_t n);
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, ssize_t s1, uint64_t n);
+void <%="cumo_#{c_iter}_chunk_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, char *p2, uint64_t n);
 void <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, size_t *idx1, ssize_t s2, uint64_t n);
 void <%="cumo_#{c_iter}_stride_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, ssize_t s1, ssize_t s2, uint64_t n);
 
@@ -21,11 +20,7 @@ static void
     CUMO_INIT_PTR(lp, 1, p2, s2);
 
     if (s2==0) {
-        if (idx1) {
-            <%="cumo_#{c_iter}_index_kernel_launch"%>(p1,p2,a1,idx1,i);
-        } else {
-            <%="cumo_#{c_iter}_stride_kernel_launch"%>(p1,p2,a1,s1,i);
-        }
+        <%="cumo_#{c_iter}_chunk_kernel_launch"%>(a1,p1,s1,idx1,p2,i);
     } else {
         if (idx1) {
             <%="cumo_#{c_iter}_index_stride_kernel_launch"%>(p1,p2,a1,idx1,s2,i);

--- a/ext/cumo/narray/gen/tmpl_bit/bit_count_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_count_kernel.cu
@@ -1,25 +1,21 @@
 #undef int_t
 #define int_t unsigned long long int
 
-__global__ void <%="cumo_#{c_iter}_index_kernel"%>(size_t p1, char* p2, CUMO_BIT_DIGIT *a1, size_t *idx1, uint64_t n)
+// One thread folds a whole word of bits at a time and one thread per block
+// reaches the accumulator, instead of one thread per bit each adding its own.
+__global__ void <%="cumo_#{c_iter}_chunk_kernel"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, char *p2, uint64_t n, uint64_t nw, uint64_t nc, int contiguous)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        CUMO_BIT_DIGIT x=0;
-        CUMO_LOAD_BIT(a1, p1 + idx1[i], x);
-        if (m_<%=name%>(x)) {
-            atomicAdd((int_t*)p2, (int_t)1);
-        }
-    }
-}
+    // m_<%=name%>(0) is 1 exactly when the zeros are what this method counts,
+    // which is the complement cumo_bit_chunk takes.
+    const int invert = m_<%=name%>(0);
+    uint64_t cnt = 0, total;
 
-__global__ void <%="cumo_#{c_iter}_stride_kernel"%>(size_t p1, char* p2, CUMO_BIT_DIGIT *a1, ssize_t s1, uint64_t n)
-{
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        CUMO_BIT_DIGIT x=0;
-        CUMO_LOAD_BIT(a1, p1 + i * s1, x);
-        if (m_<%=name%>(x)) {
-            atomicAdd((int_t*)p2, (int_t)1);
-        }
+    for (uint64_t c = blockIdx.x * blockDim.x + threadIdx.x; c < nc; c += blockDim.x * gridDim.x) {
+        cnt += (uint64_t)__popc(cumo_bit_chunk(a1, p1, s1, idx1, n, nw, c, contiguous, invert));
+    }
+    cumo_bit_block_exscan(cnt, &total);
+    if (threadIdx.x == 0 && total != 0) {
+        atomicAdd((int_t*)p2, (int_t)total);
     }
 }
 
@@ -45,19 +41,16 @@ __global__ void <%="cumo_#{c_iter}_stride_stride_kernel"%>(size_t p1, char* p2, 
     }
 }
 
-void <%="cumo_#{c_iter}_index_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, size_t *idx1, uint64_t n)
+void <%="cumo_#{c_iter}_chunk_kernel_launch"%>(CUMO_BIT_DIGIT *a1, size_t p1, ssize_t s1, size_t *idx1, char *p2, uint64_t n)
 {
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_index_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,idx1,n);
-    cumo_cuda_runtime_check_kernel_launch();
-}
+    uint64_t nc = (n + CUMO_NB - 1) / CUMO_NB;
+    int contiguous = (idx1 == NULL && s1 == 1);
+    uint64_t nw = contiguous ? (p1 + n + CUMO_NB - 1) / CUMO_NB : 0;
+    uint64_t nblocks = (nc + CUMO_BIT_CHUNK_BLOCK - 1) / CUMO_BIT_CHUNK_BLOCK;
 
-void <%="cumo_#{c_iter}_stride_kernel_launch"%>(size_t p1, char *p2, CUMO_BIT_DIGIT *a1, ssize_t s1, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{c_iter}_stride_kernel"%><<<grid_dim, block_dim>>>(p1,p2,a1,s1,n);
+    if (nc == 0) return;
+    if (nblocks > CUMO_MAX_GRID_DIM) nblocks = CUMO_MAX_GRID_DIM;
+    <%="cumo_#{c_iter}_chunk_kernel"%><<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a1,p1,s1,idx1,p2,n,nw,nc,contiguous);
     cumo_cuda_runtime_check_kernel_launch();
 }
 

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -206,6 +206,52 @@ class BitTest < Test::Unit::TestCase
     assert_equal(0, a[64].to_a.first)
   end
 
+  bits = proc { |n| (0...n).map { |i| (i * 7 + 3) % 5 == 0 ? 1 : 0 } }
+
+  [31, 32, 33, 63, 64, 65, 1000].each do |n|
+    test "count_true counts a whole array of #{n}" do
+      src = bits.call(n)
+      a = Cumo::Bit.cast(src)
+      assert { a.count_true == src.count(1) }
+      assert { a.count_false == src.count(0) }
+    end
+
+    test "count_true counts a view of #{n} that starts mid-word" do
+      src = bits.call(n)
+      a = Cumo::Bit.cast(src)
+      [1, 5, 30].each do |off|
+        assert { a[off..-1].count_true == src[off..-1].count(1) }
+        assert { a[off..-1].count_false == src[off..-1].count(0) }
+      end
+    end
+
+    test "count_true counts a view of #{n} that is not contiguous" do
+      src = bits.call(n)
+      a = Cumo::Bit.cast(src)
+      [2, 3, 7].each do |step|
+        want = (0...n).step(step).map { |i| src[i] }
+        assert { a[(0...n).step(step)].count_true == want.count(1) }
+        assert { a[(0...n).step(step)].count_false == want.count(0) }
+      end
+      assert { a[(n - 1).step(0, -1)].count_true == src[1..-1].count(1) }
+      idx = (0...n).select { |i| i % 11 == 4 }
+      assert { a[idx].count_true == idx.count { |i| src[i] == 1 } }
+      assert { a[idx].count_false == idx.count { |i| src[i] == 0 } }
+    end
+  end
+
+  test "count_true reduces along an axis across word boundaries" do
+    rows = 5
+    cols = 70
+    src = (0...rows).map { |r| bits.call(cols).rotate(r) }
+    a = Cumo::Bit.cast(src)
+    assert_equal(src.map { |row| row.count(1) }, a.count_true(axis: 1).to_a)
+    assert_equal(src.map { |row| row.count(0) }, a.count_false(axis: 1).to_a)
+    assert_equal(src.transpose.map { |col| col.count(1) }, a.count_true(axis: 0).to_a)
+    assert_equal(src.transpose.map { |col| col.count(1) }, a.transpose.count_true(axis: 1).to_a)
+    assert { a.count_true == src.flatten.count(1) }
+  end
+
   test "[]= on a frozen view raises whatever the subscript is" do
     # the store goes to a view derived from self, whose data object is the
     # root, so the check inside get_pointer_for_rw never reaches self


### PR DESCRIPTION
## Summary

`count_true` and `count_false` gave one thread to every bit and had each of those threads add its own hit to the output with a global `atomicAdd`. Both now give one thread a whole word, fold it with `__popc`, and reach the accumulator once per block.

- 16M bits, all true: 227.0 us -> 17.9 us; all false: 87.0 us -> 16.9 us
- the time no longer tracks how many bits are set, which is what the per-element atomic cost
- a step-2 view drops from 120.6 us to 26.5 us, and `where`, which sizes its output from `count_true`, from 116.4 us to 39.1 us
- `cumo_bit_chunk` already gathers a word for a contiguous, strided or index-backed loop, so the two former kernels collapse into one

## Problem

`&`, `|`, `all?` and `any?` were all given word-at-a-time kernels; the two counting methods were the ones left reading a bit per thread. On a 16M-bit array that is 16M loads of the same words and, in the worst case, 16M atomic increments of one address.

A standalone benchmark of the two shapes reproduces the measurement: for the same 16M bits the per-bit kernel with an atomic per hit takes 215.9 us and a word-at-a-time popcount takes 4.0 us.

## Note

Measured on an RTX 5070 Ti Laptop, one case per process, best of 9.

The added tests were checked against four mutations of the new kernel — dropping the partial last chunk, never inverting for `count_false`, always taking the contiguous path, and dropping blocks whose total is 1 — and each of them fails the suite.
