### PR TITLE
Finish cov, which numo left under construction

### DIFF
--- a/lib/cumo/narray/extra.rb
+++ b/lib/cumo/narray/extra.rb
@@ -1366,8 +1366,37 @@ module Cumo
     end
 
 
-    # under construction
+    # Compute a covariance matrix.
+    #
+    # @param y [Cumo::NArray] (optional) If not nil, the covariance matrix of `self` and `y` is computed.
+    # @param ddof [Integer] (optional) Delta degrees of freedom. The divisor used in calculations is `N - ddof`,
+    #   where `N` represents the number of observations.
+    # @param fweights [Cumo::NArray] (optional) 1-D array of integer frequency weights.
+    # @param aweights [Cumo::NArray] (optional) 1-D array of observation vector weights.
+    # @return [Cumo::NArray]  return covariance matrix
+    #
+    # @example
+    #   x = Cumo::DFloat[4, 5, 6]
+    #   x.cov
+    #   # => 1.0
+    #
+    #   x = Cumo::DFloat[[4, 5, 6], [3, 2, 1]]
+    #   x.cov
+    #   # => Cumo::DFloat#shape=[2,2]
+    #   # [[1, -1],
+    #   #  [-1, 1]]
+    #
+    #   y = Cumo::DFloat[7, 9, 8]
+    #   x.cov(y)
+    #   # => Cumo::DFloat#shape=[3,3]
+    #   # [[1, -1, 0.5],
+    #   #  [-1, 1, -0.5],
+    #   #  [0.5, -0.5, 1]]
     def cov(y=nil, ddof:1, fweights:nil, aweights:nil)
+      raise NArray::ShapeError, "ndim must be <= 2" if ndim > 2
+      raise NArray::ShapeError, "y.ndim must be <= 2" if !y.nil? && y.ndim > 2
+      raise ArgumentError, "ddof must be 0 or 1" unless [0, 1].include?(ddof)
+
       if y
         m = NArray.vstack([self, y])
       else
@@ -1375,38 +1404,49 @@ module Cumo
       end
       w = nil
       if fweights
-        f = fweights
-        w = f
+        fweights = NArray.cast(fweights) unless fweights.is_a?(NArray)
+        raise ArgumentError, "fweights must be 1-D array" unless fweights.ndim == 1
+        raise ArgumentError, "fweights size is wrong" unless fweights.size == m.shape[1]
+        raise ArgumentError, "fweights must be non-negative" if (fweights < 0).any?
+        raise ArgumentError, "fweights must be integer" unless fweights == fweights.floor
+        w = fweights
       end
       if aweights
-        a = aweights
-        w = w ? w * a : a
-      end
-      if w
-        w_sum = w.sum(axis:-1, keepdims:true)
-        if ddof == 0
-          fact = w_sum
-        elsif aweights.nil?
-          fact = w_sum - ddof
+        aweights = NArray.cast(aweights) unless aweights.is_a?(NArray)
+        raise ArgumentError, "aweights must be 1-D array" unless aweights.ndim == 1
+        raise ArgumentError, "aweights size is wrong" unless aweights.size == m.shape[1]
+        raise ArgumentError, "aweights must be non-negative" if (aweights < 0).any?
+        if w.nil?
+          w = aweights
         else
-          wa_sum = (w * a).sum(axis:-1, keepdims:true)
-          fact = w_sum - ddof * wa_sum / w_sum
+          w *= aweights
         end
-        if (fact <= 0).any?
-          raise StandardError, "Degrees of freedom <= 0 for slice"
-        end
-      else
-        fact = m.shape[-1] - ddof
       end
-      if w
-        m -= (m * w).sum(axis:-1, keepdims:true) / w_sum
-        mw = m * w
+      if w.nil?
+        fact = m.shape[-1] - ddof
+      elsif ddof == 0
+        fact = w.sum
+      elsif aweights.nil?
+        fact = w.sum - ddof
       else
+        w_sum = w.sum
+        fact = w_sum - ddof * (w * aweights).sum / w_sum
+      end
+      # numo's sum answers with a Ruby number, cumo's with a zero-dimensional
+      # array, and every object is truthy.
+      fact = fact.extract_cpu if fact.is_a?(NArray)
+      if fact <= 0
+        warn("Degrees of freedom <= 0 for slice")
+        fact = 0.0
+      end
+      if w.nil?
         m -= m.mean(axis:-1, keepdims:true)
         mw = m
+      else
+        m -= (m * w).sum(axis:-1, keepdims:true) / w.sum
+        mw = m * w
       end
-      mt = (m.ndim < 2) ? m : m.swapaxes(-2, -1)
-      mw.dot(mt.conj) / fact
+      m.dot(mw.transpose.conj) / fact
     end
 
     private

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 require_relative "test_helper"
 
 class NArrayExtraTest < CumoTestBase
@@ -747,17 +749,55 @@ class NArrayExtraTest < CumoTestBase
     # fweights
     fw = Cumo::Int32[1, 4, 2]
     c = x.cov(fweights: fw)
-    error = (Cumo::DFloat[[0.6190476, -0.2857143], [-0.2857143, 4.2857143]] - c).abs.max
+    error = (Cumo::DFloat[[0.6190476, -0.2857143], [-0.2857143, 4.2857143]] - c).abs.max.extract_cpu
     assert_operator(error, :<, 1e-6)
     # aweights
     aw = Cumo::DFloat[2, 0.5, 0.25]
     c = x.cov(aweights: aw)
-    error = (Cumo::DFloat[[1.4230769, -2.6538461], [-2.6538461, 8.6538461]] - c).abs.max
+    error = (Cumo::DFloat[[1.4230769, -2.6538461], [-2.6538461, 8.6538461]] - c).abs.max.extract_cpu
     assert_operator(error, :<, 1e-6)
     # fweights and aweights
     c = x.cov(fweights: fw, aweights: aw)
-    error = (Cumo::DFloat[[1.1900826, -1.7851240], [-1.7851240, 5.3553719]] - c).abs.max
+    error = (Cumo::DFloat[[1.1900826, -1.7851240], [-1.7851240, 5.3553719]] - c).abs.max.extract_cpu
     assert_operator(error, :<, 1e-6)
+    # weights given as a Ruby Array
+    assert_equal(x.cov(fweights: fw), x.cov(fweights: [1, 4, 2]))
+    assert_equal(x.cov(aweights: aw), x.cov(aweights: [2, 0.5, 0.25]))
+  end
+
+  def test_cov_invalid_argument
+    x = Cumo::DFloat[[3, 1, 2], [2, 5, 8]]
+    a = Cumo::DFloat.new(2, 2, 3).seq
+
+    assert_raise_message("ndim must be <= 2") { a.cov }
+    assert_raise_message("y.ndim must be <= 2") { x.cov(a) }
+    assert_raise_message("ddof must be 0 or 1") { x.cov(ddof: 2) }
+
+    assert_raise_message("fweights must be 1-D array") { x.cov(fweights: Cumo::Int32[[1, 4, 2]]) }
+    assert_raise_message("fweights size is wrong") { x.cov(fweights: Cumo::Int32[1, 4]) }
+    assert_raise_message("fweights must be non-negative") { x.cov(fweights: Cumo::Int32[1, -4, 2]) }
+    assert_raise_message("fweights must be integer") { x.cov(fweights: Cumo::DFloat[1.5, 4, 2]) }
+
+    assert_raise_message("aweights must be 1-D array") { x.cov(aweights: Cumo::DFloat[[2, 0.5, 0.25]]) }
+    assert_raise_message("aweights size is wrong") { x.cov(aweights: Cumo::DFloat[2, 0.5]) }
+    assert_raise_message("aweights must be non-negative") { x.cov(aweights: Cumo::DFloat[2, -0.5, 0.25]) }
+  end
+
+  def test_cov_degenerate_degrees_of_freedom
+    x = Cumo::DFloat[[3, 1, 2], [2, 5, 8]]
+
+    c = nil
+    stderr = $stderr
+    $stderr = StringIO.new
+    begin
+      c = x.cov(fweights: Cumo::Int32[0, 0, 0])
+      warning = $stderr.string
+    ensure
+      $stderr = stderr
+    end
+
+    assert_equal("Degrees of freedom <= 0 for slice\n", warning)
+    assert_equal(true, c.isnan.all?)
   end
 
   # class methods


### PR DESCRIPTION
Backports numo-narray-alt `8fb42d9`. cumo's `cov` was upstream numo's `# under construction` version verbatim -- only whitespace differed -- and its test was already ported in #208, where it passes either way, so the test never showed the gap.

- Compared against the numo-narray-alt 0.11.2 gem over 21 cases. **cumo answered five of them from input it should have rejected**: a 3-D receiver (a `[2,2,2]` array of nonsense), a 3-D `y`, 2-D `fweights`, non-integer `fweights`, and any `ddof` other than 0 or 1 (`ddof: 3` gave `inf`). All five raise now, and every case matches alt.
- Weights given as a plain Ruby `Array` raised `undefined method '+' for an instance of Hash`, because `Array#sum(axis: -1, keepdims: true)` reads the option hash as the sum's *initial value*. They are cast now.
- **Two behaviour changes**, both alt's: `ddof` other than 0 or 1 is an `ArgumentError` (numpy allows any ddof), and degrees of freedom `<= 0` warns and answers nan rather than raising `StandardError` (numpy's behaviour).
- **cumo-specific**: alt's `fact` is a Ruby number, but cumo's `sum` answers with a zero-dimensional array and every Ruby object is truthy, so `if fact <= 0` would fire on *every* weighted call and turn each one into nan. `fact` is read back to the host before the comparison.
- That same trap had already made three assertions in the ported test vacuous -- `error` was zero-dimensional, so `assert_operator(error, :<, 1e-6)` passed whatever the weighted results were. They compare on the host now.
- Removing any one of the 14 lines this adds fails the tests. The one exception is `m.dot(mw.transpose.conj)`: it replaces `mw.dot(mt.conj)` to match numpy's formulation, and since `w` is always real by the time it is used the two are equal, so nothing observes it.

Integer `cov` still raises `NoMethodError: mean` -- that needs integer `mean`, which is a separate item.
