### PR TITLE
Describe a one-element subscript with a step, not an index array

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -109,12 +109,24 @@ cumo_na_range_check(ssize_t pos, ssize_t size, int dim)
 
 // copy ruby array to idx
 static void
-cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
+cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *q, int at_mode)
 {
     int k;
     size_t* idx;
     cudaError_t status;
     int n = RARRAY_LEN(ary);
+
+    // A step names the one element a one-element subscript does, without a
+    // device allocation, a kernel to fill it, or the synchronize a loop pays
+    // to read that one entry back. at() is left out: it gathers through an
+    // index array whatever it is given, so a step only moves the same work,
+    // and its synchronize, into cumo_na_index_at_nadata.
+    if (n == 1 && !at_mode) {
+        cumo_na_index_set_step(q, orig_dim, 1,
+            cumo_na_range_check(NUM2SSIZET(RARRAY_AREF(ary,0)), size, orig_dim), 1);
+        return;
+    }
+
     //q->idx = ALLOC_N(size_t, n);
     //for (k=0; k<n; k++) {
     //    q->idx[k] = na_range_check(NUM2SSIZET(RARRAY_AREF(ary,k)), size, orig_dim);
@@ -145,7 +157,7 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
 
 // copy narray to idx
 static void
-cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
+cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_arg_t *q, int at_mode)
 {
     VALUE idx, buf;
     cumo_narray_t *na;
@@ -185,6 +197,13 @@ cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_ar
     for (k=0; k<n; k++) {
         // A checked index is non-negative, so it is already a valid size_t.
         host_idx[k] = cumo_na_range_check(host_idx[k], size, orig_dim);
+    }
+
+    if (n == 1 && !at_mode) {
+        cumo_na_index_set_step(q, orig_dim, 1, (size_t)host_idx[0], 1);
+        RB_GC_GUARD(buf);
+        RB_GC_GUARD(idx);
+        return;
     }
 
     q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
@@ -330,7 +349,7 @@ cumo_na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, cumo_na_ind
 // i: parse i-th index
 // q: parsed information is stored to *q
 static void
-cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_arg_t *q)
+cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_arg_t *q, int at_mode)
 {
     switch(TYPE(a)) {
 
@@ -370,7 +389,7 @@ cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_ar
         break;
 
     case T_ARRAY:
-        cumo_na_parse_array(a, i, size, q);
+        cumo_na_parse_array(a, i, size, q, at_mode);
         break;
 
     default:
@@ -387,7 +406,7 @@ cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_ar
         }
         // NArray index
         else if (CUMO_NA_CumoIsNArray(a)) {
-            cumo_na_parse_narray_index(a, i, size, q);
+            cumo_na_parse_narray_index(a, i, size, q, at_mode);
         }
         else {
             rb_raise(rb_eIndexError, "not allowed type");
@@ -397,7 +416,7 @@ cumo_na_index_parse_each(volatile VALUE a, ssize_t size, int i, cumo_na_index_ar
 
 
 static size_t
-cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, int ndim)
+cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, int ndim, int at_mode)
 {
     int i, j, k, l, nidx;
     size_t total=1;
@@ -415,7 +434,7 @@ cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, 
         if (v==Qfalse) {
             for (l = ndim - (nidx-1); l>0; l--) {
                 //printf("i=%d j=%d k=%d l=%d ndim=%d nidx=%d\n",i,j,k,l,ndim,nidx);
-                cumo_na_index_parse_each(Qtrue, na->shape[k], k, &q[j]);
+                cumo_na_index_parse_each(Qtrue, na->shape[k], k, &q[j], at_mode);
                 if (q[j].n > 1) {
                     total *= q[j].n;
                 }
@@ -425,12 +444,12 @@ cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, 
         }
         // new dimension
         else if (v==cumo_sym_new) {
-            cumo_na_index_parse_each(v, 1, k, &q[j]);
+            cumo_na_index_parse_each(v, 1, k, &q[j], at_mode);
             j++;
         }
         // other dimension
         else {
-            cumo_na_index_parse_each(v, na->shape[k], k, &q[j]);
+            cumo_na_index_parse_each(v, na->shape[k], k, &q[j], at_mode);
             if (q[j].n > 1) {
                 total *= q[j].n;
             }
@@ -852,7 +871,7 @@ VALUE cumo_na_aref_md_protected(VALUE data_value)
     cumo_narray_view_t *na2;
     ssize_t elmsz;
 
-    cumo_na_index_parse_args(args, na1, q, ndim);
+    cumo_na_index_parse_args(args, na1, q, ndim, at_mode);
 
     if (cumo_na_debug_flag) print_index_arg(q,ndim);
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -182,6 +182,11 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[(-5..-1) % 2] == [2, 5, 11] }
         assert { a[(-5...-1) % 2] == [2, 5] }
         assert { a[[4, 3, 0, 1, 5, 2]] == [7, 5, 1, 2, 11, 3] }
+        assert { a[[3]] == [5] }
+        assert { a[[3]].shape == [1] }
+        assert { a[[-3]] == [5] }
+        assert { a[Cumo::Int32.cast([3])] == [5] }
+        assert { a[2..-1][[1]] == [5] }
         assert { a.reverse == [11, 7, 5, 3, 2, 1] }
         assert { a.sum == 29 }
         if float_types.include?(dtype)
@@ -1142,6 +1147,10 @@ class NArrayTest < Test::Unit::TestCase
     test "#{dtype},advanced indexing" do
       a = dtype[[1, 2, 3], [4, 5, 6]]
       assert { a[[0, 1], [0, 1]].dup == [[1, 2], [4, 5]] }
+      assert { a[[1], true] == [[4, 5, 6]] }
+      assert { a[[1], true].shape == [1, 3] }
+      assert { a[true, [2]] == [[3], [6]] }
+      assert { a[[1], [2]] == [[6]] }
       assert { a[[0, 1], [0, 1]].sum == 12 }
       assert { a[[0, 1], [0, 1]].diagonal == [1, 5] }
       diag = a.dup[[0, 1], [0, 1]].diagonal


### PR DESCRIPTION

`a[[i], true]` builds an index array of one entry on the device, fills it with a kernel, and then `ndloop_set_stepidx` has to read that one entry back on the host to fold it into the position -- which it does with `cudaDeviceSynchronize`. A step describes the same view and needs none of that.

## Why it is worth it

The synchronize costs whatever is queued, and nothing in the expression suggests it waits. Measured with twenty kernels queued ahead of it, against the same operation on a view built from a range rather than an array:

| | before | after |
|---|---|---|
| `a[[0], true] * 2.0` | 104.3us | **3.5us** |
| `a[0...1, true] * 2.0` (control) | 3.2us | 3.2us |
| `a.at(idx, idx)` (control) | 108.9us | 105.2us |

With the stream empty the same expression reads 8.4us against the control's 9.5us, so the cost only shows once there is work to wait for.

## at() is left out

`at()` gathers through an index array whatever it is given, so handing it a step makes `cumo_na_index_at_nadata` allocate one and synchronize instead -- `a.at([0], [0])` went from 12.9us to 77.0us before the exclusion was added, which is where `a.at(0...1, 0...1)` already sits at 79.9us. That synchronize is a separate matter; this change leaves `at()` exactly as it was.

## Checks

- The suite passes, and `ndloop_set_stepidx` fires 305 times across it rather than 625, with the `at` sites unchanged at their old counts.
- 22 subscript forms agree with Numo on both value and shape, including negative indices, an `Int32` index, a Bit mask that selects one row, a subscript of a view, writes through the folded view, and an in-place operation on it.
- Two mutations -- a step of 0, which would trim the dimension, and folding element 0 rather than the one named -- each fail four tests in the suite. Dropping the range check core-dumps.
