### PR TITLE
Drop the bn_desc cast TODO the parameter type checks already answer

### DIFF
--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -166,7 +166,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_ERROR;
-    // TODO: bn_desc may return another type, and may need to cast gamma, beta, mean, var
+    // The derived descriptor carries x's own type -- cuDNN widens only for
+    // half, which these templates are never generated for -- and the checks
+    // above hold every parameter to x's class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -151,7 +151,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_BACKWARD_ERROR;
-    // TODO: bn_desc may return another type, and may need to cast gamma, gy, mean, var
+    // The derived descriptor carries x's own type -- cuDNN widens only for
+    // half, which these templates are never generated for -- and the checks
+    // above hold every parameter to x's class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -115,7 +115,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto FIXED_BATCH_NORM_ERROR;
-    // TODO: bn_desc may return another type, and may need to cast gamma, beta, mean, var
+    // The derived descriptor carries x's own type -- cuDNN widens only for
+    // half, which these templates are never generated for -- and the checks
+    // above hold every parameter to x's class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -329,6 +329,49 @@ class CUDNNTest < Test::Unit::TestCase
     # axis that names nothing in x answers as though a different one had been
     # given rather than failing. The sizes below are the ones that reach the
     # kernel, so nothing else can raise first.
+    # cuDNN derives the parameter descriptor from x and gives it x's own type,
+    # widening only for half, which these methods are never generated for. What
+    # makes that enough is that every parameter is held to x's class here, so
+    # the descriptor and the buffer behind it can never disagree.
+    sub_test_case "a parameter of another dtype" do
+      setup do
+        @other = (dtype == Cumo::SFloat) ? Cumo::DFloat : Cumo::SFloat
+        @x = dtype.new(2, 4, 3, 3).seq(1)
+        @gamma = dtype.ones(4)
+        @beta = dtype.zeros(4)
+        @gy = dtype.ones(2, 4, 3, 3)
+        @axis = [0, 2, 3]
+      end
+
+      test "batch_norm rejects it #{dtype}" do
+        assert_raise(TypeError) { @x.batch_norm(@other.ones(4), @beta, axis: @axis) }
+        assert_raise(TypeError) { @x.batch_norm(@gamma, @other.zeros(4), axis: @axis) }
+        assert_raise(TypeError) do
+          @x.batch_norm(@gamma, @beta, axis: @axis, running_mean: @other.zeros(4), running_var: @other.ones(4))
+        end
+        assert_raise(TypeError) do
+          @x.batch_norm(@gamma, @beta, axis: @axis, mean: @other.zeros(4), inv_std: @other.zeros(4))
+        end
+      end
+
+      test "fixed_batch_norm and batch_norm_backward reject it #{dtype}" do
+        assert_raise(TypeError) do
+          @x.fixed_batch_norm(@other.ones(4), @beta, @beta, @gamma, axis: @axis)
+        end
+        assert_raise(TypeError) do
+          @x.fixed_batch_norm(@gamma, @beta, @other.zeros(4), @gamma, axis: @axis)
+        end
+        assert_raise(TypeError) { @x.batch_norm_backward(@other.ones(4), @gy, axis: @axis) }
+        assert_raise(TypeError) { @x.batch_norm_backward(@gamma, @other.ones(2, 4, 3, 3), axis: @axis) }
+      end
+
+      test "the same call with x's own dtype goes through #{dtype}" do
+        assert { @x.batch_norm(@gamma, @beta, axis: @axis).class == dtype }
+        assert { @x.fixed_batch_norm(@gamma, @beta, @beta, @gamma, axis: @axis).class == dtype }
+        assert { @x.batch_norm_backward(@gamma, @gy, axis: @axis).first.class == dtype }
+      end
+    end
+
     sub_test_case "an axis that does not name x's dimensions" do
       setup do
         @x = dtype.new(2, 4, 3, 3).seq(1)


### PR DESCRIPTION
`batch_norm`, `batch_norm_backward` and `fixed_batch_norm` each carried a TODO saying the descriptor derived by `cudnnDeriveBNTensorDescriptor` may come back as another type, and that `gamma`, `beta`, `mean` and `var` may then need casting. It cannot happen here.

* cuDNN widens only for half. Measured on cuDNN 9.25.0 with a descriptor derived from a 4-D `x`, under both `SPATIAL` and `PER_ACTIVATION`:

  | x | derived |
  |---|---|
  | `CUDNN_DATA_FLOAT` | `FLOAT` |
  | `CUDNN_DATA_DOUBLE` | `DOUBLE` |
  | `CUDNN_DATA_HALF` | `FLOAT` |

* These templates are generated for the real float types only — `is_float && !is_complex && !is_object` in `gen/spec.rb:359` — so the half row never arises.
* Every parameter is already held to x's own class by `CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE`, so the descriptor and the buffer behind it cannot disagree. The TODO is replaced by the two sentences that make it unnecessary, the way #308 replaced the contiguity asserts.

Tests: the type checks the argument rests on had no coverage, so a parameter of the other float type is now asserted to raise `TypeError` in all three methods (`gamma`, `beta`, `running_mean`/`running_var`, `mean`/`inv_std`, `gy`), with a case asserting x's own dtype still goes through and answers in that dtype.

Positive control: making `CUMO_CUDA_CUDNN_CHECK_NARRAY_TYPE` a no-op fails all four of the new "reject" cases and leaves the two "goes through" cases passing — without it, none of those calls raise at all.

Suite: 1868 tests, 31710 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)