### PR TITLE
Reject a batch_norm axis outside x, repeated, or out of order

### DIFF
--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -151,8 +151,26 @@ cumo_cuda_cudnn_get_int_axis(int* int_axis, VALUE axis)
     for (size_t idim = 0; idim < axis_ndim; ++idim) {
         int_axis[idim] = NUM2INT(rb_ary_entry(axis, (long)idim));
     }
-    // TODO: check axis is sorted
     return axis_ndim;
+}
+
+// The axis names dimensions of x, and the batch normalization mode is picked
+// from it. One outside x, repeated, or out of order names neither: the mode
+// comes out the same either way, so the call goes through and answers as
+// though a different axis had been given.
+static inline void
+cumo_cuda_cudnn_check_axis(size_t axis_ndim, int* int_axis, size_t x_ndim)
+{
+    for (size_t idim = 0; idim < axis_ndim; ++idim) {
+        if (int_axis[idim] < 0 || (size_t)int_axis[idim] >= x_ndim) {
+            rb_raise(rb_eArgError, "axis[%d]=%d is out of range for a %d-dimensional array",
+                     (int)idim, int_axis[idim], (int)x_ndim);
+        }
+        if (idim > 0 && int_axis[idim] <= int_axis[idim - 1]) {
+            rb_raise(rb_eArgError, "axis must increase, but axis[%d]=%d follows axis[%d]=%d",
+                     (int)idim, int_axis[idim], (int)(idim - 1), int_axis[idim - 1]);
+        }
+    }
 }
 
 size_t

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -93,6 +93,7 @@ static VALUE
 
     CumoGetNArray(x, nx);
     x_ndim = nx->ndim;
+    cumo_cuda_cudnn_check_axis(axis_ndim, int_axis, x_ndim);
     x_shape = nx->shape;
 
     {

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -80,6 +80,7 @@ static VALUE
     CumoGetNArray(x, nx);
     CumoGetNArray(gamma, ngamma);
     x_ndim = nx->ndim;
+    cumo_cuda_cudnn_check_axis(axis_ndim, int_axis, x_ndim);
     x_shape = nx->shape;
     gamma_ndim = ngamma->ndim;
     gamma_shape = ngamma->shape;

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -63,6 +63,7 @@ static VALUE
 
     CumoGetNArray(x, nx);
     x_ndim = nx->ndim;
+    cumo_cuda_cudnn_check_axis(axis_ndim, int_axis, x_ndim);
     x_shape = nx->shape;
 
     {

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -325,6 +325,51 @@ class CUDNNTest < Test::Unit::TestCase
       end
     end
 
+    # The mode cuDNN is given comes from x's shape, not from the axis, so an
+    # axis that names nothing in x answers as though a different one had been
+    # given rather than failing. The sizes below are the ones that reach the
+    # kernel, so nothing else can raise first.
+    sub_test_case "an axis that does not name x's dimensions" do
+      setup do
+        @x = dtype.new(2, 4, 3, 3).seq(1)
+        @gamma = dtype.ones(4)
+        @beta = dtype.zeros(4)
+        @gy = dtype.ones(2, 4, 3, 3)
+      end
+
+      test "batch_norm rejects an axis outside x #{dtype}" do
+        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(72), dtype.zeros(72), axis: [5]) }
+        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(72), dtype.zeros(72), axis: [-1]) }
+      end
+
+      test "batch_norm rejects a repeated or unordered axis #{dtype}" do
+        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(36), dtype.zeros(36), axis: [0, 0]) }
+        assert_raise(ArgumentError) { @x.batch_norm(@gamma, @beta, axis: [3, 0, 2]) }
+        assert_raise(ArgumentError) { @x.batch_norm(@gamma, @beta, axis: [0, 3, 2]) }
+      end
+
+      test "fixed_batch_norm and batch_norm_backward reject it too #{dtype}" do
+        assert_raise(ArgumentError) do
+          @x.fixed_batch_norm(@gamma, @beta, @beta, @gamma, axis: [5])
+        end
+        assert_raise(ArgumentError) do
+          @x.fixed_batch_norm(@gamma, @beta, @beta, @gamma, axis: [0, 0])
+        end
+        assert_raise(ArgumentError) { @x.batch_norm_backward(@gamma, @gy, axis: [-1]) }
+        assert_raise(ArgumentError) { @x.batch_norm_backward(@gamma, @gy, axis: [3, 0, 2]) }
+      end
+
+      test "the spatial axis and the default still go through #{dtype}" do
+        assert { @x.batch_norm(@gamma, @beta, axis: [0, 2, 3]).shape == [2, 4, 3, 3] }
+        assert { @x.fixed_batch_norm(@gamma, @beta, @beta, @gamma, axis: [0, 2, 3]).shape == [2, 4, 3, 3] }
+        assert { @x.batch_norm_backward(@gamma, @gy, axis: [0, 2, 3]).first.shape == [2, 4, 3, 3] }
+
+        flat = dtype.new(8, 4).seq(1)
+        assert { flat.batch_norm(@gamma, @beta).shape == [8, 4] }
+        assert { flat.batch_norm(@gamma, @beta, axis: [0]).shape == [8, 4] }
+      end
+    end
+
     sub_test_case "batch_norm_backward" do
       setup do
         @batch_size = 2


### PR DESCRIPTION
The batch normalization mode cuDNN is given comes from x's shape, not from the axis: `GetBatchNormMode` returns `CUDNN_BATCHNORM_SPATIAL` for an axis of one or two dimensions whatever the values are. An axis that names nothing in x went through and answered as though a different one had been given.

Measured on `Cumo::SFloat.new(2, 4, 3, 3)`, against the result of `axis: [0, 2, 3]`:

| axis | before | after |
|---|---|---|
| `[5]` (outside x) | ok, `max\|y − spatial\| = 0` | `ArgumentError: axis[0]=5 is out of range for a 4-dimensional array` |
| `[-1]` | ok, `max\|y − spatial\| = 0` | `ArgumentError: axis[0]=-1 is out of range …` |
| `[0, 0]` (repeated) | ok, `max\|y − spatial\| = 0` | `ArgumentError: axis must increase, but axis[1]=0 follows axis[0]=0` |
| `[3, 0, 2]` (unordered) | `ShapeError: size mismatch: 4 != 24` | `ArgumentError: axis must increase, but axis[1]=0 follows axis[0]=3` |
| `[0, 2, 3]` | ok | ok |

* The only thing that stopped any of them was the reduced-size guard from #303, and that is a size check rather than an axis check — the unordered case raised about `gamma`'s size, naming the wrong operand.
* The check runs before the axis is used, in all three of `batch_norm`, `fixed_batch_norm` and `batch_norm_backward`.
* **It does not reach `axis: [1]` or `[0, 1]`**, which are inside x and ordered. Rejecting those means requiring the axis cuDNN actually honours — `0` and the dimensions after the channel — which would also reject the default `axis: [0]` on a 4-dimensional x that the tests in this file use. That is a separate, breaking decision.

Tests: 4 new cases × 2 dtypes covering each rejected form on all three methods, plus a case asserting the spatial axis and the default still go through. Positive control: making the check a no-op fails 6 of the 8 and leaves the two "still go through" cases passing.

Note for reviewers: editing only `cudnn.h` does not rebuild the templates that include it — `rake compile` reports success while the old objects stay. The templates have to be touched (or `rake clean`) or the change silently does not take effect; the first run of the positive control passed for that reason.

Suite: 1862 tests, 31688 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)