### PR TITLE
Wait where a view's index is read, not where at() writes one

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -591,6 +591,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
             // numeric index -- trim dimension
             if (!keep_dim && q[i].n==1 && q[i].step==0) {
                 if (CUMO_SDX_IS_INDEX(sdx1)) {
+                    cumo_na_index_wait_fill(na1);
                     na2->offset += CUMO_SDX_GET_INDEX(sdx1)[q[i].beg];
                 } else {
                     na2->offset += CUMO_SDX_GET_STRIDE(sdx1)*q[i].beg;
@@ -677,7 +678,6 @@ cumo_na_index_at_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
     ssize_t *strides_na1;
     size_t  *index;
     ssize_t beg, step;
-    int use_cumo_cuda_runtime_malloc = 0;
 
     strides_na1 = ALLOCA_N(ssize_t, na1->base.ndim);
     cumo_na_get_strides_nadata(na1, strides_na1, elmsz);
@@ -687,7 +687,6 @@ cumo_na_index_at_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
     } else {
         //index = ALLOC_N(size_t, size);
         index = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*size);
-        use_cumo_cuda_runtime_malloc = 1;
     }
     CUMO_SDX_SET_INDEX(na2->stridx[0], index);
 
@@ -723,10 +722,6 @@ cumo_na_index_at_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
     }
     na2->base.size = size;
     na2->base.shape[0] = size;
-    if (use_cumo_cuda_runtime_malloc) {
-        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_index_at_nadata");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    }
 }
 
 void cumo_na_index_at_naview_index_index_index_add_kernel_launch(size_t *idx, size_t *idx1, size_t *idx2, uint64_t n);
@@ -740,14 +735,12 @@ cumo_na_index_at_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
     int i;
     size_t  *index;
     size_t size = q[ndim-1].n;
-    int use_cumo_cuda_runtime_malloc = 0;
 
     if (q[ndim-1].idx != NULL) {
         index = q[ndim-1].idx;
     } else {
         //index = ALLOC_N(size_t, size);
         index = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*size);
-        use_cumo_cuda_runtime_malloc = 1;
     }
     CUMO_SDX_SET_INDEX(na2->stridx[0], index);
 
@@ -841,10 +834,6 @@ cumo_na_index_at_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
     }
     na2->base.size = size;
     na2->base.shape[0] = size;
-    if (use_cumo_cuda_runtime_malloc) {
-        CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_index_at_naview");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    }
 }
 
 static int

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5517,6 +5517,21 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([], wrong)
   end
 
+  test "trimming a dimension waits for the kernel that filled the view's index" do
+    rows, cols = 4096, 512
+    a = Cumo::SFloat.new(rows, cols).seq(1)
+    busy = Cumo::SFloat.new(2048, 2048).seq(1)
+    wrong = []
+    8.times do |rep|
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      30.times { busy.inplace * 2.0 }
+      order = (0...rows).to_a.rotate(rep * 11 + 3)
+      got = a[Cumo::Int32.cast(order), true][0, true][0].to_a.first
+      wrong << [rep, got] if got != order[0] * cols + 1.0
+    end
+    assert_equal([], wrong)
+  end
+
   test "a subclass of RObject keeps its data on the host too" do
     klass = Class.new(Cumo::RObject)
     a = klass.new(6)


### PR DESCRIPTION

Trimming a dimension of an index-backed view -- `a[idx, true][0, true]` -- reads one entry of the parent's index array on the host without waiting for the kernel that wrote it. It answers with whatever the memory held. Thirty rounds that build such a view behind forty queued kernels and read an element back get **23 of 30 wrong**, some of them garbage:

```
rep 1: got 1.0 want 7169.0
rep 2: got 5.95782781324968e-39 want 12801.0
```

The fence added in #332 is what that read was missing.

## The synchronize at the other end

`cumo_na_index_at_nadata` and `cumo_na_index_at_naview` end with a `cudaDeviceSynchronize`, guarded by whether the function allocated the index array itself. Nothing in either function reads that array on the host, and the branch that does not allocate runs the same kernels over the same kind of memory without synchronizing -- so the guard tracks who allocated rather than anything about correctness. Every host read of an index array now waits for itself, so this one can go.

It was not free: `a.at(0...1, 0...1)` behind twenty queued kernels **79.9us to 3.9us**. `a.at([0, 1], [0, 1])` reads 8.2us either way, since a subscript that brings its own index array never took the syncing branch.

## Checks

- The suite passes, and the new test -- build an index-backed view behind thirty kernels, trim a dimension, read an element -- fails when the fence is taken out again.
- The `at` race the removed synchronize might have been hiding does not appear: thirty rounds building an `at` view behind a queue and reading an element are all correct.
- `a[idx, true].dot(b)` matches Numo quiet and behind a queue, before and after.

## One that is not a bug

`cumo_na_new_dimension_for_dot` reads a parent's index on the host too, and copies one into host memory with `ALLOC_N`. `a[idx, true].dot(b)` matches Numo in both conditions, so there is nothing to reproduce and this leaves it alone. A first reading that said otherwise was an absolute tolerance of 1e-4 against single-precision values near 1000.
