### PR TITLE
Copy an ndloop buffer one element per thread, not one row

### DIFF
--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1113,6 +1113,13 @@ cumo_ndfunc_set_bufcp(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
                 sz *= n;
             }
             LBUFCP(lp,j) = ALLOC(cumo_na_buffer_copy_t);
+            LBUFCP(lp,j)->buf_on_device = cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr);
+            if (LBUFCP(lp,j)->buf_on_device) {
+                // The copy below runs one thread per element, so a contracted
+                // element leaves a whole row to a single thread.
+                ndim = nd;
+                elmsz = LARG(lp,j).elmsz;
+            }
             LBUFCP(lp,j)->ndim = ndim;
             LBUFCP(lp,j)->elmsz = elmsz;
             LBUFCP(lp,j)->n = buf_shape;
@@ -1121,7 +1128,6 @@ cumo_ndfunc_set_bufcp(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
             LARG(lp,j).iter = buf_iter;
             //printf("in cumo_ndfunc_set_bufcp(1): lp->user.args[%d].iter=%lx\n",j,(size_t)(LARG(lp,j).iter));
             LBUFCP(lp,j)->src_ptr = LARG(lp,j).ptr;
-            LBUFCP(lp,j)->buf_on_device = cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr);
             if (LBUFCP(lp,j)->buf_on_device) {
                 LARG(lp,j).ptr = LBUFCP(lp,j)->buf_ptr = cumo_cuda_runtime_malloc(sz);
             }

--- a/ext/cumo/narray/ndloop_kernel.cu
+++ b/ext/cumo/narray/ndloop_kernel.cu
@@ -32,12 +32,20 @@ CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(1)
 CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(2)
 CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(3)
 CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(4)
+CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(5)
+CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(6)
+CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(7)
+CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL(8)
 CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL()
 
 CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(1)
 CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(2)
 CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(3)
 CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(4)
+CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(5)
+CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(6)
+CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(7)
+CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL(8)
 CUMO_NDLOOP_COPY_TO_BUFFER_KERNEL()
 
 #undef CUMO_NDLOOP_COPY_FROM_BUFFER_KERNEL
@@ -59,6 +67,18 @@ void cumo_ndloop_copy_from_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo
             break;
         case 4:
             cumo_ndloop_copy_from_buffer_kernel_dim4<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 5:
+            cumo_ndloop_copy_from_buffer_kernel_dim5<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 6:
+            cumo_ndloop_copy_from_buffer_kernel_dim6<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 7:
+            cumo_ndloop_copy_from_buffer_kernel_dim7<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 8:
+            cumo_ndloop_copy_from_buffer_kernel_dim8<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
             break;
         default:
             cumo_ndloop_copy_from_buffer_kernel_dim<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
@@ -83,6 +103,18 @@ void cumo_ndloop_copy_to_buffer_kernel_launch(cumo_na_iarray_stridx_t *a, cumo_n
             break;
         case 4:
             cumo_ndloop_copy_to_buffer_kernel_dim4<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 5:
+            cumo_ndloop_copy_to_buffer_kernel_dim5<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 6:
+            cumo_ndloop_copy_to_buffer_kernel_dim6<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 7:
+            cumo_ndloop_copy_to_buffer_kernel_dim7<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
+            break;
+        case 8:
+            cumo_ndloop_copy_to_buffer_kernel_dim8<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);
             break;
         default:
             cumo_ndloop_copy_to_buffer_kernel_dim<<<grid_dim, block_dim>>>(*a,*indexer,buf,elmsz);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3202,6 +3202,37 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  # A store into a view with an index array is buffered by ndloop, which copies
+  # the operand one element per thread. Contracting the trailing contiguous
+  # dimensions into a single element left a whole row to one thread.
+  test "index assignment writes every element for any rank" do
+    order = [2, 0, 1]
+    (1..8).each do |rank|
+      shape = [3] * rank
+      sub = [Cumo::Int64[*order]] * rank
+      a = Cumo::Int32.new(*shape).seq(1)
+      b = Cumo::Int32.new(*shape).seq(1000)
+      want = a.to_a
+      apply = lambda do |dst, src, depth|
+        order.each_with_index do |d, k|
+          depth == rank - 1 ? dst[d] = src[k] : apply.call(dst[d], src[k], depth + 1)
+        end
+      end
+      apply.call(want, b.to_a, 0)
+      a[*sub] = b
+      assert_equal(want, a.to_a, "rank #{rank}")
+    end
+  end
+
+  test "index assignment fills a wide row" do
+    a = Cumo::Int32.new(5, 300).seq(1)
+    b = Cumo::Int32.new(3, 300).seq(1000)
+    want = a.to_a
+    [4, 1, 2].each_with_index { |dst, k| want[dst] = b.to_a[k] }
+    a[Cumo::Int64[4, 1, 2], true] = b
+    assert_equal(want, a.to_a)
+  end
+
   test "flatten of a view writes through to its source" do
     a = Cumo::Int32.new(4, 6).seq(1)
     f = a[true, 0...3].flatten


### PR DESCRIPTION

ndloop buffers an operand into contiguous memory when the ndfunc cannot walk an index array itself, and `cumo_ndfunc_set_bufcp` contracts the trailing contiguous dimensions into one larger element first. A host loop wants that -- it turns the copy into one `memcpy` per row. The device copy runs one thread per element, so the same contraction leaves a whole row to a single thread.

`a[idx, true] = b` on a 1024x1024 `SFloat` spent 1567us, of which 1540us was the two copy kernels (768us and 772us) against 9.7us for the store itself. Both moved 8MB at about 10 GB/s.

- Keep the contraction for a host buffer and drop it when the buffer is device memory, so the copy gets one thread per element.
- Instantiate the copy kernels up to `CUMO_NA_INDEXER_OPTIMIZED_NDIM` instead of 4, so an operand carrying an index array on more than four dimensions stops falling back to the generic indexer.

| case | before | after |
| --- | --- | --- |
| `a[idx,true] = b`, 1024x1024 | 1567.3us | 67.5us |
| `a[idx,true] = b`, 1024x4096 | 6205.3us | 226.5us |
| `a[idx,true] = b`, 4096x1024 | 1865.6us | 259.7us |
| index array on all 5 dimensions | 9114.7us | 624.2us |
| `a[idx, step2] = b` (control) | 82.5us | 82.9us |
| index array on all 3 dimensions (control) | 93.5us | 94.1us |

The two controls are the shapes the change does not reach: a non-contiguous last dimension was never contracted, and three dimensions already had a kernel of their own.

Dispatching dimension 2, 6 and 8 one kernel lower fails the new tests, so both the specialized kernels and the ranks above four are covered.
