### PR TITLE
Credit the index cases with the bytes they actually move

### DIFF
--- a/bench/cumo_probe.rb
+++ b/bench/cumo_probe.rb
@@ -385,11 +385,15 @@ op(:compact, 'where', :bit) { |c| c.a.where }
 op(:compact, 'where2', :bit) { |c| c.a.where2 }
 op(:compact, 'mask') { |c| c.a[c.mask] }
 
-# subscripting
-op(:index, 'aref index', :num, peer: false) { |c| c.a[c.idx, true] }
-op(:index, 'aset scalar') { |c| c.dst[0...(c.rows / 2), true] = c.scalar }
+# Subscripting, where the group's own work is wrong for three of the five: a
+# subscript that returns a view writes one index array and never reads the
+# array it indexes, and a scalar assignment to half the rows writes half the
+# array and reads nothing. Left at 2*n*elmsz the scalar assignment reports
+# what the card cannot do and becomes the reference the rest are read against.
+op(:index, 'aref index', :num, peer: false, work: ->(c) { c.rows * 8 }) { |c| c.a[c.idx, true] }
+op(:index, 'aset scalar', work: ->(c) { (c.rows / 2) * c.cols * c.elmsz }) { |c| c.dst[0...(c.rows / 2), true] = c.scalar }
 op(:index, 'aset array') { |c| c.dst[c.idx, true] = c.b }
-op(:index, 'at', :num) { |c| c.a.at(c.idx, c.idx) }
+op(:index, 'at', :num, peer: false, work: ->(c) { c.rows * 8 }) { |c| c.a.at(c.idx, c.idx) }
 op(:index, 'diagonal', :num, work: ->(c) { 2 * Math.sqrt(c.n) * c.elmsz }) { |c| c.sq.diagonal.copy }
 
 # store and cast, each into a destination the context already allocated


### PR DESCRIPTION

`work` is per group rather than per case, so every member of `index` was credited `2 * n * elmsz`. Three of the five do not move that much:

- `dst[0...(rows / 2), true] = scalar` writes half the array and reads nothing -- four times less than it was credited with.
- `a[idx, true]` and `a.at(idx, idx)` return views. Neither reads the array it subscripts; each writes one index array of `rows` entries.

The scalar assignment is the one that mattered. Credited four times over it reported 926 to 941 GB/s, at the limit of what the card can do, and it is the fastest member of its cell, so it stood as the reference the rest of the group was read against. That put `dst[idx, true] = b` at 7.1x to 7.7x off its peers after it had already been fixed in #319.

| row | before | after |
| --- | --- | --- |
| `aset scalar` (the reference) | 926-941 GB/s | 155-244 GB/s |
| `aset array` | 7.1x - 7.7x | 1.2x - 2.0x |
| `at`, `aref index` | 219 GB/s, 428 GB/s | measured as views, `peer: false` |

The index group now flags nothing. No other group is touched: a ratio is computed within one group, dtype and layout.
