### PR TITLE
Build the flattened view once, not inside the timed body

### DIFF
--- a/bench/cumo_probe.rb
+++ b/bench/cumo_probe.rb
@@ -150,7 +150,7 @@ def operand(klass, rows, cols, layout)
 end
 
 Ctx = Struct.new(:klass, :dtype, :layout, :rows, :cols, :n, :elmsz, :a, :b, :scalar, :mask, :idx, :sq,
-                 :unit, :dst, :sc, :usc, :wide, :int, :tdst, :fdst, :bdst)
+                 :unit, :dst, :sc, :usc, :wide, :int, :tdst, :fdst, :bdst, :flat)
 
 # A case that allocates its own result does not measure a kernel in cumo, it
 # measures whether the pool happened to hold a block of the size it wanted --
@@ -194,8 +194,13 @@ def context(dtype, layout, rows = ROWS)
   int = (klass == XM::Int64 ? XM::Int32 : XM::Int64).new(rows, cols).fill(0)
   tdst = klass.new(cols, rows).fill(dtype == 'Bit' ? 1 : 0)
   fdst = klass.new(n).fill(dtype == 'Bit' ? 1 : 0)
+  # Flattening a view that no stride can describe builds an index array of one
+  # size_t per element, and a fresh managed block of that size costs more to
+  # first touch than any kernel in this file: 8MB of it reads 563us against the
+  # 9.2us the kernel filling it takes. Built here, the row measures the store.
+  flat = a.flatten
   Ctx.new(klass, dtype, layout, rows, cols, n, elmsz, a, b, scalar, mask, idx, sq,
-          unit, dst, sc, usc, wide, int, tdst, fdst, bdst)
+          unit, dst, sc, usc, wide, int, tdst, fdst, bdst, flat)
 end
 
 # --- the case table --------------------------------------------------------
@@ -404,7 +409,7 @@ op(:store, 'cast from bit', :bit, work: ->(c) { c.n * (0.125 + 8) }) { |c| c.int
 op(:store, 'fill', :num, work: ->(c) { c.n * c.elmsz }) { |c| c.dst.fill(c.scalar) }
 op(:store, 'seq', :num, work: ->(c) { c.n * c.elmsz }) { |c| c.dst.seq(1) }
 op(:store, 'transpose copy', :num) { |c| c.tdst.store(c.a.transpose) }
-op(:store, 'reshape copy', :num) { |c| c.fdst.store(c.a.flatten) }
+op(:store, 'reshape copy', :num) { |c| c.fdst.store(c.flat) }
 
 # sorting
 op(:sort, 'sort', :real) { |c| c.a.sort }


### PR DESCRIPTION

`reshape copy` timed `fdst.store(c.a.flatten)`. For a view no stride can describe, `flatten` builds an index array of one `size_t` per element, and a fresh managed block of that size costs far more to first touch than any kernel here. The row read 13.1 to 14.5 GB/s on a column slice, 56.8x to 63.3x off its peers, and none of it was the store.

Splitting the body says where it went, and profiling says the kernel is not the reason:

| | |
| --- | --- |
| `fdst.store(a.flatten)` | 595.1us |
| `a.flatten` alone | 605.7us |
| `fdst.store(flat)`, flattened first | 28.2us |
| `flatten_index_kernel_dim2`, median of 11 | 9.2us |
| the same kernel, first call on a fresh block | 1380.6us |

The kernel writes its 8MB at 870 GB/s. What the row measured was one 8MB managed allocation per rep -- eleven flattens with no collection in between take the pool from 8.4MB to 100.7MB.

Build the flattened view in the context, as #318 did for the destinations, so the row measures the store through an index array:

| row | before | after |
| --- | --- | --- |
| `reshape copy` SFloat colslice | 14.5 GB/s, 56.8x | 288.9 GB/s, 2.9x |
| `reshape copy` Int32 colslice | 13.1 GB/s, 63.3x | 301.6 GB/s, 2.8x |
| `reshape copy` contig | 744-632 GB/s | 800-787 GB/s |

A contiguous flatten is a metadata change, so those two rows only lose their measurement noise.

The default sweep goes from 8 flagged rows to 6, and what is left is the two `atan2_s` rows NMath runs in double, the three `median` rows that sort, and one `count_true` row.
