### PR TITLE
Copy a Bit through its own method, not a byte at a time

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -6,6 +6,7 @@
 #include "cumo/template.h"
 #include "cumo/indexer.h"
 
+static ID cumo_id_copy;
 static ID cumo_id_mulsum;
 static ID cumo_id_store;
 static ID cumo_id_swap_byte;
@@ -98,6 +99,13 @@ cumo_na_copy(VALUE self)
     cumo_ndfunc_arg_in_t ain[1] = {{Qnil,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{INT2FIX(0),0}};
     cumo_ndfunc_t ndf = { iter_copy_bytes, CUMO_FULL_LOOP, 1, 1, ain, aout };
+
+    // The loops below move whole bytes, which is one element of every class but
+    // Cumo::Bit, whose element is one bit. Its own copy is the one that can
+    // address that.
+    if (rb_obj_is_kind_of(self, cumo_cBit)) {
+        return rb_funcall(self, cumo_id_copy, 0);
+    }
 
     // Cumo::RObject data is host memory, which the kernel below must not touch.
     // Everything else goes through the indexer so that ndloop hands the whole
@@ -1021,6 +1029,7 @@ Init_cumo_na_data(void)
 
     //rb_define_method(cNArray, "dot", cumo_na_dot, 1);
 
+    cumo_id_copy         = rb_intern("copy");
     cumo_id_mulsum       = rb_intern("mulsum");
     cumo_id_store        = rb_intern("store");
     cumo_id_swap_byte    = rb_intern("swap_byte");

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -355,6 +355,36 @@ class BitTest < Test::Unit::TestCase
     end
   end
 
+  # A reduction addresses its operands itself, so mulsum makes one that carries
+  # an index array contiguous first -- with a copy that moves whole bytes, where
+  # a Bit element is one bit. The sum came out of the wrong bits.
+  test "mulsum over an indexed Bit operand reads the bits it was given" do
+    n = 12
+    src = (0...n).map { |i| i % 3 == 1 ? 1 : 0 }
+    a = Cumo::SFloat.new(n).seq(1)
+    b = Cumo::Bit.cast(src)
+
+    assert_equal(src.each_index.sum { |i| (i + 1) * src[i] }.to_f, Float(a.mulsum(b)))
+
+    [[1, 4, 7, 10], [0, 1, 2], [11, 10, 9], [4, 4, 4]].each do |idx|
+      want = idx.sum { |i| (i + 1) * src[i] }.to_f
+      at = "idx #{idx.inspect}"
+      assert_equal(idx.map { |i| src[i] }, b[idx].to_a, "#{at} view")
+      assert_equal(want, Float(a[idx].mulsum(b[idx])), at)
+      assert_equal(want, Float(a[idx].mulsum(b[idx].copy)), "#{at} copied")
+    end
+  end
+
+  test "NArray#copy of a Bit copies bits, not bytes" do
+    src = (0...40).map { |i| i % 3 == 1 ? 1 : 0 }
+    b = Cumo::Bit.cast(src)
+    na_copy = Cumo::NArray.instance_method(:copy)
+    assert_equal(src, na_copy.bind(b).call.to_a)
+    idx = (0...40).select { |i| i % 7 == 2 }
+    assert_equal(idx.map { |i| src[i] }, na_copy.bind(b[idx]).call.to_a)
+    assert_equal(src[5, 20], na_copy.bind(b[5...25]).call.to_a)
+  end
+
   test "all? and any? split a long axis across blocks" do
     rows = 2
     cols = 200_003


### PR DESCRIPTION
- `cumo_na_copy` moves whole bytes, which is one element of every class but `Cumo::Bit`, whose element is one bit. Handed a Bit it reads the wrong data: `Cumo::Bit[1,0,1,0,1,0][[0,2,4]]` holds `[1,1,1]` and copies as `[1,0,1]`.
- That reaches an answer through `mulsum`, which makes an operand carrying an index array contiguous before reducing it: `Cumo::SFloat[1,3,5].mulsum(bits)` returned 6.0 where Numo returns 9.0. Numo has no such copy -- its reduction lets ndloop buffer the operand -- so this is Cumo's own.
- `cumo_na_copy` now delegates a Bit to the class's own `copy`, which addresses bits. `Cumo::NArray#copy` was wrong the same way for any Bit and is fixed with it.
- `mulsum` is the only method that can hand a Bit to `cumo_na_copy`; the other callers pass `self` from a template that is never generated for Bit, or a float operand. Every Bit ndfunc was checked for the buffering that the same mismatch would cause, and none is missing `CUMO_NDF_INDEX_LOOP`.