### PR TITLE
Return a zero-dimensional Bit from extract, as every other dtype does

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/bit_reduce.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_reduce.c
@@ -46,7 +46,10 @@ static VALUE
     if (argc > 0) {
         return v;
     }
-    v = <%=find_tmpl("extract").c_func%>(v);
+    // all?, any? and none? answer with a Ruby boolean either way, so this
+    // reads the bit rather than handing back the zero-dimensional Bit that
+    // extract returns outside compatible mode.
+    v = <%=find_tmpl("extract_cpu").c_func%>(v);
     switch (v) {
     case INT2FIX(0):
         return Qfalse;

--- a/ext/cumo/narray/gen/tmpl_bit/extract.c
+++ b/ext/cumo/narray/gen/tmpl_bit/extract.c
@@ -1,36 +1,22 @@
-/*
-  Extract an element only if self is a dimensionless NArray.
-  @overload extract
-  @return [Numeric,Cumo::NArray]
-  --- Extract element value as Ruby Object if self is a dimensionless NArray,
-  otherwise returns self.
-*/
+static VALUE
+<%=c_func(0)%>_cpu(VALUE self);
 
-// TODO(sonots): Return Cumo::Bit instead of ruby built-in object to avoid synchronization
+/*
+  Returns self.
+  @overload extract
+  @return [Cumo::Bit]
+  --- Note that Cumo::Bit always returns Cumo::Bit and does not
+  return a Ruby Integer as Numo::Bit does to avoid
+  synchronization between CPU and GPU for performance.
+
+  Call `Cumo.enable_compatible_mode` to make this method behave
+  compatible with Numo, or you can use `extract_cpu` method instead.
+*/
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
-    CUMO_BIT_DIGIT *ptr, val;
-    size_t pos;
-    cumo_narray_t *na;
-    CumoGetNArray(self,na);
-
-    if (na->ndim==0) {
-        pos = cumo_na_get_offset(self);
-        ptr = (CUMO_BIT_DIGIT*)cumo_na_get_pointer_for_read(self);
-
-        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-
-        {
-            // Reading through the managed pointer faults the whole page back from
-            // the device, which costs more than the kernel that wrote it.
-            CUMO_BIT_DIGIT word;
-            cumo_cuda_runtime_check_status(cudaMemcpy(&word, ptr+(pos)/CUMO_NB, sizeof(CUMO_BIT_DIGIT), cudaMemcpyDeviceToHost));
-            val = (word >> ((pos)%CUMO_NB)) & 1u;
-        }
-        cumo_na_release_lock(self);
-        return INT2FIX(val);
+    if (cumo_compatible_mode_enabled_p()) {
+        return <%=c_func(0)%>_cpu(self);
     }
     return self;
 }

--- a/test/cumo_test.rb
+++ b/test/cumo_test.rb
@@ -61,6 +61,7 @@ class CumoTest < Test::Unit::TestCase
     count_true: -> { (Cumo::DFloat[3, 1, 7] > 2).count_true },
     count_false: -> { (Cumo::DFloat[3, 1, 7] > 2).count_false },
     bit_aref: -> { (Cumo::DFloat[3, 1, 7] > 2)[1] },
+    bit_extract: -> { Cumo::Bit.cast(1).extract },
   }.freeze
 
   def test_compatible_mode_extracts_every_documented_method


### PR DESCRIPTION
`Cumo::Bit#extract` answered with a Ruby `Integer` and synchronized to get it, where every other dtype returns self and reads the value only under compatible mode or through `extract_cpu`. That is what the other `extract`'s own documentation says it does — *"does not return a Ruby numeric object as Numo::NArray does to avoid synchronization between CPU and GPU for performance"* — and `tmpl_bit/extract.c` did not even look at `cumo_compatible_mode_enabled_p()`, so there was no way to ask for the cheap answer.

| | `extract` on a 0-dim | `extract_cpu` |
|---|---|---|
| `DFloat`, `Int32`, … | `Cumo::DFloat` | `Float` |
| `Bit` **before** | `Integer` | `Integer` |
| `Bit` **after** | `Cumo::Bit` | `Integer` |

Behind twenty queued kernels, one case per process, min of 9: **13.3us → 0.3us**, which is what the same call costs on `DFloat` (0.2us). `bit[0]` itself was already 0.2us — it returns the zero-dimensional view — so the cost only ever appeared on an explicit `extract`.

**Breaking**: `Bit#extract` returns `Cumo::Bit` where it returned `Integer`. `Cumo.enable_compatible_mode` and `extract_cpu` both give the old answer, as they do for every other dtype. `bit[i]` is unaffected either way: aref only extracts under compatible mode, which still reaches `extract_cpu`.

`all?`, `any?` and `none?` read the bit through `extract_cpu` now. They answer with a Ruby boolean in both modes, and `bit_reduce` switched on the Fixnum `extract` used to return — `default: rb_bug("unexpected result")`, which it reaches the moment it is handed the zero-dimensional Bit. That is how `bit_test.rb:38` caught it, as a SIGABRT, and it stands as the positive control for that half of the change.

Tests: `bit_extract` joins the `ZERO_DIMENSIONAL_INTEGERS` family in `cumo_test.rb`, so it is now covered by both directions the suite already checks — `Integer` under compatible mode, a 0-dimensional `Cumo::NArray` without it. The entry fails on master, which is the positive control for this half.

Suite: 1868 tests, 31713 assertions, 0 failures.

This is the last item in the driver/`Bit#extract` TODO inventory with anything to change; the other three (`cuLinkCreate` / `cuLinkAddData` / `cuLinkAddFile` taking no `CUjit_option`) are worth doing alongside issue #106, whose NVRTC path is their only caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)