### PR TITLE
Build flatten's index array on the device

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -516,15 +516,15 @@ cumo_na_reshape(int argc, VALUE *argv, VALUE self)
 
 //----------------------------------------------------------------------
 
+void cumo_na_flatten_index_kernel_launch(size_t *idx, cumo_na_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer);
+
 VALUE
 cumo_na_flatten_dim(VALUE self, int sd)
 {
     int i, nd, fd;
-    size_t j, ofs;
-    size_t *c, *pos, *idx1, *idx2;
+    size_t *idx1, *idx2;
     size_t stride;
     size_t  *shape, size;
-    cumo_stridx_t sdx;
     cumo_narray_t *na;
     cumo_narray_view_t *na1, *na2;
     volatile VALUE view;
@@ -577,10 +577,6 @@ cumo_na_flatten_dim(VALUE self, int sd)
         for (i=0; i<sd; i++) {
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                // idx2 = ALLOC_N(size_t, shape[i]);
-                // for (j=0; j<shape[i]; j++) {
-                //     idx2[j] = idx1[j];
-                // }
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[i]);
                 cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*shape[i],cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
@@ -592,44 +588,20 @@ cumo_na_flatten_dim(VALUE self, int sd)
         if (RTEST(cumo_na_check_ladder(self,sd))) {
             na2->stridx[sd] = na1->stridx[nd-1];
         } else {
-            // set index
-            // idx2 = ALLOC_N(size_t, (shape[sd]==0) ? 1 : shape[sd]);
+            cumo_na_iarray_stridx_t iarray;
+            cumo_na_indexer_t indexer;
+
             idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*((shape[sd]==0) ? 1 : shape[sd]));
             CUMO_SDX_SET_INDEX(na2->stridx[sd],idx2);
-            // init for md-loop
             fd = nd-sd;
-            c = ALLOCA_N(size_t, fd);
-            for (i=0; i<fd; i++) c[i]=0;
-            pos = ALLOCA_N(size_t, fd+1);
-            pos[0] = 0;
-            // md-loop
-            CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("na_flatten_dim", "any");
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-            for (i=j=0;;) {
-                for (; i<fd; i++) {
-                    sdx = na1->stridx[i+sd];
-                    if (CUMO_SDX_IS_INDEX(sdx)) {
-                        if (CUMO_SDX_GET_INDEX(sdx)) {
-                            ofs = CUMO_SDX_GET_INDEX(sdx)[c[i]];
-                        } else {
-                            ofs = 0;
-                        }
-                    } else {
-                        ofs = CUMO_SDX_GET_STRIDE(sdx)*c[i];
-                    }
-                    pos[i+1] = pos[i] + ofs;
-                }
-                idx2[j++] = pos[i];
-                for (;;) {
-                    if (i==0) goto loop_end;
-                    i--;
-                    c[i]++;
-                    if (c[i] < na1->base.shape[i+sd]) break;
-                    c[i] = 0;
-                }
+            iarray.ptr = NULL;
+            indexer.ndim = fd;
+            indexer.total_size = shape[sd];
+            for (i=0; i<fd; i++) {
+                indexer.shape[i] = na1->base.shape[i+sd];
+                iarray.stridx[i] = na1->stridx[i+sd];
             }
-        loop_end:
-            ;
+            cumo_na_flatten_index_kernel_launch(idx2, &iarray, &indexer);
         }
         break;
     }

--- a/ext/cumo/narray/data_kernel.cu
+++ b/ext/cumo/narray/data_kernel.cu
@@ -40,6 +40,55 @@ __global__ void cumo_na_diagonal_stride_index_kernel(size_t *idx, ssize_t s0, si
     }
 }
 
+// flatten builds an index array whenever the dimensions it collapses do not
+// come out as one stride. Filling it on the host meant a size_t store per
+// element into memory the device owns, which faults a page at a time: a
+// 512x2048 column slice took 2.4 ms, and the copy that follows faults every
+// page back. The offsets are the same mixed-radix walk the host loop did.
+#define CUMO_NA_FLATTEN_INDEX_KERNEL(NDIM) \
+__global__ void cumo_na_flatten_index_kernel_dim##NDIM(size_t *idx, cumo_na_iarray_stridx_t iarray, cumo_na_indexer_t indexer) \
+{ \
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) { \
+        uint64_t rest = i; \
+        size_t pos = 0; \
+        for (int idim = NDIM; --idim >= 0;) { \
+            uint64_t c = rest % indexer.shape[idim]; \
+            rest /= indexer.shape[idim]; \
+            if (CUMO_SDX_IS_INDEX(iarray.stridx[idim])) { \
+                size_t *idim_idx = CUMO_SDX_GET_INDEX(iarray.stridx[idim]); \
+                if (idim_idx) pos += idim_idx[c]; \
+            } else { \
+                pos += (size_t)(CUMO_SDX_GET_STRIDE(iarray.stridx[idim]) * (ssize_t)c); \
+            } \
+        } \
+        idx[i] = pos; \
+    } \
+}
+
+CUMO_NA_FLATTEN_INDEX_KERNEL(1)
+CUMO_NA_FLATTEN_INDEX_KERNEL(2)
+CUMO_NA_FLATTEN_INDEX_KERNEL(3)
+CUMO_NA_FLATTEN_INDEX_KERNEL(4)
+
+__global__ void cumo_na_flatten_index_kernel_dim(size_t *idx, cumo_na_iarray_stridx_t iarray, cumo_na_indexer_t indexer)
+{
+    for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
+        uint64_t rest = i;
+        size_t pos = 0;
+        for (int idim = indexer.ndim; --idim >= 0;) {
+            uint64_t c = rest % indexer.shape[idim];
+            rest /= indexer.shape[idim];
+            if (CUMO_SDX_IS_INDEX(iarray.stridx[idim])) {
+                size_t *idim_idx = CUMO_SDX_GET_INDEX(iarray.stridx[idim]);
+                if (idim_idx) pos += idim_idx[c];
+            } else {
+                pos += (size_t)(CUMO_SDX_GET_STRIDE(iarray.stridx[idim]) * (ssize_t)c);
+            }
+        }
+        idx[i] = pos;
+    }
+}
+
 // Copying a whole view in one launch, so that ndloop does not have to walk the
 // outer dimensions itself. It synchronizes once per outer step when an operand
 // carries an index array, which for a gathered view costs far more than the
@@ -126,6 +175,32 @@ void cumo_iter_copy_bytes_indexer_kernel_launch(cumo_na_iarray_t* a1, cumo_na_ia
         break;
     default:
         cumo_iter_copy_bytes_indexer_kernel_dim<<<grid_dim, block_dim>>>(*a1, *a2, *indexer, elmsz);
+        break;
+    }
+    cumo_cuda_runtime_check_kernel_launch();
+}
+
+void cumo_na_flatten_index_kernel_launch(size_t *idx, cumo_na_iarray_stridx_t* iarray, cumo_na_indexer_t* indexer)
+{
+    size_t grid_dim, block_dim;
+    if (indexer->total_size == 0) return;
+    grid_dim = cumo_get_grid_dim(indexer->total_size);
+    block_dim = cumo_get_block_dim(indexer->total_size);
+    switch (indexer->ndim) {
+    case 1:
+        cumo_na_flatten_index_kernel_dim1<<<grid_dim, block_dim>>>(idx, *iarray, *indexer);
+        break;
+    case 2:
+        cumo_na_flatten_index_kernel_dim2<<<grid_dim, block_dim>>>(idx, *iarray, *indexer);
+        break;
+    case 3:
+        cumo_na_flatten_index_kernel_dim3<<<grid_dim, block_dim>>>(idx, *iarray, *indexer);
+        break;
+    case 4:
+        cumo_na_flatten_index_kernel_dim4<<<grid_dim, block_dim>>>(idx, *iarray, *indexer);
+        break;
+    default:
+        cumo_na_flatten_index_kernel_dim<<<grid_dim, block_dim>>>(idx, *iarray, *indexer);
         break;
     }
     cumo_cuda_runtime_check_kernel_launch();

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3174,6 +3174,43 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  # A view whose dimensions do not collapse into one stride cannot be flattened
+  # by adjusting the strides, so flatten builds an index array for it. That path
+  # is the one worth pinning down; the ladder path is a metadata change.
+  test "flatten lists a non-contiguous view in row-major order" do
+    [[6], [6, 5], [4, 3, 2], [3, 2, 2, 2], [2, 2, 2, 2, 2]].each do |shape|
+      n = shape.reduce(:*)
+      wide = Cumo::Int32.new(*shape.each_with_index.map { |s, i| i.zero? ? s : s * 2 }).seq(1)
+      rotate = shape.each_with_index.map { |s, i| i.zero? ? (0...s).to_a.rotate(1) : true }
+      views = {
+        contig: Cumo::Int32.new(*shape).seq(1),
+        slice: wide[*shape.each_with_index.map { |s, i| i.zero? ? true : (0...s) }],
+        step2: wide[*shape.each_with_index.map { |s, i| i.zero? ? true : (0...(s * 2)).step(2) }],
+        reverse: Cumo::Int32.new(*shape).seq(1).reverse(0),
+        index: Cumo::Int32.new(*shape).seq(1)[*rotate]
+      }
+      views[:transpose] = Cumo::Int32.new(*shape.reverse).seq(1).transpose if shape.size > 1
+      views.each do |name, v|
+        want = v.to_a
+        want = want.flatten while want.first.is_a?(Array)
+        at = "#{shape.inspect} #{name}"
+        assert_equal([n], v.flatten.shape, at)
+        assert_equal(want, v.flatten.to_a, at)
+        assert_equal(want, v.flatten.copy.to_a, "#{at} copy")
+        assert_equal(want, v[(0...n).to_a].to_a, "#{at} flat aref")
+      end
+    end
+  end
+
+  test "flatten of a view writes through to its source" do
+    a = Cumo::Int32.new(4, 6).seq(1)
+    f = a[true, 0...3].flatten
+    f[0] = 999
+    f[7] = 888
+    assert_equal(999, a.to_a[0][0])
+    assert_equal(888, a.to_a[2][1])
+  end
+
   test "mulsum over long axes, views and broadcasts" do
     rows = 5
     cols = 40_000


### PR DESCRIPTION
`flatten` collapses the dimensions it is given by adjusting the strides when they come out as one stride, and by building an index array when they do not. cumo allocates that index array on the device -- `cumo_cuda_runtime_malloc`, so `cudaMallocManaged` -- but kept numo's host loop to fill it, storing a `size_t` per element into memory the device owns. It also had to `cudaDeviceSynchronize` first, since the loop reads the operand's own index arrays.

The cost is a flat 2.32 ns per element whatever the shape: 131k elements 241.1us, 262k 614.9us, 524k 1225.7us, 1M 2432.6us, 2M 4875.2us.

* Fill the index array with a kernel, unrolled for one to four dimensions and with a general form beyond that
* Drop the synchronize, since the kernel reads those index arrays where they already live
* `reshape` was never on this path -- it dups and rewrites the shape -- which is why the same flattening through `reshape` was already sixteen times faster

512x2048 SFloat, one case per process, minimum of five, three runs:

| | before | after |
|---|---|---|
| `col.flatten` | 2448.5us | 529.1us |
| `col.flatten.copy` | 4633.0us | 578.1us |
| `transposed.flatten` | 2446.5us | 553.4us |
| `index_backed.flatten` | 2379.3us | 541.6us |

What is left is not the index build. The index array is 8MB for a 4MB operand, and a fresh 8MB managed allocation filled by any kernel costs about that much on its own: in the same nsys capture a plain `seq` writing 8MB took 1.59ms, more per byte than the new kernel's 789us. `cudaMemPrefetchAsync` on the allocation makes it worse, not better (529 -> 721us). That floor belongs to the allocator, not to `flatten`, so the probe row this came from is improved but not yet in line with its peers.

Tests cover flatten and `flatten.copy` over contiguous, sliced, strided, reversed, transposed and index-backed views at one through five dimensions -- which reaches every arm of the dispatch -- plus the flat subscript that goes through the same function, and writing through the flattened view. Checked against injected faults: reversing the mixed-radix order fails both new tests and two existing ones, and treating an index dimension as a stride or dispatching the wrong arity dumps core.
