### PR TITLE
Gather a word from a Bit operand's rows, not a bit at a time

### DIFF
--- a/ext/cumo/include/cumo/types/bit_kernel.h
+++ b/ext/cumo/include/cumo/types/bit_kernel.h
@@ -118,6 +118,92 @@ cumo_bit_chunk(const CUMO_BIT_DIGIT *a, size_t p, ssize_t s, const size_t *idx, 
     return z & CUMO_SLB(kend);
 }
 
+// The trailing loop dimensions along which a Bit operand runs bit by bit. When
+// the output takes a whole word from one thread, the input can be gathered a
+// word at a time over those rather than a bit at a time through the indexer,
+// whose decomposition costs two runtime divisions per element. A column slice
+// is a run per row with the rows apart, which is the case this is for.
+typedef struct {
+    int ok;
+    int outer_ndim;      // loop dimensions [0, outer_ndim) address a row
+    int64_t inner_len;   // elements in one row
+} cumo_bit_run_t;
+
+static inline cumo_bit_run_t
+cumo_bit_make_run(const cumo_na_bit_iarray_stridx_t* a, const cumo_na_indexer_t* indexer)
+{
+    cumo_bit_run_t run;
+    int k = indexer->ndim;
+    ssize_t acc = 1;
+
+    run.ok = 0;
+    run.outer_ndim = indexer->ndim;
+    run.inner_len = 1;
+    while (k > 0 &&
+           CUMO_SDX_IS_STRIDE(a->stridx[k-1]) &&
+           CUMO_SDX_GET_STRIDE(a->stridx[k-1]) == acc) {
+        acc *= (ssize_t)indexer->shape[k-1];
+        --k;
+    }
+    // A row shorter than a word would leave the gather below assembling one out
+    // of several rows, which is what the bit-at-a-time path already does.
+    if (k < indexer->ndim && acc >= (ssize_t)CUMO_NB) {
+        run.ok = 1;
+        run.outer_ndim = k;
+        run.inner_len = (int64_t)acc;
+    }
+    return run;
+}
+
+// Bit position of the first element of the given row.
+__device__ static inline size_t
+cumo_bit_run_pos(const cumo_na_bit_iarray_stridx_t* a, const cumo_na_indexer_t* indexer, cumo_bit_run_t run, int64_t row)
+{
+    size_t pos = a->pos;
+    for (int j = run.outer_ndim; --j >= 0;) {
+        int64_t n = (int64_t)indexer->shape[j];
+        int64_t k = row % n;
+        row /= n;
+        if (CUMO_SDX_IS_INDEX(a->stridx[j])) {
+            pos += CUMO_SDX_GET_INDEX(a->stridx[j])[k];
+        } else {
+            pos += CUMO_SDX_GET_STRIDE(a->stridx[j]) * k;
+        }
+    }
+    return pos;
+}
+
+// Elements [w*CUMO_NB, w*CUMO_NB+CUMO_NB) of a loop over n elements, as one
+// word. A word straddles two rows unless the row length is a multiple of
+// CUMO_NB, so it is taken in as many pieces as it has rows -- one, almost
+// always two at most.
+__device__ static inline CUMO_BIT_DIGIT
+cumo_bit_run_word(const cumo_na_bit_iarray_stridx_t* a, const cumo_na_indexer_t* indexer, cumo_bit_run_t run, uint64_t w, uint64_t n)
+{
+    const ssize_t nb = (ssize_t)CUMO_NB;
+    uint64_t base = w * CUMO_NB;
+    CUMO_BIT_DIGIT z = 0;
+    uint64_t k = 0;
+
+    while (k < CUMO_NB && base + k < n) {
+        int64_t i = (int64_t)(base + k);
+        int64_t row = i / run.inner_len;
+        int64_t col = i - row * run.inner_len;
+        uint64_t take = (uint64_t)(run.inner_len - col);
+        if (take > CUMO_NB - k)   take = CUMO_NB - k;
+        if (base + k + take > n)  take = n - (base + k);
+
+        size_t p = cumo_bit_run_pos(a, indexer, run, row) + (size_t)col;
+        ssize_t o = (ssize_t)(p % CUMO_NB);
+        uint64_t nw = (uint64_t)((o + (ssize_t)take + nb - 1) / nb);
+        CUMO_BIT_DIGIT piece = cumo_bit_gather_word(a->ptr + p / CUMO_NB, o, nw, 0);
+
+        z |= (piece & CUMO_SLB(take)) << k;
+        k += take;
+    }
+    return z;
+}
+
 // Stores the k-th index of a where result, whose element size the caller picked
 // from the size of the operand.
 __device__ static inline void

--- a/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/binary_kernel.cu
@@ -19,6 +19,18 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_strid
 }
 <% end %>
 
+// One thread per word of the output, taking each word from the operands' own
+// rows. Both have to run bit by bit for this: a warp cannot pool what one of
+// them scatters.
+__global__ void <%="cumo_#{c_iter}_run_kernel"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_bit_iarray_stridx_t a2, cumo_na_indexer_t indexer, cumo_bit_run_t run1, cumo_bit_run_t run2, CUMO_BIT_DIGIT *out, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_run_word(&a1, &indexer, run1, w, n);
+        CUMO_BIT_DIGIT y = cumo_bit_run_word(&a2, &indexer, run2, w, n);
+        cumo_bit_store_word(out, w, m_<%=name%>(x,y), 0, n);
+    }
+}
+
 __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a2, ssize_t o2, uint64_t w2, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
 {
     for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
@@ -34,6 +46,21 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_n
     // operand is laid out, so the lanes can pool their bits into that word
     // rather than each taking it with an atomic.
     CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+
+    // With the output taking a whole word from one thread, operands whose rows
+    // run bit by bit can be gathered a word at a time as well.
+    if (out != NULL) {
+        cumo_bit_run_t run1 = cumo_bit_make_run(a1, indexer);
+        cumo_bit_run_t run2 = cumo_bit_make_run(a2, indexer);
+        if (run1.ok && run2.ok) {
+            uint64_t w3 = (indexer->total_size + CUMO_NB - 1) / CUMO_NB;
+            <%="cumo_#{c_iter}_run_kernel"%><<<cumo_get_grid_dim(w3), cumo_get_block_dim(w3)>>>(
+                *a1, *a2, *indexer, run1, run2, out, indexer->total_size, w3);
+            cumo_cuda_runtime_check_kernel_launch();
+            return;
+        }
+    }
+
     uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
     size_t grid_dim = cumo_get_grid_dim(end);
     // the ballot needs whole warps, so a short loop cannot shrink the block

--- a/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/store_bit_kernel.cu
@@ -16,6 +16,17 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_strid
 }
 <% end %>
 
+// One thread per word of the output, taking the word from the operand's own
+// rows. The lanes of a warp would otherwise each pay the indexer to read one
+// bit of the same word.
+__global__ void <%="cumo_#{c_iter}_run_kernel"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_indexer_t indexer, cumo_bit_run_t run, CUMO_BIT_DIGIT *out, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_run_word(&a1, &indexer, run, w, n);
+        cumo_bit_store_word(out, w, x, 0, n);
+    }
+}
+
 __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
 {
     for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
@@ -30,6 +41,20 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_n
     // operand is laid out, so the lanes can pool their bits into that word
     // rather than each taking it with an atomic.
     CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+
+    // With the output taking a whole word from one thread, an operand whose
+    // rows run bit by bit can be gathered a word at a time as well.
+    if (out != NULL) {
+        cumo_bit_run_t run = cumo_bit_make_run(a1, indexer);
+        if (run.ok) {
+            uint64_t w3 = (indexer->total_size + CUMO_NB - 1) / CUMO_NB;
+            <%="cumo_#{c_iter}_run_kernel"%><<<cumo_get_grid_dim(w3), cumo_get_block_dim(w3)>>>(
+                *a1, *indexer, run, out, indexer->total_size, w3);
+            cumo_cuda_runtime_check_kernel_launch();
+            return;
+        }
+    }
+
     uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
     size_t grid_dim = cumo_get_grid_dim(end);
     // the ballot needs whole warps, so a short loop cannot shrink the block

--- a/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/unary_kernel.cu
@@ -18,6 +18,17 @@ __global__ void <%="cumo_#{c_iter}_kernel_dim#{idim}"%>(cumo_na_bit_iarray_strid
 }
 <% end %>
 
+// One thread per word of the output, taking the word from the operand's own
+// rows. The lanes of a warp would otherwise each pay the indexer to read one
+// bit of the same word.
+__global__ void <%="cumo_#{c_iter}_run_kernel"%>(cumo_na_bit_iarray_stridx_t a1, cumo_na_indexer_t indexer, cumo_bit_run_t run, CUMO_BIT_DIGIT *out, uint64_t n, uint64_t w3)
+{
+    for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
+        CUMO_BIT_DIGIT x = cumo_bit_run_word(&a1, &indexer, run, w, n);
+        cumo_bit_store_word(out, w, m_<%=name%>(x), 0, n);
+    }
+}
+
 __global__ void <%="cumo_#{c_iter}_contiguous_kernel"%>(CUMO_BIT_DIGIT *a1, ssize_t o1, uint64_t w1, CUMO_BIT_DIGIT *a3, size_t p3, uint64_t n, uint64_t w3)
 {
     for (uint64_t w = blockIdx.x * blockDim.x + threadIdx.x; w < w3; w += blockDim.x * gridDim.x) {
@@ -32,6 +43,20 @@ void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_iarray_stridx_t* a1, cumo_n
     // operand is laid out, so the lanes can pool their bits into that word
     // rather than each taking it with an atomic.
     CUMO_BIT_DIGIT *out = cumo_na_bit_iarray_stridx_is_flat(a3, indexer) ? a3->ptr + a3->pos / CUMO_NB : NULL;
+
+    // With the output taking a whole word from one thread, an operand whose
+    // rows run bit by bit can be gathered a word at a time as well.
+    if (out != NULL) {
+        cumo_bit_run_t run = cumo_bit_make_run(a1, indexer);
+        if (run.ok) {
+            uint64_t w3 = (indexer->total_size + CUMO_NB - 1) / CUMO_NB;
+            <%="cumo_#{c_iter}_run_kernel"%><<<cumo_get_grid_dim(w3), cumo_get_block_dim(w3)>>>(
+                *a1, *indexer, run, out, indexer->total_size, w3);
+            cumo_cuda_runtime_check_kernel_launch();
+            return;
+        }
+    }
+
     uint64_t end = out ? ((indexer->total_size + CUMO_NB - 1) & ~(uint64_t)(CUMO_NB - 1)) : indexer->total_size;
     size_t grid_dim = cumo_get_grid_dim(end);
     // the ballot needs whole warps, so a short loop cannot shrink the block

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -355,6 +355,60 @@ class BitTest < Test::Unit::TestCase
     end
   end
 
+  # An operand whose rows are runs of bits but which sit apart -- a column slice
+  # -- was read one bit at a time through the indexer, two runtime divisions an
+  # element, while the output took whole words from one thread each. The word is
+  # gathered from the operand's own rows now. A row length that is not a whole
+  # number of words makes a word straddle two rows, which is the case that has
+  # to come out right.
+  test "Bit elementwise ops take a word from a view whose rows are runs" do
+    [[5, 70], [9, 37], [7, 31], [4, 96], [2, 33], [3, 200]].each do |rows, cols|
+      wide = cols * 2
+      s1 = (0...(rows * wide)).map { |i| (i * 7 + 3) % 5 == 0 ? 1 : 0 }
+      s2 = (0...(rows * wide)).map { |i| (i * 3 + 1) % 4 == 0 ? 1 : 0 }
+      a = Cumo::Bit.cast(s1).reshape(rows, wide)
+      b = Cumo::Bit.cast(s2).reshape(rows, wide)
+      take = ->(src, off) { (0...rows).map { |r| (0...cols).map { |c| src[r * wide + off + c] } } }
+      zip = ->(x, y, &op) { x.zip(y).map { |u, v| u.zip(v).map { |m, n| op.call(m, n) } } }
+
+      [0, 1].each do |off|
+        va = a[true, off...(off + cols)]
+        vb = b[true, off...(off + cols)]
+        wa = take.call(s1, off)
+        wb = take.call(s2, off)
+        at = "#{rows}x#{cols} off #{off}"
+
+        dst = Cumo::Bit.new(rows, cols).fill(1)
+        dst.store(va)
+        assert_equal(wa, dst.to_a, "#{at} store")
+        assert_equal(wa, va.copy.to_a, "#{at} copy")
+        assert_equal(wa.map { |row| row.map { |v| 1 - v } }, (~va).to_a, "#{at} not")
+        assert_equal(zip.call(wa, wb) { |u, v| u & v }, (va & vb).to_a, "#{at} and")
+        assert_equal(zip.call(wa, wb) { |u, v| u | v }, (va | vb).to_a, "#{at} or")
+        assert_equal(zip.call(wa, wb) { |u, v| u ^ v }, (va ^ vb).to_a, "#{at} xor")
+        assert_equal(wa.flatten.count(1), va.count_true.to_i, "#{at} count_true")
+      end
+    end
+  end
+
+  test "Bit elementwise ops keep the bit-at-a-time path for a scattered operand" do
+    n = 96
+    src = (0...(n * n)).map { |i| (i * 7 + 3) % 5 == 0 ? 1 : 0 }
+    a = Cumo::Bit.cast(src).reshape(n, n)
+    at = ->(i, j) { src[i * n + j] }
+
+    t = a.transpose
+    assert_equal((0...n).map { |i| (0...n).map { |j| at.call(j, i) } }, t.copy.to_a, "transposed copy")
+    assert_equal((0...n).map { |i| (0...n).map { |j| at.call(j, i) ^ at.call(i, j) } }, (t ^ a).to_a, "transposed xor")
+
+    step = a[true, (0...n).step(2)]
+    assert_equal((0...n).map { |i| (0...n).step(2).map { |j| at.call(i, j) } }, step.copy.to_a, "stepped copy")
+
+    idx = (0...n).to_a.rotate(7)
+    picked = a[true, idx]
+    assert_equal((0...n).map { |i| idx.map { |j| at.call(i, j) } }, picked.copy.to_a, "indexed copy")
+  end
+
   # A view whose rows are each a run of bits but sit apart -- a column slice --
   # is not flat over the whole reduce group, and the fold within a row was given
   # up along with it. These rows start at a different bit of their word from one


### PR DESCRIPTION
- The Bit elementwise kernels take a whole word of the output from one thread when the output is laid out end to end, but they read the operand one bit at a time through the indexer however it is laid out -- two runtime divisions an element. A column slice is a run of bits per row with the rows sitting apart, so a word of the output almost always comes from one run of the operand.
- `cumo_bit_make_run` finds the trailing loop dimensions along which an operand runs bit by bit and `cumo_bit_run_word` gathers a word over them, in as many pieces as the word has rows -- one, or two where the row length is not a whole number of words. `store`, the unary ops and the binary ops take it; a binary needs both operands to be runs.
- 512x2048 Bit, min of 9, alternating in one session: `dst.store(slice)` 18.0 -> 8.9us, `~slice` 18.4 -> 9.4us, `slice & slice` 21.9 -> 12.9us, `slice ^ slice` 21.9 -> 12.3us. nsys puts the kernel itself at 13.1 -> 3.9us, against 0.7us for the contiguous one.
- Contiguous operands are unchanged (5.7 -> 5.8us), and so is one nothing can be gathered from: a transposed operand keeps the bit-at-a-time path at 22.3 -> 22.1us.
- A row shorter than a word keeps the old path as well, where a gather would be assembling a word out of several rows for no gain.