### PR TITLE
Give the bit probes the same byte count as the rest of the table

### DIFF
--- a/bench/cumo_probe.rb
+++ b/bench/cumo_probe.rb
@@ -69,6 +69,12 @@ end
 
 F32 = 4.0
 
+# A Bit element is a thirty-second of a word, so a bit probe takes that many
+# more columns and moves the same bytes as the rest of the table. Reporting a
+# bit array of COLS columns in GB/s put it 32x below every other row, where no
+# verdict could reach BAND_OK however fast the kernel ran.
+BITCOLS = COLS * 32
+
 # --- store and copy --------------------------------------------------------
 
 probe('store', 'store contig') do |rows, cols|
@@ -224,9 +230,16 @@ probe('reduce', 'cumsum contig') do |rows, cols|
   [-> { src.cumsum }, 2 * rows * cols * F32, 'GB']
 end
 
-probe('reduce', 'count_true') do |rows, cols|
-  bit = (XM::SFloat.new(rows, cols).seq > 0.5)
-  [-> { bit.count_true }, rows * cols / 8.0, 'GB']
+probe('reduce', 'count_true') do |rows, _cols|
+  bit = XM::UInt8.new(rows, BITCOLS).seq > 127
+  [-> { bit.count_true }, rows * BITCOLS / 8.0, 'GB']
+end
+
+# The peer for the row above: a reduction over the same bytes of the same dtype.
+# An all-ones array never lets all? stop early, so it reads every word.
+probe('reduce', 'all? contig') do |rows, _cols|
+  bit = XM::Bit.ones(rows, BITCOLS)
+  [-> { bit.all? }, rows * BITCOLS / 8.0, 'GB']
 end
 
 # --- GEMM ------------------------------------------------------------------
@@ -289,7 +302,7 @@ end
 
 puts "ruby      : #{RUBY_VERSION} (#{RUBY_PLATFORM})"
 puts "backend   : #{XM} #{version}"
-puts "params    : COLS=#{COLS} ROWS=#{ROWS.join(',')} REPS=#{REPS}"
+puts "params    : COLS=#{COLS} ROWS=#{ROWS.join(',')} REPS=#{REPS} (bit probes use #{BITCOLS} columns)"
 
 tiny = XM::SFloat.new(1).seq
 launch = measure(-> { tiny * 2.0 })


### PR DESCRIPTION
## Summary

The `count_true` row of the probe reported the packed bytes of a `COLS`-wide bit array, a thirty-second of what every other row moves. It now takes 32x the columns, so its GB/s can be read beside the rest of the table.

- 7.36 GB/s and a bare `?` becomes 251.49 GB/s and `ok (bandwidth)`
- against the kernel before #309 the same row reads 18.39 GB/s and `LAUNCH-BOUND`, which is the answer the old figure could not give
- adds `all?` as the peer for that row: a reduction over the same bytes of the same dtype, on an all-ones array so it never stops early

## Problem

`BAND_OK` is a fixed 50 GB/s, so a row whose operand is 32x smaller than the others can never earn a verdict however fast its kernel runs. `count_true` printed `?` whether it was healthy or not, and there was nothing beside it to compare against.
