### PR TITLE
Say what TestRemoveFromFreeList holds, not what it waits for

### DIFF
--- a/ext/cumo/cuda/memory_pool_impl_test.cpp
+++ b/ext/cumo/cuda/memory_pool_impl_test.cpp
@@ -337,7 +337,10 @@ public:
         assert(pool_->GetFreeBytes() == kRoundSize * 8);
     }
 
-    // TODO(sonots): Fix after implementing compaction
+    // RemoveFromFreeList leaves an emptied bin in the arena -- it erases the
+    // chunk and returns, where Malloc drops one through CompactIndex. The
+    // assertions below spell that out, so they describe the arena as it is
+    // rather than wait on a compaction this path is not getting.
     void TestRemoveFromFreeList() {
         Arena& arena = pool_->GetArena(stream_ptr_);
         ArenaIndexMap& arena_index_map = pool_->GetArenaIndexMap(stream_ptr_);


### PR DESCRIPTION
`TestRemoveFromFreeList` carried `// TODO(sonots): Fix after implementing compaction`. Since #279 there *is* compaction — in `Malloc`, which drops a free list it empties through `CompactIndex` — so the comment now reads as though the test were waiting for something that has already landed.

What it is actually waiting for is compaction in `RemoveFromFreeList`, which does not do it: it finds the bin, erases the chunk from the free list and returns, leaving the emptied bin in the arena. The assertions below the comment describe exactly that — an arena of three bins with two empty free lists, and an index map that does not move — so the comment now says that instead.

Comment only; the assertions are untouched. `rake ctest` passes (the `.exe` was deleted first so it really rebuilt — `rake clean` does not remove it).

This is the last of the five items in the memory-pool/stream TODO inventory that had anything to change. The other four are: two that are conditional on cumo gaining a Stream object (`memory_pool.cpp:43,182` — passing `0` is correct while every kernel runs on the default stream), and two about the test harness (`googletest?` / building outside extconf, while `rake ctest` works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)