### PR TITLE
Count the synchronizes so a view's index is read through at most one of them

### DIFF
--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -78,6 +78,8 @@ void cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep);
 
 // used in aref, aset
 int cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);
+void cumo_na_index_mark_filled(cumo_narray_view_t *nv);
+void cumo_na_index_wait_fill(const cumo_narray_view_t *nv);
 VALUE cumo_na_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result_nd, size_t pos);
 VALUE cumo_na_at_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result_nd, size_t pos);
 

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -248,6 +248,8 @@ typedef struct {
                          // elm.step_unit = elm.bit_size / elm.access_unit
                          // elm.step_unit = elm.size_bits / elm.unit_bits
     cumo_stridx_t *stridx;    // stride or indices of data pointer for each dimension
+    uint64_t index_sync_epoch; // synchronizes counted when the index fills were
+                               // issued; UINT64_MAX when that is not known
 } cumo_narray_view_t;
 
 

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -613,6 +613,7 @@ cumo_na_flatten_dim(VALUE self, int sd)
         }
         break;
     }
+    cumo_na_index_mark_filled(na2);
     return view;
 }
 

--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -154,6 +154,7 @@ static VALUE
     nv->stridx = ALLOC_N(cumo_stridx_t,1);
     nv->stridx[0] = stridx0;
     nv->offset = 0;
+    cumo_na_index_mark_filled(nv);
 
     switch(CUMO_NA_TYPE(na)) {
     case CUMO_NARRAY_DATA_T:

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -107,6 +107,36 @@ cumo_na_range_check(ssize_t pos, ssize_t size, int dim)
     return idx;
 }
 
+// A view's index arrays are written once, by the kernels that build the view,
+// and never again, so a host read of one entry has to wait for those and for
+// nothing else. cudaDeviceSynchronize is the only way to ask, and it waits for
+// everything queued: a scalar read of a[idx, true] cost 70us behind twenty
+// kernels, against 0.2us for the same read on a view built from a range.
+//
+// What it does give is that one of them settles every view built before it. So
+// count them, have a view remember the count its fills were issued at, and skip
+// the wait once the count has moved on. A view whose count is unknown waits as
+// it did before, which is what makes missing a place that builds one cost speed
+// rather than correctness.
+static uint64_t cumo_na_sync_epoch = 0;
+
+void
+cumo_na_index_mark_filled(cumo_narray_view_t *nv)
+{
+    nv->index_sync_epoch = cumo_na_sync_epoch;
+}
+
+void
+cumo_na_index_wait_fill(const cumo_narray_view_t *nv)
+{
+    if (nv->index_sync_epoch < cumo_na_sync_epoch) {
+        return;
+    }
+    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_index_wait_fill");
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_na_sync_epoch++;
+}
+
 // copy ruby array to idx
 static void
 cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *q, int at_mode)
@@ -926,6 +956,8 @@ VALUE cumo_na_aref_md_protected(VALUE data_value)
         }
         break;
     }
+    cumo_na_index_mark_filled(na2);
+
     if (store) {
         cumo_na_get_pointer_for_write(store); // allocate memory
         cumo_na_store(cumo_na_flatten_dim(store,0),view);
@@ -1152,8 +1184,7 @@ cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, 
                 x = cumo_na_range_check(idx[i], na->shape[i], i);
                 sdx = nv->stridx[i];
                 if (CUMO_SDX_IS_INDEX(sdx)) {
-                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_get_result_dimension");
-                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+                    cumo_na_index_wait_fill(nv);
                     pos += CUMO_SDX_GET_INDEX(sdx)[x];
                 } else {
                     pos += CUMO_SDX_GET_STRIDE(sdx)*x;
@@ -1170,8 +1201,7 @@ cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, 
                 x = x / s;
                 sdx = nv->stridx[i];
                 if (CUMO_SDX_IS_INDEX(sdx)) {
-                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_get_result_dimension");
-                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+                    cumo_na_index_wait_fill(nv);
                     pos += CUMO_SDX_GET_INDEX(sdx)[m];
                 } else {
                     pos += CUMO_SDX_GET_STRIDE(sdx)*m;

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -215,6 +215,7 @@ cumo_na_s_allocate_view(VALUE klass)
     na->data = Qnil;
     na->offset = 0;
     na->stridx = NULL;
+    na->index_sync_epoch = UINT64_MAX;
     return TypedData_Wrap_Struct(klass, &cumo_na_data_type_view, (void*)na);
 }
 

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -581,8 +581,7 @@ ndloop_set_stepidx(cumo_na_md_loop_t *lp, int j, VALUE vna, int *dim_map, int rw
                 }
             } else if (n==1) {
                 if (CUMO_SDX_IS_INDEX(sdx)) {
-                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("ndloop_set_stepidx", "any");
-                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+                    cumo_na_index_wait_fill((const cumo_narray_view_t *)na);
                     LITER(lp,0,j).pos += CUMO_SDX_GET_INDEX(sdx)[0];
                 }
             }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5487,6 +5487,36 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([5.0], a.at(Cumo::Int32[0], Cumo::Int32[1], Cumo::Int32[2]).to_a)
   end
 
+  test "an element read waits for the kernel that filled the view's index" do
+    rows, cols = 4096, 512
+    a = Cumo::SFloat.new(rows, cols).seq(1)
+    busy = Cumo::SFloat.new(2048, 2048).seq(1)
+    wrong = []
+    8.times do |rep|
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      30.times { busy.inplace * 2.0 }
+      order = (0...rows).to_a.rotate(rep * 7 + 1)
+      view = a[Cumo::Int32.cast(order), true]
+      got = view[0, 0].to_a.first
+      wrong << [rep, got] if got != order[0] * cols + 1.0
+    end
+    assert_equal([], wrong)
+  end
+
+  test "an element read waits for the kernel that filled a mask's index" do
+    n = 1 << 20
+    a = Cumo::SFloat.new(n).seq(1)
+    busy = Cumo::SFloat.new(2048, 2048).seq(1)
+    wrong = []
+    8.times do
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      30.times { busy.inplace * 2.0 }
+      view = a[a > 1.0]
+      wrong << view[0].to_a.first if view[0].to_a.first != 2.0
+    end
+    assert_equal([], wrong)
+  end
+
   test "a subclass of RObject keeps its data on the host too" do
     klass = Class.new(Cumo::RObject)
     a = klass.new(6)


### PR DESCRIPTION

Reading one element of a view whose dimension is backed by an index array -- `a[idx, true][0, 0]`, or `a[mask][0]` -- has to fetch one `size_t` from device memory that a kernel wrote, so it waits with `cudaDeviceSynchronize`, which waits for everything queued. Nothing in the expression suggests it, and the cost is whatever the program has in flight.

Measured with twenty kernels queued, against the same read on a view built from a range rather than an index array:

| | before | after |
|---|---|---|
| `a[idx, true][0, 0]`, read again after the queue was refilled | 54.2us | **0.2us** |
| `a[0...rows, true][0, 0]`, same (control) | 0.2us | 0.2us |

## What it does

A view's index arrays are written once, by the kernels that build the view, and never again. And one `cudaDeviceSynchronize` settles every view built before it. So count them: a view remembers the count its fills were issued at, and a read skips the wait once the count has moved on. The first read of a view still waits -- there is no way to ask for less without an event -- but every read after it, of that view or of any view built earlier, is free.

A view whose count is unknown waits exactly as it did before. That is what makes missing a place that builds one cost speed rather than correctness; `aref`, `at`, `mask` and `flatten` set it, and the rest keep the old behaviour.

## Checks

- The suite passes. The two new tests bury the index fill behind thirty kernels and read an element straight after: with the wait removed both fail, and so does stamping the view with an epoch it was not built at.
- 22 subscript forms agree with Numo on value and shape, and a forty-round race repro that reads a permuted view immediately after building it answers wrong 22 times out of 40 without the wait and never with it.
