### PR TITLE
Reduce mulsum in one kernel instead of one per output

### DIFF
--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -162,18 +162,21 @@ __device__ static inline ssize_t axes_offset(const cumo_na_iarray_t& iarray, con
     return off;
 }
 
+// The input side takes the iarray and the indexer rather than the whole
+// reduction arg, so that mulsum can address its second operand with the same
+// indexer and a step set of its own.
 template <bool FLAT>
-__device__ static inline ssize_t reduce_in_out_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, int64_t i_out) {
+__device__ static inline ssize_t reduce_in_out_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, int64_t i_out) {
     if (FLAT || ad.in_out_flat) return i_out * ad.in_out_step;
     if (ad.split < 0) return 0;
-    return axes_offset(arg.in, arg.in_indexer, 0, ad.split, i_out);
+    return axes_offset(in, in_indexer, 0, ad.split, i_out);
 }
 
 template <bool FLAT>
-__device__ static inline ssize_t reduce_in_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, ssize_t in_out_off, int64_t i_reduce, int64_t i_in) {
+__device__ static inline ssize_t reduce_in_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ssize_t in_out_off, int64_t i_reduce, int64_t i_in) {
     if (FLAT || ad.in_reduce_flat) return in_out_off + i_reduce * ad.in_reduce_step;
-    if (ad.split < 0) return axes_offset(arg.in, arg.in_indexer, 0, arg.in_indexer.ndim, i_in);
-    return in_out_off + axes_offset(arg.in, arg.in_indexer, ad.split, arg.in_indexer.ndim, i_reduce);
+    if (ad.split < 0) return axes_offset(in, in_indexer, 0, in_indexer.ndim, i_in);
+    return in_out_off + axes_offset(in, in_indexer, ad.split, in_indexer.ndim, i_reduce);
 }
 
 template <bool FLAT>
@@ -221,14 +224,14 @@ __device__ static inline TypeReduce reduce_in_block(TypeReduce accum, TypeReduce
 // the offset of the element from the start of the input, which is the index
 // (min|max)_index answers with.
 template <bool FLAT, bool ARG_INDEX, typename TypeIn, typename ReductionImpl>
-__device__ static inline auto reduce_axis(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, ReductionImpl& impl,
+__device__ static inline auto reduce_axis(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ReductionImpl& impl,
         ssize_t in_out_off, int64_t i_in, int64_t begin, int64_t end, int64_t reduce_offset, int64_t reduce_block_size) -> decltype(impl.Identity(0)) {
     using TypeReduce = decltype(impl.Identity(0));
 
-    char* in_base = arg.in.ptr;
+    char* in_base = in.ptr;
     TypeIn* in_head = reinterpret_cast<TypeIn*>(in_base);
     int64_t i_reduce = begin + reduce_offset;
-    char* p = in_base + reduce_in_offset<FLAT>(arg, ad, in_out_off, i_reduce, i_in);
+    char* p = in_base + reduce_in_offset<FLAT>(in, in_indexer, ad, in_out_off, i_reduce, i_in);
     ssize_t advance = ad.in_reduce_step * reduce_block_size;
 
     TypeReduce accum = ARG_INDEX ? impl.Identity(reduce_offset)
@@ -239,7 +242,38 @@ __device__ static inline auto reduce_axis(const cumo_na_reduction_arg_t& arg, co
         impl.Reduce(impl.MapIn(*in_ptr, ARG_INDEX ? i_reduce : static_cast<int64_t>(in_ptr - in_head)), accum);
         p = (FLAT || ad.in_reduce_flat)
             ? p + advance
-            : in_base + reduce_in_offset<FLAT>(arg, ad, in_out_off, i_reduce + reduce_block_size, i_in + reduce_block_size);
+            : in_base + reduce_in_offset<FLAT>(in, in_indexer, ad, in_out_off, i_reduce + reduce_block_size, i_in + reduce_block_size);
+    }
+    return accum;
+}
+
+// Reduces one output element's slice of the reduce axis over two inputs at
+// once, which is what mulsum wants: the product it accumulates never exists as
+// an array. The pair comes out of one broadcast, so arg.in_indexer addresses
+// both and only the steps differ, which is what in2 and ad2 carry.
+template <bool FLAT, typename TypeIn, typename ReductionImpl>
+__device__ static inline auto reduce_axis_zip(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& in2,
+        const cumo_reduce_addr_t& ad, const cumo_reduce_addr_t& ad2, ReductionImpl& impl,
+        ssize_t in_out_off, ssize_t in_out_off2, int64_t i_in, int64_t begin, int64_t end,
+        int64_t reduce_offset, int64_t reduce_block_size) -> decltype(impl.Identity(0)) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    int64_t i_reduce = begin + reduce_offset;
+    char* p = arg.in.ptr + reduce_in_offset<FLAT>(arg.in, arg.in_indexer, ad, in_out_off, i_reduce, i_in);
+    char* q = in2.ptr + reduce_in_offset<FLAT>(in2, arg.in_indexer, ad2, in_out_off2, i_reduce, i_in);
+    ssize_t advance = ad.in_reduce_step * reduce_block_size;
+    ssize_t advance2 = ad2.in_reduce_step * reduce_block_size;
+
+    TypeReduce accum = impl.Identity(0);
+
+    for (; i_reduce < end; i_reduce += reduce_block_size, i_in += reduce_block_size) {
+        impl.Reduce(impl.MapIn(*reinterpret_cast<TypeIn*>(p), *reinterpret_cast<TypeIn*>(q), i_reduce), accum);
+        p = (FLAT || ad.in_reduce_flat)
+            ? p + advance
+            : arg.in.ptr + reduce_in_offset<FLAT>(arg.in, arg.in_indexer, ad, in_out_off, i_reduce + reduce_block_size, i_in + reduce_block_size);
+        q = (FLAT || ad2.in_reduce_flat)
+            ? q + advance2
+            : in2.ptr + reduce_in_offset<FLAT>(in2, arg.in_indexer, ad2, in_out_off2, i_reduce + reduce_block_size, i_in + reduce_block_size);
     }
     return accum;
 }
@@ -264,10 +298,43 @@ __global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, cumo_reduce
     int64_t out_stride = gridDim.x * out_block_size;
 
     for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
         int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
+        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg.in, arg.in_indexer, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
+
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            TypeOut* out_ptr = reinterpret_cast<TypeOut*>(arg.out.ptr + reduce_out_offset<FLAT>(arg, ad, i_out));
+            *out_ptr = impl.MapOut(accum);
+        }
+    }
+}
+
+// Variant of reduction_kernel reading two inputs, for mulsum. See
+// reduce_axis_zip above.
+template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
+__global__ static void reduction_zip_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, cumo_reduce_addr_t ad, cumo_reduce_addr_t ad2, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
+        ssize_t in_out_off2 = reduce_in_out_offset<FLAT>(in2, arg.in_indexer, ad2, i_out);
+        int64_t i_in = i_out * reduce_total_size + reduce_offset;
+
+        TypeReduce accum = reduce_axis_zip<FLAT,TypeIn>(arg, in2, ad, ad2, impl, in_out_off, in_out_off2, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
         accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
         if (reduce_offset == 0) {
@@ -296,10 +363,10 @@ __global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, cumo_re
     int64_t out_stride = gridDim.x * out_block_size;
 
     for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
         int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-        TypeReduce accum = reduce_axis<FLAT,true,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
+        TypeReduce accum = reduce_axis<FLAT,true,TypeIn>(arg.in, arg.in_indexer, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
         accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
         if (reduce_offset == 0) {
@@ -329,10 +396,10 @@ __global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_n
     int64_t out_stride = gridDim.x * out_block_size;
 
     for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
         int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
-        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
+        TypeReduce accum = reduce_axis<FLAT,false,TypeIn>(arg.in, arg.in_indexer, ad, impl, in_out_off, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
 
         accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
         if (reduce_offset == 0) {
@@ -371,10 +438,45 @@ __global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cum
         int64_t begin = i_split * chunk;
         int64_t end = begin + chunk;
         if (end > reduce_total_size) end = reduce_total_size;
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg, ad, i_out);
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
         int64_t i_in = i_out * reduce_total_size + begin + reduce_offset;
 
-        TypeReduce accum = reduce_axis<FLAT,ARG,TypeIn>(arg, ad, impl, in_out_off, i_in, begin, end, reduce_offset, reduce_block_size);
+        TypeReduce accum = reduce_axis<FLAT,ARG,TypeIn>(arg.in, arg.in_indexer, ad, impl, in_out_off, i_in, begin, end, reduce_offset, reduce_block_size);
+
+        accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            partial[i_out * n_split + i_split] = accum;
+        }
+    }
+}
+
+// First pass of a split zip reduction. See reduction_partial_kernel above.
+template <bool FLAT, typename TypeIn, typename TypeReduce, typename ReductionImpl>
+__global__ static void reduction_zip_partial_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, cumo_reduce_addr_t ad, cumo_reduce_addr_t ad2, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+    extern __shared__ __align__(8) char sdata_raw[];
+    TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+    int64_t partial_total_size = out_total_size * n_split;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i = out_base + out_offset; i < partial_total_size; i += out_stride) {
+        int64_t i_out = i % out_total_size;
+        int64_t i_split = i / out_total_size;
+        int64_t begin = i_split * chunk;
+        int64_t end = begin + chunk;
+        if (end > reduce_total_size) end = reduce_total_size;
+        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
+        ssize_t in_out_off2 = reduce_in_out_offset<FLAT>(in2, arg.in_indexer, ad2, i_out);
+        int64_t i_in = i_out * reduce_total_size + begin + reduce_offset;
+
+        TypeReduce accum = reduce_axis_zip<FLAT,TypeIn>(arg, in2, ad, ad2, impl, in_out_off, in_out_off2, i_in, begin, end, reduce_offset, reduce_block_size);
 
         accum = reduce_in_block(accum, sdata, tid, out_block_size, impl);
         if (reduce_offset == 0) {
@@ -426,6 +528,40 @@ TypeReduce* reduce_partial_pass(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t 
         reduction_partial_kernel<true,ARG,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     } else {
         reduction_partial_kernel<false,ARG,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, ad, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+
+    arg2->in.ptr = reinterpret_cast<char*>(partial);
+    arg2->in.step[0] = sizeof(TypeReduce);
+    arg2->in_indexer.ndim = 1;
+    arg2->in_indexer.shape[0] = partial_total_size;
+    arg2->in_indexer.total_size = partial_total_size;
+    return partial;
+}
+
+// True when both operands of a zip reduction walk by a single stride, which is
+// what lets the offset helpers drop their decomposition.
+static inline bool zip_axes_are_flat(const cumo_reduce_addr_t& ad, const cumo_reduce_addr_t& ad2) {
+    return ad.in_out_flat && ad.in_reduce_flat && ad2.in_out_flat && ad2.in_reduce_flat;
+}
+
+// First pass of a split zip reduction. See reduce_partial_pass above.
+template <typename TypeIn, typename TypeReduce, typename ReductionImpl>
+TypeReduce* reduce_zip_partial_pass(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, cumo_reduce_addr_t ad, cumo_reduce_addr_t ad2, int64_t n_split, int64_t reduce_total_size, cumo_na_reduction_arg_t* arg2, ReductionImpl& impl) {
+    int64_t chunk = (reduce_total_size + n_split - 1) / n_split;
+    int64_t partial_total_size = arg.out_indexer.total_size * n_split;
+    TypeReduce* partial = reinterpret_cast<TypeReduce*>(cumo_cuda_runtime_malloc(sizeof(TypeReduce) * partial_total_size));
+
+    int64_t out_block_size, reduce_block_size;
+    reduce_block_split(ad, chunk, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (partial_total_size + out_block_size - 1) / out_block_size;
+    int64_t grid_size = std::min(max_grid_size, out_block_num);
+    int64_t shared_mem_size = sizeof(TypeReduce) * max_block_size;
+
+    if (zip_axes_are_flat(ad, ad2)) {
+        reduction_zip_partial_kernel<true,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, in2, ad, ad2, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
+    } else {
+        reduction_zip_partial_kernel<false,TypeIn,TypeReduce,ReductionImpl><<<grid_size, max_block_size, shared_mem_size>>>(arg, in2, ad, ad2, partial, n_split, chunk, out_block_size, reduce_block_size, impl);
     }
     cumo_cuda_runtime_check_kernel_launch();
 
@@ -493,6 +629,68 @@ void cumo_reduce_split(cumo_na_reduction_arg_t arg, ReductionImpl&& impl) {
     cumo_na_reduction_arg_t arg2 = arg;
     TypeReduce* partial = cumo_detail::reduce_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, ad, n_split, reduce_total_size, &arg2, impl);
     cumo_reduce<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(arg2, cumo_detail::reduce_combine<ReductionImpl>{impl});
+    cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
+}
+
+// Variant of cumo_reduce reading two inputs, for mulsum. in2 describes the same
+// shape as arg.in, since the one in_indexer addresses both.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_zip(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, ReductionImpl&& impl) {
+    if (arg.out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_na_reduction_arg_t arg2 = arg;
+    arg2.in = in2;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+    cumo_detail::cumo_reduce_addr_t ad2 = cumo_detail::make_reduce_addr(arg2, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t block_size = cumo_detail::max_block_size;
+    int64_t grid_size = std::min(cumo_detail::max_grid_size, out_block_num);
+    int64_t shared_mem_size = sizeof(decltype(impl.Identity(0))) * block_size;
+
+    if (cumo_detail::zip_axes_are_flat(ad, ad2) && ad.out_flat) {
+        cumo_detail::reduction_zip_kernel<true,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, in2, ad, ad2, out_block_size, reduce_block_size, impl);
+    } else {
+        cumo_detail::reduction_zip_kernel<false,TypeIn,TypeOut,ReductionImpl><<<grid_size, block_size, shared_mem_size>>>(arg, in2, ad, ad2, out_block_size, reduce_block_size, impl);
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+// cumo_reduce_split for a zip reduction. The first pass reads both operands and
+// the combine pass has only accumulators left, so it is the plain one.
+template <typename TypeIn, typename TypeOut, typename ReductionImpl>
+void cumo_reduce_zip_split(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, ReductionImpl&& impl) {
+    using TypeReduce = decltype(impl.Identity(0));
+
+    if (arg.out_indexer.total_size == 0) {
+        return;
+    }
+
+    int64_t reduce_total_size = arg.in_indexer.total_size / arg.out_indexer.total_size;
+    cumo_na_reduction_arg_t arg2 = arg;
+    arg2.in = in2;
+    cumo_detail::cumo_reduce_addr_t ad = cumo_detail::make_reduce_addr(arg, reduce_total_size);
+    cumo_detail::cumo_reduce_addr_t ad2 = cumo_detail::make_reduce_addr(arg2, reduce_total_size);
+
+    int64_t out_block_size, reduce_block_size;
+    cumo_detail::reduce_block_split(ad, reduce_total_size, &out_block_size, &reduce_block_size);
+    int64_t out_block_num = (arg.out_indexer.total_size + out_block_size - 1) / out_block_size;
+
+    int64_t n_split = cumo_detail::reduce_split_count(reduce_total_size, out_block_num);
+    if (n_split < 2) {
+        cumo_reduce_zip<TypeIn, TypeOut, ReductionImpl>(arg, in2, std::forward<ReductionImpl>(impl));
+        return;
+    }
+
+    cumo_na_reduction_arg_t combine = arg;
+    TypeReduce* partial = cumo_detail::reduce_zip_partial_pass<TypeIn, TypeReduce, ReductionImpl>(arg, in2, ad, ad2, n_split, reduce_total_size, &combine, impl);
+    cumo_reduce<TypeReduce, TypeOut, cumo_detail::reduce_combine<ReductionImpl>>(combine, cumo_detail::reduce_combine<ReductionImpl>{impl});
     cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }
 

--- a/ext/cumo/narray/gen/tmpl/accum_binary.c
+++ b/ext/cumo/narray/gen/tmpl/accum_binary.c
@@ -1,25 +1,24 @@
 //<% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
 <% unless type_name == 'robject' %>
-void <%="cumo_#{type_name}_#{name}#{nan}_reduce_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, uint64_t n);
-void <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n);
+void <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* in2);
 <% end %>
 
 static void
 <%=c_iter%><%=nan%>(cumo_na_loop_t *const lp)
 {
-    size_t   n;
-    char    *p1, *p2, *p3;
-    ssize_t  s1, s2, s3;
-
-    CUMO_INIT_COUNTER(lp, n);
-    CUMO_INIT_PTR(lp, 0, p1, s1);
-    CUMO_INIT_PTR(lp, 1, p2, s2);
-    CUMO_INIT_PTR(lp, 2, p3, s3);
-
     <% if type_name == 'robject' %>
     {
+        size_t   n;
+        char    *p1, *p2, *p3;
+        ssize_t  s1, s2, s3;
         size_t i;
+
+        CUMO_INIT_COUNTER(lp, n);
+        CUMO_INIT_PTR(lp, 0, p1, s1);
+        CUMO_INIT_PTR(lp, 1, p2, s2);
+        CUMO_INIT_PTR(lp, 2, p3, s3);
+
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
         if (s3==0) {
             dtype z;
@@ -46,12 +45,11 @@ static void
     }
     <% else %>
     {
-        if (s3==0) {
-            <%="cumo_#{type_name}_#{name}#{nan}_reduce_kernel_launch"%>(p1,p2,p3,s1,s2,n);
-            return;
-        } else {
-            <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(p1,p2,p3,s1,s2,s3,n);
-        }
+        // The two operands come out of one broadcast, so the reduction arg's
+        // indexer addresses both and the second only has to carry its steps.
+        cumo_na_reduction_arg_t arg = cumo_na_make_reduction_arg(lp, 2);
+        cumo_na_iarray_t in2 = cumo_na_make_iarray_given_ndim(&lp->args[1], lp->args[0].ndim);
+        <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(&arg, &in2);
     }
     <% end %>
 }
@@ -62,9 +60,16 @@ static VALUE
 {
     VALUE v, reduce;
     VALUE naryv[2];
+    //<% if type_name == 'robject' %>
     cumo_ndfunc_arg_in_t ain[4] = {{cT,0},{cT,0},{cumo_sym_reduce,0},{cumo_sym_init,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP_NIP, 4, 1, ain, aout };
+    <% else %>
+    VALUE a1, a2;
+    cumo_ndfunc_arg_in_t ain[3] = {{cT,0},{cT,0},{cumo_sym_reduce,0}};
+    cumo_ndfunc_arg_out_t aout[1] = {{cT,0}};
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_INDEXER_LOOP, 3, 1, ain, aout };
+    <% end %>
 
     if (argc < 1) {
         rb_raise(rb_eArgError,"wrong number of arguments (%d for >=1)",argc);
@@ -78,7 +83,18 @@ static VALUE
     reduce = cumo_na_reduce_dimension(argc-1, argv+1, 2, naryv, &ndf, 0);
     //<% end %>
 
+    //<% if type_name == 'robject' %>
     v =  cumo_na_ndloop(&ndf, 4, self, argv[0], reduce, m_<%=name%>_init);
+    <% else %>
+    // The reduction addresses its operands itself and cannot follow an index
+    // array, so a view backed by one is made contiguous first.
+    a1 = cumo_na_has_idx_p(self) ? cumo_na_copy(self) : self;
+    a2 = argv[0];
+    if (CumoIsNArray(a2) && cumo_na_has_idx_p(a2)) {
+        a2 = cumo_na_copy(a2);
+    }
+    v =  cumo_na_ndloop(&ndf, 3, a1, a2, reduce);
+    <% end %>
     return <%=type_name%>_extract(v);
 }
 

--- a/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/accum_binary_kernel.cu
@@ -2,93 +2,42 @@
 <% $cumo_narray_gen_tmpl_accum_binary_kernel_included = 1 %>
 
 <% unless type_name == 'robject' %>
-// One output at a time, so the reduce is a plain block tree over n elements of
-// two operands. Enough blocks to fill the device, then one block folds their
-// partials and adds the result to whatever the init argument left in the output.
-#define CUMO_MULSUM_BLOCK_DIM 512
-#define CUMO_MULSUM_MAX_GRID_DIM 1024
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
 
 //<% (is_float ? ["","_nan"] : [""]).each do |nan| %>
 
-__device__ static void <%="cumo_#{type_name}_#{name}#{nan}_block_reduce"%>(dtype *sdata, dtype acc)
+// The product is never an array of its own: MapIn takes one element of each
+// operand, which is what a zip reduction hands it. The accumulator stays dtype
+// rather than widening, as the host loop it replaces did.
+struct <%="cumo_#{type_name}_#{name}#{nan}_impl"%> {
+    __device__ dtype Identity(int64_t /*index*/) { return m_zero; }
+    __device__ dtype MapIn(dtype x, dtype y, int64_t /*index*/) {
+        dtype z = m_zero;
+        m_<%=name%><%=nan%>(x, y, z);
+        return z;
+    }
+    __device__ void Reduce(dtype next, dtype& accum) { accum = m_add(next, accum); }
+    __device__ dtype MapOut(dtype accum) { return accum; }
+};
+//<% end %>
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+//<% (is_float ? ["","_nan"] : [""]).each do |nan| %>
+void <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(cumo_na_reduction_arg_t* arg, cumo_na_iarray_t* in2)
 {
-    sdata[threadIdx.x] = acc;
-    __syncthreads();
-    for (unsigned int stride = CUMO_MULSUM_BLOCK_DIM / 2; stride > 0; stride >>= 1) {
-        if (threadIdx.x < stride) {
-            sdata[threadIdx.x] = m_add(sdata[threadIdx.x], sdata[threadIdx.x + stride]);
-        }
-        __syncthreads();
-    }
-}
-
-// Writes its block's partial to partial[blockIdx.x], or straight to the output
-// when the grid is one block and there is nothing left to combine.
-__global__ void <%="cumo_#{type_name}_#{name}#{nan}_partial_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, uint64_t n, dtype *partial)
-{
-    __shared__ dtype sdata[CUMO_MULSUM_BLOCK_DIM];
-    dtype acc = m_zero;
-
-    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        dtype x = *(dtype*)(p1 + i * s1);
-        dtype y = *(dtype*)(p2 + i * s2);
-        m_<%=name%><%=nan%>(x, y, acc);
-    }
-    <%="cumo_#{type_name}_#{name}#{nan}_block_reduce"%>(sdata, acc);
-    if (threadIdx.x == 0) {
-        if (partial) {
-            partial[blockIdx.x] = sdata[0];
-        } else {
-            *(dtype*)p3 = m_add(*(dtype*)p3, sdata[0]);
-        }
-    }
-}
-
-__global__ void <%="cumo_#{type_name}_#{name}#{nan}_combine_kernel"%>(char *p3, dtype *partial, uint64_t n)
-{
-    __shared__ dtype sdata[CUMO_MULSUM_BLOCK_DIM];
-    dtype acc = m_zero;
-
-    for (uint64_t i = threadIdx.x; i < n; i += CUMO_MULSUM_BLOCK_DIM) {
-        acc = m_add(acc, partial[i]);
-    }
-    <%="cumo_#{type_name}_#{name}#{nan}_block_reduce"%>(sdata, acc);
-    if (threadIdx.x == 0) {
-        *(dtype*)p3 = m_add(*(dtype*)p3, sdata[0]);
-    }
-}
-
-__global__ void <%="cumo_#{type_name}_#{name}#{nan}_kernel"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
-{
-    for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-        m_<%=name%><%=nan%>(*(dtype*)(p1+(i*s1)), *(dtype*)(p2+(i*s2)), *(dtype*)(p3+(i*s3)));
-    }
-}
-
-void <%="cumo_#{type_name}_#{name}#{nan}_reduce_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, uint64_t n)
-{
-    uint64_t grid_dim = (n + CUMO_MULSUM_BLOCK_DIM - 1) / CUMO_MULSUM_BLOCK_DIM;
-    dtype *partial = NULL;
-
-    if (grid_dim == 0) grid_dim = 1;
-    if (grid_dim > CUMO_MULSUM_MAX_GRID_DIM) grid_dim = CUMO_MULSUM_MAX_GRID_DIM;
-    if (grid_dim > 1) {
-        partial = (dtype*)cumo_cuda_runtime_malloc(sizeof(dtype) * grid_dim);
-    }
-    <%="cumo_#{type_name}_#{name}#{nan}_partial_kernel"%><<<grid_dim, CUMO_MULSUM_BLOCK_DIM>>>(p1,p2,p3,s1,s2,n,partial);
-    if (partial) {
-        <%="cumo_#{type_name}_#{name}#{nan}_combine_kernel"%><<<1, CUMO_MULSUM_BLOCK_DIM>>>(p3,partial,grid_dim);
-        cumo_cuda_runtime_free((char*)partial);
-    }
-    cumo_cuda_runtime_check_kernel_launch();
-}
-
-void <%="cumo_#{type_name}_#{name}#{nan}_kernel_launch"%>(char *p1, char *p2, char *p3, ssize_t s1, ssize_t s2, ssize_t s3, uint64_t n)
-{
-    size_t grid_dim = cumo_get_grid_dim(n);
-    size_t block_dim = cumo_get_block_dim(n);
-    <%="cumo_#{type_name}_#{name}#{nan}_kernel"%><<<grid_dim, block_dim>>>(p1,p2,p3,s1,s2,s3,n);
-    cumo_cuda_runtime_check_kernel_launch();
+    cumo_reduce_zip_split<dtype, dtype, <%="cumo_#{type_name}_#{name}#{nan}_impl"%>>(*arg, *in2, <%="cumo_#{type_name}_#{name}#{nan}_impl"%>{});
 }
 //<% end %>
 <% end %>

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -813,6 +813,47 @@ class NArrayTest < Test::Unit::TestCase
         c = a[(0..5).step(2)].reverse(0)
         assert { c.mulsum(c, axis: 0) == (c * c).sum(axis: 0) }
       end
+
+      # The reduction addresses each operand with a step set of its own, so the
+      # two do not have to be laid out alike. The reference is the same call
+      # with both made contiguous, which holds for every dtype: comparing
+      # against an elementwise product would widen where mulsum does not.
+      test "mulsum where the two operands have different layouts" do
+        a = small.call([4, 3])
+        b = small.call([4, 3])
+        [[a, b.reverse(0)],
+         [a.reverse(1), b],
+         [a[(0..3).step(2), true], b[(0..3).step(2), true]],
+         [a[[3, 1, 0, 2], true], b],
+         [a, b[[2, 0, 1, 3], true]],
+         [a.transpose, b.transpose],
+         [a.transpose, b.transpose.copy]].each do |x, y|
+          [0, 1].each do |axis|
+            assert { x.mulsum(y, axis: axis) == x.copy.mulsum(y.copy, axis: axis) }
+          end
+        end
+      end
+
+      # A thread walks the reduce axis by a stride of its own only once the axis
+      # outruns the threads a block hands it, so a short one never gets there.
+      test "mulsum walks a long reduce axis on both operands" do
+        n = 1100
+        a = small.call([n, 2])
+        b = small.call([n, 2])
+        [[a, b.reverse(0)],
+         [a.reverse(0), b],
+         [a.reverse(0), b.reverse(0)],
+         [a[(0...n).step(3), true], b[(0...n).step(3), true]],
+         [a[(0...n).step(3), true], b[(0...n).step(3), true].copy]].each do |x, y|
+          assert { x.mulsum(y, axis: 0) == x.copy.mulsum(y.copy, axis: 0) }
+        end
+      end
+
+      test "mulsum keeps the reduced axes when asked" do
+        a = small.call([2, 3, 4])
+        assert { a.mulsum(a, axis: 1, keepdims: true) == (a * a).sum(axis: 1, keepdims: true) }
+        assert { a.mulsum(a, axis: [0, 1], keepdims: true) == (a * a).sum(axis: [0, 1], keepdims: true) }
+      end
     end
 
     sub_test_case "#{dtype}, #dot" do
@@ -3161,6 +3202,12 @@ class NArrayTest < Test::Unit::TestCase
     v = Array.new(cols) { |i| ((i % 5) - 2).to_f }
     assert_equal((0...rows).map { |r| (0...cols).sum { |c| xs[r * cols + c] * v[c] } },
                  g.mulsum(Cumo::DFloat.cast(v), axis: 1).to_a)
+
+    # transposed, the reduce axis is the outer one and neither operand walks by
+    # a single stride
+    want = (0...rows).map { |r| (0...cols).sum { |c| xs[r * cols + c] * ys[r * cols + c] } }
+    assert_equal(want, g.transpose.mulsum(h.transpose, axis: 0).to_a)
+    assert_equal(want, g.transpose.mulsum(h.transpose.copy, axis: 0).to_a)
   end
 
   # the multi-dimensional index of the i-th element of a C-contiguous shape


### PR DESCRIPTION
`mulsum` was the only reduction still on the plain stride loop, so ndloop called its iterator once per output element and each call launched a whole reduction of its own. A 512x2048 `mulsum(axis: 1)` fired two kernels and a device malloc and free for each of its 512 rows; `(a * b).sum(axis: 1)`, which materialises the product first, was 90x faster than the method meant to avoid it.

* Give `mulsum` `CUMO_NDF_INDEXER_LOOP` so the whole reduction reaches one launch, the way `sum` and the other reductions already do
* Add `cumo_reduce_zip` and `cumo_reduce_zip_split`, which walk a second iarray beside the first so the product never becomes an array
* Take the iarray and the indexer on the input side of the offset helpers rather than the whole reduction arg, since the two operands come out of one broadcast and share an indexer
* A view backed by an index array is made contiguous first, as the other reductions do

512x2048 SFloat, one case per process, minimum of five:

| | before | after | `sum` for comparison |
|---|---|---|---|
| `mulsum(b, axis: 1)` | 1758.8us | 13.6us | 12.5us |
| `mulsum(b, axis: 0)` | 856.2us | 15.2us | 13.9us |
| `mulsum(b)` | 20.0us | 14.5us | 13.0us |

Tests cover operands that are not laid out alike -- reversed, transposed, strided and index-backed on either side -- and a reduce axis long enough that a thread walks it by a stride of its own, which is where the two step sets have to stay apart. Both new tests were checked against injected faults: mixing up the two stride sets fails the long-axis test on all twelve numeric dtypes, and dropping the index-array copy fails the layout test on all twelve.
