### PR TITLE
Answer the SPATIAL_PERSISTENT TODO with what it measures

### DIFF
--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -552,7 +552,15 @@ cumo_cuda_cudnn_GetBatchNormMode(size_t ndim, int* axis) {
     }
     if ((ndim == 3 && axis[0] == 0 && axis[1] == 2 && axis[2] == 3) ||
         (ndim == 4 && axis[0] == 0 && axis[1] == 2 && axis[2] == 3 && axis[3] == 4)) {  // (1, channels, (1, )1, 1)
-        // TODO: Consider CUDNN_BATCHNORM_SPATIAL_PERSISTENT if we can afford to check for overflow, with or without blocking.
+        // CUDNN_BATCHNORM_SPATIAL_PERSISTENT is not worth taking. The overflow
+        // check it asks for is affordable -- cudnnQueryRuntimeError costs 0.1us
+        // either way -- but the mode is 1.3 to 1.8x faster only where the
+        // spatial extent is large, and 1.6x slower on 32x256x14x14 backward.
+        // Worse, on 32x64x56x56 it raises CUDNN_STATUS_RUNTIME_FP_OVERFLOW for x
+        // in [-2, 2] with gamma 1 and beta 0, answering bit for bit what SPATIAL
+        // does; honouring that means running SPATIAL again on top. The mode, and
+        // the batch normalization API it belongs to, are deprecated as of cuDNN
+        // 9.0.0 besides.
         return CUDNN_BATCHNORM_SPATIAL;
     }
     rb_raise(rb_eRuntimeError, "Invalid axis for BatchNorm using cuDNN. Expected 1, 3 or 4 dimensions.");


### PR DESCRIPTION
`cumo_cuda_cudnn_GetBatchNormMode` carried `// TODO: Consider CUDNN_BATCHNORM_SPATIAL_PERSISTENT if we can afford to check for overflow, with or without blocking.` Measured, and the answer is no. The comment is replaced by the reason so the question does not have to be reopened.

**The check is affordable.** `cudnnQueryRuntimeError` costs 0.10us non-blocking and 0.13us blocking. That part of the TODO's worry does not hold.

**The mode is not a uniform win.** cuDNN 9.25.0, NCHW float, twenty calls to a synchronize, min of five, reproduced twice:

| shape | forward | backward |
|---|---|---|
| 32x64x56x56 | 1.31–1.35x | 1.69–1.72x |
| 32x256x14x14 | 1.00x | **0.61x** |
| 128x32x32x32 | 1.34–1.35x | 1.66–1.83x |
| 2x4x3x3 | 1.00x | 1.02x |

Taking it unconditionally makes `32x256x14x14` backward half again slower. Taking it conditionally needs a rule cuDNN does not document, tuned per card.

**And where it does pay, it raises the overflow flag on ordinary input.** On `32x64x56x56` with x in [-2, 2], gamma 1 and beta 0, `cudnnQueryRuntimeError` reports `CUDNN_STATUS_RUNTIME_FP_OVERFLOW` after the forward — while the output is bit for bit what `SPATIAL` produces (`max|y diff| = 0`, same for `dx` and `dgamma`). Smaller shapes do not raise it. Honouring the flag as documented means running `SPATIAL` again on top, so the fast case is the one that costs double.

**The API is deprecated anyway.** `cudnnBatchNormMode_t` and the three `cudnnBatchNormalization*` entry points cumo calls are all marked `CUDNN_DEPRECATED` as of cuDNN 9.0.0, "Use graph API instead".

No test comes with this: the change is a comment, and what it records is cuDNN's behaviour rather than cumo's. Suite unchanged at 1868 tests, 31710 assertions, 0 failures.

With this the cuDNN-layer TODO list from the 2026-08-20 inventory is down to two, both of which were assessed as not worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)