### PR TITLE
Keep the word at a time bit store when the operand is a view

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
@@ -1,13 +1,20 @@
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a2, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a2, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        CUMO_BIT_DIGIT x, y;
-        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
-        CUMO_LOAD_BIT(a2.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a2, &indexer), y);
-        CUMO_BIT_DIGIT z = m_<%=name%>(x,y) & 1u;
-        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), z);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT z = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            CUMO_BIT_DIGIT x, y;
+            CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
+            CUMO_LOAD_BIT(a2.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a2, &indexer), y);
+            z = m_<%=name%>(x,y) & 1u;
+        }
+        if (out) {
+            cumo_bit_store_ballot(out, i, z, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), z);
+        }
     }
 }
 <% end %>
@@ -23,16 +30,22 @@ __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssiz
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a2, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // Only the output decides: a warp holds one whole word of it however the
+    // operand is laid out, so the lanes can pool their bits into that word
+    // rather than each taking it with an atomic.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*a3,*indexer,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
@@ -1,11 +1,17 @@
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        CUMO_BIT_DIGIT x;
-        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
-        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), x);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
+        }
+        if (out) {
+            cumo_bit_store_ballot(out, i, x, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), x);
+        }
     }
 }
 <% end %>
@@ -20,16 +26,22 @@ __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssiz
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // Only the output decides: a warp holds one whole word of it however the
+    // operand is laid out, so the lanes can pool their bits into that word
+    // rather than each taking it with an atomic.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
@@ -1,12 +1,19 @@
 <% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
-__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer)
+__global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a3, cumo_na_indexer_t indexer, uint64_t end, CUMO_BIT_DIGIT *out)
 {
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
-        CUMO_BIT_DIGIT x;
-        CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
-        CUMO_BIT_DIGIT y = m_<%=name%>(x) & 1u;
-        CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), y);
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < end; i += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT y = 0;
+        if (i < indexer.total_size) {
+            cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+            CUMO_BIT_DIGIT x;
+            CUMO_LOAD_BIT(a1.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a1, &indexer), x);
+            y = m_<%=name%>(x) & 1u;
+        }
+        if (out) {
+            cumo_bit_store_ballot(out, i, y, indexer.total_size);
+        } else {
+            CUMO_STORE_BIT(a3.ptr, cumo_na_bit_iarray_stridx_at_dim<%=idim%>(&a3, &indexer), y);
+        }
     }
 }
 <% end %>
@@ -21,16 +28,22 @@ __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssiz
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_na_bit_iarray_stridx_t* a3, cumo_na_indexer_t* indexer)
 {
-    size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
-    size_t block_dim = cumo_get_block_dim(indexer->total_size);
+    // Only the output decides: a warp holds one whole word of it however the
+    // operand is laid out, so the lanes can pool their bits into that word
+    // rather than each taking it with an atomic.
+    CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+    uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
+    size_t grid_dim = cumo_get_grid_dim(end);
+    // the ballot needs whole warps, so a short loop cannot shrink the block
+    size_t block_dim = out ? CUMO_MAX_BLOCK_DIM : cumo_get_block_dim(end);
     switch (indexer->ndim) {
     <% (0..opt_indexer_ndim).each do |idim| %>
     case <%=idim%>:
-        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer,end,out);
         break;
     <% end %>
     default:
-        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer);
+        <%="cumo_#{c_iter}_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a3,*indexer,end,out);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -270,6 +270,63 @@ class BitTest < Test::Unit::TestCase
     assert_equal([0, 1, 1, 1, 0], a.to_a)
   end
 
+  # The word at a time store needs only the output contiguous, so these check
+  # the operand shapes that used to fall back to one atomic per element.
+  [1, 31, 32, 33, 64, 65, 1000].each do |n|
+    make = proc { Cumo::Bit.cast((0...(2 * n)).map { |i| (i * 5 + 1) % 3 == 0 ? 1 : 0 }) }
+
+    test "a bit operation on a strided operand of #{n}" do
+      a = make.call
+      [2, 3, 7].each do |st|
+        v = a[(0...(2 * n)).step(st)]
+        rows = v.to_a
+        assert_equal(rows.map { |x| 1 - x }, (~v).to_a)
+        assert_equal(rows, (v & v).to_a)
+        assert_equal([0] * v.size, (v ^ v).to_a)
+        assert_equal(rows, Cumo::Bit.new(v.size).store(v).to_a)
+      end
+      rev = a[(2 * n - 1).step(0, -1)]
+      assert_equal(rev.to_a.map { |x| 1 - x }, (~rev).to_a)
+      idx = (0...(2 * n)).select { |i| i % 13 == 2 }
+      assert_equal(a[idx].to_a.map { |x| 1 - x }, (~a[idx]).to_a)
+      assert_equal(a[idx].to_a, Cumo::Bit.new(idx.size).store(a[idx]).to_a)
+    end
+
+    test "a bit operation on an operand of #{n} that starts mid-word" do
+      a = make.call
+      [1, 5, 31, 33].each do |off|
+        next if off + n > 2 * n
+        v = a[off...(off + n)]
+        assert_equal(v.to_a.map { |x| 1 - x }, (~v).to_a)
+        assert_equal(v.to_a, Cumo::Bit.new(n).store(v).to_a)
+      end
+    end
+
+    # The destination is not contiguous here, so the atomic has to stay: the
+    # elements it does not own belong to the rest of the array.
+    test "a bit operation writing into a view of #{n} leaves the rest alone" do
+      a = make.call[0...n]
+      want = a.to_a.map { |x| 1 - x }
+      [0, 1, 5, 32, 33, 64].each do |off|
+        d = Cumo::Bit.ones(n + 128)
+        d[off...(off + n)] = ~a
+        assert_equal([1] * off + want + [1] * (128 - off), d.to_a)
+      end
+      d = Cumo::Bit.ones(2 * n)
+      d[(0...(2 * n)).step(2)] = ~a
+      assert_equal((0...(2 * n)).map { |i| i.odd? ? 1 : want[i / 2] }, d.to_a)
+    end
+  end
+
+  test "a bit operation on a transposed operand" do
+    r, c = 33, 65
+    a = Cumo::Bit.cast((0...r).map { |i| (0...c).map { |j| (i + j) % 3 == 0 ? 1 : 0 } })
+    t = a.transpose
+    assert_equal(t.to_a.map { |row| row.map { |x| 1 - x } }, (~t).to_a)
+    assert_equal(t.to_a, (t & t).to_a)
+    assert_equal(t.to_a, Cumo::Bit.new(c, r).store(t).to_a)
+  end
+
   # A contiguous bit output is built a word at a time by a whole warp, so the
   # sizes that matter are the ones around a word and the operands whose output
   # is not contiguous and has to fall back.


### PR DESCRIPTION
## Summary

The word at a time store #311 gave the comparisons is what Bit's own operations were still missing whenever an operand was not laid out end to end. Only the output decides whether a warp owns a whole word of it, so `~`, `&`, `|`, `^`, `eq` and `store` now keep that store when the operand is a view.

- 4M elements: `~view` 475.9 us -> 34.5 us, `view & view` 481.5 -> 42.6, `Bit#store(view)` 466.5 -> 34.5, a transposed operand 554.5 -> 77.1
- an index-backed or reversed operand takes it too: the lanes read their own bits however they like and only pool them at the end
- an output that is not contiguous, or that starts mid-word, still keeps the atomic

## Problem

Every one of these was around sixty-seven times its contiguous self — 470 to 550 us against 7 us — because the thirty-two lanes that share an output word each took it with `atomicOr` or `atomicAnd`. The existing contiguous kernel needs *both* operands flat, so a single strided view dropped the whole operation back to one atomic per element.

## Note

Measured on an RTX 5070 Ti Laptop, one case per process, best of 9. `cumo.so` grows 1.1%.

Three mutations fail the suite: deciding from the operand instead of the output, always taking the ballot, and dropping a bit of every word. The first two show up only through `store_bit` — a unary or binary operation cannot have an output whose layout differs from its operand's in a way a result can show.
