### PR TITLE
Wait once before an md-loop walks an index array, not once per row

### DIFF
--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1550,6 +1550,8 @@ loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
         rb_bug("bug? lp->ndim = %d\n", lp->ndim);
     }
 
+    // One wait settles every index array the loop below reads, so the loop
+    // reads them without one of its own.
     ndloop_sync_md_index(lp);
     ndloop_sync_user_index(lp);
 
@@ -1582,8 +1584,6 @@ loop_narray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp)
             // j-th argument
             for (j=0; j<lp->narg; j++) {
                 if (LITER(lp,i,j).idx) {
-                    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("loop_narrayx", "any");
-                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).idx[c[i]];
                 } else {
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).step*c[i];


### PR DESCRIPTION
`ndloop` walks the outer dimensions of a view built from an index array on the host, reading one `size_t` per row out of memory a kernel filled. Each of those reads took a `cudaDeviceSynchronize` of its own, added in a271430b (2018) to avoid a bus error.

* That wait is already done. Since #265, `ndloop_sync_md_index` runs at the top of `loop_narray` and covers exactly the iterators the loop reads — `loop_is_using_idx` scans dimensions `0` to `lp->ndim` over every argument. The other md-loops built on it, `loop_inspect` among them, read `idx` without one of their own; `loop_narray` kept both.
* Measured on a view gathering 2000 rows of a 4000x64 array, twenty kernels queued first, one case per process, min of 9, builds alternated: `rand` 11.2ms → 3.4ms, `bincount` 12.1ms → 6.3ms.
* What reaches this loop is any ndfunc without `CUMO_NDF_INDEXER_LOOP` applied to a view whose index array sits on an axis the user loop does not cover: `a[bit]`, `Bit#where`, `bincount`, `rand`, `logseq`, `each`, `format`, `swap_byte`/`hton`/`to_network`, and every `RObject` operation.
* No test comes with this. The synchronize is redundant rather than load-bearing, and a build that drops the remaining wait as well still passes — the allocation each of these operations makes drains the queue before the host reads `idx`, so nothing distinguishes the two. The existing coverage of these paths passes unchanged, along with the rest of the suite (1851 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)