### PR TITLE
Build a contiguous bit output a word at a time

### DIFF
--- a/ext/cumo/include/cumo/indexer.h
+++ b/ext/cumo/include/cumo/indexer.h
@@ -375,6 +375,36 @@ CUMO_NA_BIT_IARRAY_STRIDX_AT(3)
 CUMO_NA_BIT_IARRAY_STRIDX_AT(2)
 CUMO_NA_BIT_IARRAY_STRIDX_AT(0)
 
+// True when the loop writes the operand's bits end to end from a word boundary,
+// so element i of the loop is bit i of the operand and a warp of thirty-two
+// lanes owns one whole word of it.
+__host__ __device__
+static inline int
+cumo_na_bit_iarray_is_flat(cumo_na_bit_iarray_t* iarray, cumo_na_indexer_t* indexer) {
+    ssize_t acc = 1;
+    if (iarray->pos % CUMO_NB != 0) return 0;
+    for (int idim = indexer->ndim; --idim >= 0;) {
+        if (iarray->step[idim] != acc) return 0;
+        acc *= (ssize_t)indexer->shape[idim];
+    }
+    return 1;
+}
+
+// The same for an operand that may be backed by an index array, which is never
+// flat: it says nothing about where in the operand the next element lands.
+__host__ __device__
+static inline int
+cumo_na_bit_iarray_stridx_is_flat(cumo_na_bit_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer) {
+    ssize_t acc = 1;
+    if (iarray->pos % CUMO_NB != 0) return 0;
+    for (int idim = indexer->ndim; --idim >= 0;) {
+        if (!CUMO_SDX_IS_STRIDE(iarray->stridx[idim])) return 0;
+        if (CUMO_SDX_GET_STRIDE(iarray->stridx[idim]) != acc) return 0;
+        acc *= (ssize_t)indexer->shape[idim];
+    }
+    return 1;
+}
+
 // cumo_na_indexer_set_dim1 leaves index[] alone, so one dimension has to be
 // addressed through raw_index
 __host__ __device__

--- a/ext/cumo/include/cumo/narray_kernel.h
+++ b/ext/cumo/include/cumo/narray_kernel.h
@@ -165,6 +165,47 @@ typedef unsigned int CUMO_BIT_DIGIT;
 #define CUMO_BALL   (~(CUMO_BIT_DIGIT)0)
 #define CUMO_SLB(n) (((n)==CUMO_NB)?~(CUMO_BIT_DIGIT)0:(~(~(CUMO_BIT_DIGIT)0<<(n))))
 
+#ifdef __CUDACC__
+
+// The bits of word w that belong to a loop covering bits [p, p+n). The words at
+// either end are shared with elements the loop must not read or write.
+__device__ static inline CUMO_BIT_DIGIT
+cumo_bit_word_mask(size_t p, uint64_t n, uint64_t w)
+{
+    size_t lb = (w == 0) ? p : 0;
+    size_t hb = ((w + 1) * CUMO_NB <= p + n) ? CUMO_NB : (p + n - w * CUMO_NB);
+    return CUMO_SLB(hb) & ~CUMO_SLB(lb);
+}
+
+// Stores z as word w of a loop covering bits [p, p+n) of a. Only one thread
+// owns a word, so the partial words at either end need no atomic.
+__device__ static inline void
+cumo_bit_store_word(CUMO_BIT_DIGIT *a, uint64_t w, CUMO_BIT_DIGIT z, size_t p, uint64_t n)
+{
+    CUMO_BIT_DIGIT mask = cumo_bit_word_mask(p, n, w);
+    if (mask == CUMO_BALL) {
+        a[w] = z;
+    } else {
+        a[w] = (z & mask) | (a[w] & ~mask);
+    }
+}
+
+// Element i of a loop writing bits end to end from a word boundary, where a
+// warp's lanes hold one whole word of the output. The warp builds the word and
+// stores it once instead of every lane taking the word with an atomic. Every
+// lane must reach this, so a lane past the end of the loop passes zero.
+__device__ static inline void
+cumo_bit_store_ballot(CUMO_BIT_DIGIT *a, uint64_t i, CUMO_BIT_DIGIT b, uint64_t n)
+{
+    static_assert(CUMO_NB == 32, "a warp holds one bit digit");
+    CUMO_BIT_DIGIT z = __ballot_sync(0xffffffffu, b != 0);
+    if ((threadIdx.x & 31u) == 0) {
+        cumo_bit_store_word(a, i / CUMO_NB, z, 0, n);
+    }
+}
+
+#endif // __CUDACC__
+
 typedef union {
     ssize_t stride;
     size_t *index;

--- a/ext/cumo/include/cumo/types/bit_kernel.h
+++ b/ext/cumo/include/cumo/types/bit_kernel.h
@@ -55,29 +55,6 @@ cumo_bit_gather_word(const CUMO_BIT_DIGIT *a, ssize_t o, uint64_t nw, uint64_t w
     return x;
 }
 
-// The bits of word w that belong to a loop covering bits [p, p+n). The words at
-// either end are shared with elements the loop must not read or write.
-__device__ static inline CUMO_BIT_DIGIT
-cumo_bit_word_mask(size_t p, uint64_t n, uint64_t w)
-{
-    size_t lb = (w == 0) ? p : 0;
-    size_t hb = ((w + 1) * CUMO_NB <= p + n) ? CUMO_NB : (p + n - w * CUMO_NB);
-    return CUMO_SLB(hb) & ~CUMO_SLB(lb);
-}
-
-// Stores z as word w of a loop covering bits [p, p+n) of a. Only one thread
-// owns a word, so the partial words at either end need no atomic.
-__device__ static inline void
-cumo_bit_store_word(CUMO_BIT_DIGIT *a, uint64_t w, CUMO_BIT_DIGIT z, size_t p, uint64_t n)
-{
-    CUMO_BIT_DIGIT mask = cumo_bit_word_mask(p, n, w);
-    if (mask == CUMO_BALL) {
-        a[w] = z;
-    } else {
-        a[w] = (z & mask) | (a[w] & ~mask);
-    }
-}
-
 // Threads per block of the chunk scan below. The warp-shuffle scan is written
 // for a block that is a whole number of warps.
 #define CUMO_BIT_CHUNK_BLOCK 128

--- a/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_binary_kernel.cu
@@ -4,35 +4,48 @@
 // which would cost a whole kernel launch of its own to fill. It reaches the
 // left side through coerce, so use_scalar says which side it is on. It is the
 // same for every thread, so the branch costs nothing.
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_iarray_t a2, cumo_na_bit_iarray_t a3, cumo_na_indexer_t indexer, dtype sv, int use_scalar, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        dtype v = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        dtype x, y;
-        switch (use_scalar) {
-        case 1:  x = v; y = sv; break;
-        case 2:  x = sv; y = v; break;
-        default: x = v; y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT b = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            dtype v = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+            dtype x, y;
+            switch (use_scalar) {
+            case 1:  x = v; y = sv; break;
+            case 2:  x = sv; y = v; break;
+            default: x = v; y = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a2, &indexer);
+            }
+            b = (m_<%=name%>(x,y)) ? 1:0;
         }
-        CUMO_BIT_DIGIT b = (m_<%=name%>(x,y)) ? 1:0;
-        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a3, &indexer), b);
+        if (out) {
+            cumo_bit_store_ballot(out, i, b, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a3, &indexer), b);
+        }
     }
 }
 <% end %>
 
 static void <%="cumo_#{c_iter}_kernel_dispatch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_bit_iarray_t* a3, cumo_na_indexer_t* indexer, dtype sv, int use_scalar)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // A contiguous output gives each warp a whole word of it, which the warp
+    // builds with a ballot and stores once. Anything else keeps the atomic,
+    // since the lanes then hold bits of no one word.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,sv,use_scalar,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/cond_unary_kernel.cu
@@ -1,28 +1,41 @@
 <% unless type_name == 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_bit_iarray_t a2, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cumo_na_bit_iarray_t a2, cumo_na_indexer_t indexer, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
-        CUMO_BIT_DIGIT b = (m_<%=name%>(x)) ? 1:0;
-        CUMO_STORE_BIT(a2.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a2, &indexer), b);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT b = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            dtype x = *(dtype*)cumo_na_iarray_at_dim<%=idim%>(&a1, &indexer);
+            b = (m_<%=name%>(x)) ? 1:0;
+        }
+        if (out) {
+            cumo_bit_store_ballot(out, i, b, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a2.ptr, cumo_na_bit_iarray_at_dim<%=idim%>(&a2, &indexer), b);
+        }
     }
 }
 <% end %>
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_bit_iarray_t* a2, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // A contiguous output gives each warp a whole word of it, which the warp
+    // builds with a ballot and stores once. Anything else keeps the atomic,
+    // since the lanes then hold bits of no one word.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_is_flat(a2, indexer) ? a2->ptr + a2->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/ext/cumo/narray/gen/tmpl_bit/store_from_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_from_kernel.cu
@@ -1,28 +1,41 @@
 <% unless c_iter.include? 'robject' %>
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_iarray_stridx_t a2, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_iarray_stridx_t a2, cumo_na_indexer_t indexer, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        char* p2 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a2, &indexer);
-        CUMO_BIT_DIGIT y = <%=macro%>(*(<%=dtype%>*)(p2));
-        CUMO_STORE_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), y);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT y = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            char* p2 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a2, &indexer);
+            y = <%=macro%>(*(<%=dtype%>*)(p2));
+        }
+        if (out) {
+            cumo_bit_store_ballot(out, i, y, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), y);
+        }
     }
 }
 <% end %>
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_iarray_stridx_t* a2, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // A contiguous output gives each warp a whole word of it, which the warp
+    // builds with a ballot and stores once. Anything else keeps the atomic,
+    // since the lanes then hold bits of no one word.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a1, indexer) ? a1->ptr + a1->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -269,4 +269,62 @@ class BitTest < Test::Unit::TestCase
     w[1..2] = 1
     assert_equal([0, 1, 1, 1, 0], a.to_a)
   end
+
+  # A contiguous bit output is built a word at a time by a whole warp, so the
+  # sizes that matter are the ones around a word and the operands whose output
+  # is not contiguous and has to fall back.
+  [1, 31, 32, 33, 63, 64, 65, 129, 1000].each do |n|
+    src = proc { (0...n).map { |i| (i % 7) - 3 } }
+
+    test "a comparison fills #{n} bits" do
+      want = src.call.map { |x| x > 0 ? 1 : 0 }
+      a = Cumo::Int32.cast(src.call)
+      assert_equal(want, (a > 0).to_a)
+      assert_equal(want.map { |x| 1 - x }, (a <= 0).to_a)
+      assert_equal(want, Cumo::SFloat.cast(src.call).gt(0).to_a)
+      assert_equal(src.call.map { |x| x == 1 ? 1 : 0 }, a.eq(1).to_a)
+      assert_equal(want, (0 < a).to_a)
+    end
+
+    test "a cast to Bit fills #{n} bits" do
+      assert_equal(src.call.map { |x| x.zero? ? 0 : 1 }, Cumo::Bit.cast(Cumo::Int32.cast(src.call)).to_a)
+    end
+
+    test "a comparison of a non-contiguous operand fills #{n} bits" do
+      wide = (0...(2 * n)).map { |i| (i % 7) - 3 }
+      a = Cumo::Int32.cast(wide).reshape(n, 2)
+      assert_equal((0...n).map { |i| wide[2 * i] > 0 ? 1 : 0 }, (a[true, 0] > 0).to_a)
+      assert_equal((0...n).map { |i| wide[2 * i + 1] > 0 ? 1 : 0 }, (a[true, 1] > 0).to_a)
+      assert_equal(wide.map { |x| x > 0 ? 1 : 0 }, (a.transpose > 0).transpose.flatten.to_a)
+    end
+
+    test "a comparison writing into a bit view fills #{n} bits" do
+      a = Cumo::Int32.cast(src.call)
+      [0, 1, 5, 32].each do |off|
+        b = Cumo::Bit.zeros(n + 64)
+        b[off...(off + n)] = (a > 0)
+        want = [0] * off + src.call.map { |x| x > 0 ? 1 : 0 } + [0] * (64 - off)
+        assert_equal(want, b.to_a)
+      end
+      b = Cumo::Bit.zeros(2 * n)
+      b[(0...(2 * n)).step(2)] = (a > 0)
+      assert_equal((0...(2 * n)).map { |i| i.odd? ? 0 : (src.call[i / 2] > 0 ? 1 : 0) }, b.to_a)
+    end
+
+    # The elements past the end of the last word belong to the rest of the
+    # array, so filling that word must leave them as they were. A destination
+    # of ones is what makes an unmasked store show up.
+    test "a store into a bit view of #{n} leaves the rest of it alone" do
+      a = Cumo::Int32.cast(src.call)
+      want = src.call.map { |x| x.zero? ? 0 : 1 }
+      [0, 1, 5, 31, 32, 33, 64].each do |off|
+        b = Cumo::Bit.ones(n + 128)
+        b[off...(off + n)] = a
+        assert_equal([1] * off + want + [1] * (128 - off), b.to_a)
+        b = Cumo::Bit.ones(n + 128)
+        b[off...(off + n)].store(a)
+        assert_equal([1] * off + want + [1] * (128 - off), b.to_a)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`CUMO_STORE_BIT` takes the word with `atomicOr` or `atomicAnd` once per element, so the thirty-two threads that share a word serialise on it. Where the output is laid out end to end from a word boundary, a warp now builds its whole word with `__ballot_sync` and stores it once.

- 4M elements: `a > 0.5` 459.0 us -> 31.5 us, `a.isnan` 459.0 -> 31.1, `Bit.cast(Int32)` 455.8 -> 35.2
- covers the thirteen methods on `cond_binary` and `cond_unary` — `eq` `ne` `nearly_eq` `gt` `ge` `lt` `le` `signbit` `isnan` `isinf` `isposinf` `isneginf` `isfinite` — and Bit's `store_from`
- only the output's layout decides, so a strided input still takes it: a 2-D colslice goes 457.9 -> 48.1 us
- an output that is not contiguous, or that starts mid-word, keeps the atomic

## Problem

A comparison moves a third of the bytes the multiply beside it moves and took twelve times as long. A standalone benchmark of the two shapes gives 201.1 us for the atomic per element and 19.9 us for the ballot over the same 4M bits.

The mirror pair says the same: reading bits one at a time and writing a whole dtype (`Int32.cast(bit)`) is 38.4 us, while reading a whole dtype and writing bits one at a time (`Bit.cast(Int32)`) was 455.8. Only the write side was expensive.

## Note

Measured on an RTX 5070 Ti Laptop, one case per process, best of 9. `cumo.so` grows 2.7%.

Five mutations were injected into the new path. Three fail the suite: dropping the top bit of every word, storing the last word unmasked, and calling a mid-word view flat. Two do not and are kept anyway — not rounding the loop up to a whole warp, and letting a short loop shrink the block below a warp — since both leave `__ballot_sync` named for threads that are not there, which this GPU happens to tolerate. An instrumented store confirms those paths do run.
