### PR TITLE
Scatter one element per lane instead of one word per thread

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
@@ -5,28 +5,26 @@
 // rather than the flat index, so the result indexes that array's data.
 __global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, uint64_t nchunks, uint64_t cpb, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t *block_sums)
 {
-    uint64_t start = blockIdx.x * cpb;
-    uint64_t end = (nchunks - start < cpb) ? nchunks : start + cpb;
+    uint64_t startc = blockIdx.x * cpb;
+    uint64_t endc = (nchunks - startc < cpb) ? nchunks : startc + cpb;
     uint64_t off = block_sums[blockIdx.x];
-    uint64_t c0;
+    uint64_t start, end, i0;
 
-    if (start > nchunks) { start = end = nchunks; }
-    for (c0 = start; c0 < end; c0 += blockDim.x) {
-        uint64_t c = c0 + threadIdx.x;
-        CUMO_BIT_DIGIT z = 0;
+    if (startc > nchunks) { startc = endc = nchunks; }
+    start = startc * CUMO_NB;
+    end = (endc * CUMO_NB < n) ? endc * CUMO_NB : n;
+    for (i0 = start; i0 < end; i0 += blockDim.x) {
+        uint64_t i = i0 + threadIdx.x;
+        CUMO_BIT_DIGIT x = 0;
         uint64_t total;
         uint64_t pre;
-        uint64_t o;
 
-        if (c < end) {
-            z = cumo_bit_chunk(a, p, s, idx, n, nw, c, contiguous, 0);
+        if (i < end) {
+            CUMO_LOAD_BIT(a, cumo_bit_pos(p, s, idx, i), x);
         }
-        pre = cumo_bit_block_exscan((uint64_t)__popc(z), &total);
-        o = off + pre;
-        while (z) {
-            uint64_t j = c * CUMO_NB + (uint64_t)(__ffs(z) - 1);
-            out[o++] = idx2 ? p2 + idx2[j] : (size_t)((ssize_t)p2 + (ssize_t)j * s2);
-            z &= z - 1;
+        pre = cumo_bit_block_exscan(x, &total);
+        if (x) {
+            out[off + pre] = idx2 ? p2 + idx2[i] : (size_t)((ssize_t)p2 + (ssize_t)i * s2);
         }
         off += total;
         __syncthreads();

--- a/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
@@ -50,30 +50,32 @@ __global__ void cumo_bit_where_scan_kernel(uint64_t *block_sums, uint64_t nblock
     }
 }
 
+// The scatter takes an element per lane rather than a chunk, so that the lanes
+// that do write land next to each other. A thread that owned a whole chunk wrote
+// a run of its own, which put the lanes of a warp a run apart.
 __global__ void cumo_bit_where_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, int invert, uint64_t nchunks, uint64_t cpb, char *out, size_t elmsz, uint64_t count, uint64_t *block_sums)
 {
-    uint64_t start = blockIdx.x * cpb;
-    uint64_t end = (nchunks - start < cpb) ? nchunks : start + cpb;
+    uint64_t startc = blockIdx.x * cpb;
+    uint64_t endc = (nchunks - startc < cpb) ? nchunks : startc + cpb;
     uint64_t off = block_sums[blockIdx.x];
-    uint64_t c0;
+    uint64_t start, end, i0;
 
-    if (start > nchunks) { start = end = nchunks; }
-    for (c0 = start; c0 < end; c0 += blockDim.x) {
-        uint64_t c = c0 + threadIdx.x;
-        CUMO_BIT_DIGIT z = 0;
+    if (startc > nchunks) { startc = endc = nchunks; }
+    start = startc * CUMO_NB;
+    end = (endc * CUMO_NB < n) ? endc * CUMO_NB : n;
+    for (i0 = start; i0 < end; i0 += blockDim.x) {
+        uint64_t i = i0 + threadIdx.x;
+        CUMO_BIT_DIGIT x = 0;
         uint64_t total;
         uint64_t pre;
-        uint64_t o;
 
-        if (c < end) {
-            z = cumo_bit_chunk(a, p, s, idx, n, nw, c, contiguous, invert);
+        if (i < end) {
+            CUMO_LOAD_BIT(a, cumo_bit_pos(p, s, idx, i), x);
+            if (invert) x = !x;
         }
-        pre = cumo_bit_block_exscan((uint64_t)__popc(z), &total);
-        o = off + pre;
-        while (z) {
-            int k = __ffs(z) - 1;
-            cumo_bit_store_index(out, elmsz, o++, count + c * CUMO_NB + k);
-            z &= z - 1;
+        pre = cumo_bit_block_exscan(x, &total);
+        if (x) {
+            cumo_bit_store_index(out, elmsz, off + pre, count + i);
         }
         off += total;
         __syncthreads();

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -252,6 +252,66 @@ class BitTest < Test::Unit::TestCase
     assert { a.count_true == src.flatten.count(1) }
   end
 
+  # where, where2 and mask only reach the device below
+  # CUMO_BIT_WHERE_MIN_KERNEL_SIZE, which is 8192, so these are the sizes that
+  # exercise the compaction rather than the host loop. 4096 elements is one
+  # block's range, so the sizes straddle that too.
+  [8192, 8193, 12_289, 100_003].each do |n|
+    patterns = {
+      "all true" => proc { |i| 1 },
+      "all false" => proc { |i| 0 },
+      "sparse" => proc { |i| i % 97 == 3 ? 1 : 0 },
+      "mixed" => proc { |i| (i * 7 + i / 13) % 3 == 0 ? 1 : 0 }
+    }
+    patterns.each do |kind, gen|
+      test "where and mask over #{n} #{kind} bits" do
+        src = (0...n).map { |i| gen.call(i) }
+        a = Cumo::Bit.cast(src)
+        f = Cumo::SFloat.new(n).seq
+        ones = (0...n).select { |i| src[i] == 1 }
+        zeros = (0...n).select { |i| src[i].zero? }
+        assert_equal(ones, a.where.to_a)
+        assert_equal([ones, zeros], a.where2.map(&:to_a))
+        assert_equal(ones.map(&:to_f), f[a].to_a)
+        assert_equal(ones.size, a.count_true[0])
+      end
+    end
+
+    test "where and mask over a view of #{n} bits" do
+      src = (0...(2 * n)).map { |i| (i * 5 + 2) % 4 == 0 ? 1 : 0 }
+      a = Cumo::Bit.cast(src)
+      f = Cumo::SFloat.new(2 * n).seq
+      [2, 3].each do |st|
+        r = (0...(2 * n)).step(st)
+        want = r.each_with_index.select { |j, _| src[j] == 1 }.map { |_, k| k }
+        assert_equal(want, a[r].where.to_a)
+        assert_equal(want.map { |k| (k * st).to_f }, f[r][a[r]].to_a)
+      end
+      [1, 5, 33].each do |off|
+        want = (0...n).select { |i| src[off + i] == 1 }
+        assert_equal(want, a[off...(off + n)].where.to_a)
+        assert_equal(want.map { |i| (off + i).to_f }, f[off...(off + n)][a[off...(off + n)]].to_a)
+      end
+      rev = (2 * n - 1).step(0, -1)
+      assert_equal((0...(2 * n)).select { |k| src[2 * n - 1 - k] == 1 }, a[rev].where.to_a)
+    end
+  end
+
+  # The cursor that orders one loop segment after the next lives on the device,
+  # so a shape that ndloop walks in more than one segment is its own case.
+  test "where and mask over a multi-dimensional mask" do
+    r, c = 70, 1000
+    src = (0...(r * c)).map { |i| (i * 3 + 1) % 5 == 0 ? 1 : 0 }
+    a = Cumo::Bit.cast(src).reshape(r, c)
+    f = Cumo::DFloat.new(r * c).seq.reshape(r, c)
+    ones = (0...(r * c)).select { |i| src[i] == 1 }
+    assert_equal(ones, a.where.to_a)
+    assert_equal(ones.map(&:to_f), f[a].to_a)
+    t = (0...(r * c)).select { |k| src[(k % r) * c + k / r] == 1 }
+    assert_equal(t, a.transpose.where.to_a)
+    assert_equal(t.map { |k| ((k % r) * c + k / r).to_f }, f.transpose[a.transpose].to_a)
+  end
+
   test "[]= on a frozen view raises whatever the subscript is" do
     # the store goes to a view derived from self, whose data object is the
     # root, so the check inside get_pointer_for_rw never reaches self


### PR DESCRIPTION
## Summary

The compaction behind `where`, `where2` and `mask` gave each thread a whole word of the mask and had it write that word's hits in a loop of its own, which put the lanes of a warp a run apart. Each lane now takes one element, so the lanes that do write land next to each other.

- 4M elements: `mask` (`f[bit]`) 193.8 us -> 106.2 us, `where` 131.4 -> 74.1
- the scatter kernel itself goes 170.5 us -> 82.8 us, which is 406 GB/s for the 33.6 MB it writes and matches what a standalone kernel of that shape reaches
- the block ranges are unchanged, so the count and scan phases stay as they were

## Problem

For an all-true mask each thread wrote thirty-two consecutive `size_t`, so at any one instruction the thirty-two lanes of a warp were writing addresses 256 bytes apart — one sector each. The counting phase is right to work a word at a time, since it only reads; the scatter is the phase that writes, and it wants the opposite layout.

A standalone benchmark of the two shapes over the same 4M elements gives 100.6 us for a chunk per thread and 79.3 us for an element per lane, the latter being the bandwidth the output alone costs.

## Note

Measured on an RTX 5070 Ti Laptop, one case per process, best of 9.

`CUMO_BIT_WHERE_MIN_KERNEL_SIZE` is 8192, so the existing tests for these methods all ran on the host loop. The tests added here start at that size. Four mutations fail the suite: dropping the clamp to n on the last block, dropping the invert `where2` needs, not advancing the cursor between iterations, and dropping the element stride in `mask`.
