### PR TITLE
Add argsort, the axis-relative counterpart of sort_index

### DIFF
--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -1121,6 +1121,61 @@ module Cumo
       a
     end
 
+    # Returns an index array of sort result.
+    #
+    # @example
+    #   require 'cumo/narray'
+    #
+    #   a = Cumo::DFloat[[0.1, 0.7],
+    #                    [0.4, 0.2],
+    #                    [0.2, 0.5]]
+    #   pp a.argsort
+    #   # =>
+    #   # Cumo::Int32#shape=[3,2]
+    #   # [[0, 1],
+    #   #  [1, 0],
+    #   #  [0, 1]]
+    #   pp a.argsort(axis: 0)
+    #   # =>
+    #   # Cumo::Int32#shape=[3,2]
+    #   # [[0, 1],
+    #   #  [2, 2],
+    #   #  [1, 0]]
+    #   pp a.argsort(axis: 1)
+    #   # =>
+    #   # Cumo::Int32#shape=[3,2]
+    #   # [[0, 1],
+    #   #  [1, 0],
+    #   #  [0, 1]]
+    #   pp a.argsort(axis: nil)
+    #   # =>
+    #   # Cumo::Int32#shape=[6]
+    #   # [0, 3, 4, 2, 5, 1]
+    #
+    # @overload argsort(axis: -1)
+    #   @param axis [Integer, nil] Axis along which to sort. Default is -1 (the last axis).
+    #     If `nil` is given, the array is flattened before sorting.
+    #   @return [Cumo::Int32] An array of indices that would sort the array.
+    def argsort(axis_ = 'none', axis: -1)
+      raise NotImplementedError, "argsort is not implemented for #{self.class}" unless respond_to?(:sort_index)
+
+      axis = axis_ unless axis_ == 'none'
+
+      return flatten.sort_index if axis.nil?
+
+      axis += ndim if axis < 0
+      raise NArray::DimensionError, "dimension is out of range" if axis < 0 || axis >= ndim
+
+      return sort_index if ndim == 1
+
+      # sort_index answers with an index into the flattened array; the axes
+      # after axis divide out of it and the ones before it fall to the modulo.
+      idx = sort_index(axis)
+      inner = shape[(axis + 1)..-1].reduce(1, :*)
+      idx = idx / inner if inner > 1
+      idx % shape[axis]
+    end
+
     # Return the sum along diagonals of the array.
     #
     # If 2-D array, computes the summation along its diagonal with the

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -484,8 +484,21 @@ class NArrayExtraTest < CumoTestBase
     end
   end
 
+  def argsort_ref_3d(ary, axis)
+    res = Cumo::Int32.zeros(*ary.shape)
+    d0, d1 = [0, 1, 2] - [axis]
+    ary.shape[d0].times do |i|
+      ary.shape[d1].times do |j|
+        slicer = Array.new(3, true)
+        slicer[d0] = i
+        slicer[d1] = j
+        res[*slicer] = ary[*slicer].sort_index
+      end
+    end
+    res
+  end
+
   def test_argsort
-    omit("Cumo does not implement argsort")
     types = [Cumo::SFloat, Cumo::DFloat, Cumo::Int64, Cumo::Int32, Cumo::Int16, Cumo::Int8,
              Cumo::UInt64, Cumo::UInt32, Cumo::UInt16, Cumo::UInt8]
     types.each do |dtype|
@@ -556,6 +569,21 @@ class NArrayExtraTest < CumoTestBase
         assert_equal(ex0, a.argsort(-2))
         assert_equal(ex1, a.argsort(-1))
         assert_equal(ex1, a.argsort)
+      end
+
+      shapes = [[2, 3, 4], [3, 2, 2]]
+      shapes.each do |shape|
+        a = dtype.new(*shape).rand - 0.5
+        ex0 = argsort_ref_3d(a, 0)
+        ex1 = argsort_ref_3d(a, 1)
+        ex2 = argsort_ref_3d(a, 2)
+
+        assert_equal(ex0, a.argsort(0))
+        assert_equal(ex1, a.argsort(1))
+        assert_equal(ex2, a.argsort(2))
+        assert_equal(ex0, a.argsort(-3))
+        assert_equal(ex2, a.argsort)
+        assert_equal(a.flatten.sort_index, a.argsort(nil))
       end
     end
   end


### PR DESCRIPTION
Ports `argsort` from numo-narray-alt (`514a1df`). The test was already in the tree behind an `omit`, which was the suite's last one.

`sort_index` answers with indices into the flattened array, so the position along the axis has to be derived from it. numo-narray-alt does that with a Ruby loop over every 1-D slice once the array is 3-D or more, which on a GPU is a separate sort per slice. This takes it from one `sort_index(axis)` instead: `idx / inner % shape[axis]`, where `inner` is the product of the axes after `axis`. Any rank costs one segmented sort plus two elementwise kernels.

- `DFloat[64,64,256]`, min of 5, device-synchronised: axis 0 **373 -> 9.3 ms**, axis 2 **94 -> 21 ms**.
- 2-D is a wash, as expected -- both are O(1) launches there. `[4096,1024]` axis 1: 7.7 vs 8.0 ms.
- Answers agree with numo-narray-alt's algorithm over 6 shapes x every axis, and with per-slice `sort_index` for 4 dtypes including tie-heavy integers. Ties keep the smallest position, as `sort_index` does.
- The ported test covers 3-D only with `seq`, so a 3-D random case is added. Dropping the division, or taking the modulus of the wrong extent, fails it.
- Suite: 1868 tests, 32015 assertions, 0 failures, 0 omissions.
