### PR TITLE
Address a store's index array from its kernel, not a buffer

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_from.c
+++ b/ext/cumo/narray/gen/tmpl/store_from.c
@@ -1,12 +1,10 @@
 //<% unless c_iter.include? 'robject' %>
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer);
-//<% end %>
-//<% if type_name == class_name && !c_iter.include?('robject') %>
 void <%="cumo_#{c_iter}_stridx_kernel_launch"%>(cumo_na_iarray_stridx_t* a1, cumo_na_iarray_stridx_t* a2, cumo_na_indexer_t* indexer);
 
-// store_array calls this iterator with a loop of its own that keeps
-// CUMO_NDF_INDEX_LOOP on, so an index array can reach here. cumo_na_iarray_t
-// carries byte steps only, and an indexed operand has a step of zero.
+// With INDEX_LOOP on either operand can arrive carrying an index array, and
+// cumo_na_iarray_t carries byte steps only: an indexed operand has a step of
+// zero there, so those are addressed through cumo_na_iarray_stridx_t instead.
 static int
 <%=c_iter%>_has_index(cumo_na_loop_t *const lp)
 {
@@ -74,15 +72,12 @@ static void
     {
         cumo_na_indexer_t indexer = cumo_na_make_indexer(&lp->args[0]);
 
-        //<% if type_name == class_name %>
         if (<%=c_iter%>_has_index(lp)) {
             cumo_na_iarray_stridx_t b1 = cumo_na_make_iarray_stridx(&lp->args[0]);
             cumo_na_iarray_stridx_t b2 = cumo_na_make_iarray_stridx(&lp->args[1]);
 
             <%="cumo_#{c_iter}_stridx_kernel_launch"%>(&b1,&b2,&indexer);
-        } else
-        //<% end %>
-        {
+        } else {
             cumo_na_iarray_t a1 = cumo_na_make_iarray(&lp->args[0]);
             cumo_na_iarray_t a2 = cumo_na_make_iarray(&lp->args[1]);
 
@@ -101,10 +96,10 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 2, 0, ain, 0 };
     <% else %>
     // Without INDEXER_LOOP ndloop walks the outer dimensions itself and the
-    // kernel runs once per row, which for a column slice costs one launch per
-    // row and nothing else. An index on either side is buffered into
-    // contiguous memory first, in one launch of its own.
-    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 0, ain, 0 };
+    // kernel runs once per row. INDEX_LOOP has to stay on too: staging an
+    // indexed operand into a contiguous buffer costs a copy in each direction,
+    // and the one of the destination is read back over by this very store.
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP, 2, 0, ain, 0 };
     <% end %>
 
     cumo_na_ndloop(&ndf, 2, self, obj);

--- a/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/store_from_kernel.cu
@@ -11,29 +11,34 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_iarray_t a1, cum
 }
 <% end %>
 
-<% if type_name == class_name %>
-// store_array runs this iterator inside its own loop, which keeps
-// CUMO_NDF_INDEX_LOOP on, so either operand can arrive carrying an index array
-// even though this method's own ndfunc drops it. Only the same-type store is
-// reachable that way, and the path is not hot, so one generic kernel is enough.
-__global__ void <%="cumo_#{c_iter}_stridx_kernel"%>(cumo_na_iarray_stridx_t a1, cumo_na_iarray_stridx_t a2, cumo_na_indexer_t indexer)
+<% ((0..opt_indexer_ndim).to_a << '').each do |idim| %>
+__global__ void <%="cumo_#{c_iter}_stridx_kernel_dim#{idim}"%>(cumo_na_iarray_stridx_t a1, cumo_na_iarray_stridx_t a2, cumo_na_indexer_t indexer)
 {
     for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < indexer.total_size; i += blockDim.x * gridDim.x) {
-        cumo_na_indexer_set_dim(&indexer, i);
-        char* p1 = cumo_na_iarray_stridx_at_dim(&a1, &indexer);
-        char* p2 = cumo_na_iarray_stridx_at_dim(&a2, &indexer);
+        cumo_na_indexer_set_dim<%=idim%>(&indexer, i);
+        char* p1 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a1, &indexer);
+        char* p2 = cumo_na_iarray_stridx_at_dim<%=idim%>(&a2, &indexer);
         *(dtype*)(p1) = <%=macro%>(*(<%=dtype%>*)(p2));
     }
 }
+<% end %>
 
 void <%="cumo_#{c_iter}_stridx_kernel_launch"%>(cumo_na_iarray_stridx_t* a1, cumo_na_iarray_stridx_t* a2, cumo_na_indexer_t* indexer)
 {
     size_t grid_dim = cumo_get_grid_dim(indexer->total_size);
     size_t block_dim = cumo_get_block_dim(indexer->total_size);
-    <%="cumo_#{c_iter}_stridx_kernel"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+    switch (indexer->ndim) {
+    <% (0..opt_indexer_ndim).each do |idim| %>
+    case <%=idim%>:
+        <%="cumo_#{c_iter}_stridx_kernel_dim#{idim}"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    <% end %>
+    default:
+        <%="cumo_#{c_iter}_stridx_kernel_dim"%><<<grid_dim, block_dim>>>(*a1,*a2,*indexer);
+        break;
+    }
     cumo_cuda_runtime_check_kernel_launch();
 }
-<% end %>
 
 void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_iarray_t* a1, cumo_na_iarray_t* a2, cumo_na_indexer_t* indexer)
 {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3233,6 +3233,34 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(want, a.to_a)
   end
 
+  # A store between two dtypes staged an indexed operand through a contiguous
+  # buffer, so only the same-type store ever addressed an index itself. Each
+  # pair of dtypes now has a kernel of its own to do it.
+  test "a cast store writes every element through an index" do
+    order = [4, 0, 2]
+    idx = Cumo::Int64[*order]
+    [[Cumo::SFloat, Cumo::DFloat], [Cumo::DFloat, Cumo::SFloat],
+     [Cumo::Int32, Cumo::Int64], [Cumo::Int64, Cumo::UInt8],
+     [Cumo::UInt8, Cumo::Int32], [Cumo::DComplex, Cumo::DFloat],
+     [Cumo::SFloat, Cumo::Int32]].each do |dst_type, src_type|
+      at = "#{dst_type} <- #{src_type}"
+
+      src = src_type.new(order.size, 5).seq(1)
+      want = dst_type.new(6, 5).fill(0)
+      order.each_with_index { |row, k| want[row, true] = src[k, true] }
+      dst = dst_type.new(6, 5).fill(0)
+      dst[idx, true] = src
+      assert_equal(want.to_a, dst.to_a, "#{at} indexed destination")
+
+      wide = src_type.new(6, 5).seq(1)
+      want = dst_type.new(order.size, 5).fill(0)
+      order.each_with_index { |row, k| want[k, true] = wide[row, true] }
+      dst = dst_type.new(order.size, 5).fill(0)
+      dst.store(wide[idx, true])
+      assert_equal(want.to_a, dst.to_a, "#{at} indexed source")
+    end
+  end
+
   test "flatten of a view writes through to its source" do
     a = Cumo::Int32.new(4, 6).seq(1)
     f = a[true, 0...3].flatten


### PR DESCRIPTION
## Summary

`store` dropped `CUMO_NDF_INDEX_LOOP` when it gained the indexer loop in #245, so ndloop staged an
indexed operand into a contiguous buffer before the kernel ran and copied it back afterwards. For
`dst[idx, true] = b` that is three kernels where one would do, and the first of them reads a
destination this very store is about to overwrite. #257 already added a kernel that addresses an
index through `cumo_na_iarray_stridx_t`; this turns the flag back on and sends every case there.

- Set the ndfunc flag back to `CUMO_FULL_LOOP|CUMO_NDF_INDEXER_LOOP`, which is what numo has
- Give the stridx kernel the same per-dimension accessors the plain one has, so it is not left on
  the generic indexer's 64-bit division
- Generate it for every pair of dtypes, not only the same-type store, since an index now reaches
  the cast stores too
- 512x2048 SFloat, half the rows: an indexed destination 30.1 to 12.4us, an indexed source 21.4 to
  12.2us, a cast into an indexed destination 30.1 to 12.4us; contiguous stores unchanged
- `bench/cumo_probe.rb` `index aset array`: 118-128 to 209-227 GB/s over two alternating A/B runs

## Verification

`rake test` passes, 1837 tests / 31114 assertions. 48 indexed stores compared against Numo over six
dtypes, seven dtype pairs, ranks 1 to 8 and transposed, stepped and reversed operands agree except
for a duplicate index, which picks the first source row where Numo's serial loop picks the last --
identical before and after this change.

Positive control: making the stridx kernel ignore the source index fails all four index-store tests,
and dispatching one dimension too low fails or crashes them.