### PR TITLE
Add mean, var, stddev and rms to the integer types

### DIFF
--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -327,6 +327,12 @@ if is_float
   accum "stddev", "rtype", "cRT"
   accum "var", "rtype", "cRT"
   accum "rms", "rtype", "cRT"
+elsif is_int && !is_object
+  # An integer is exact but none of these are, so they answer in double.
+  accum "mean", "double", "cumo_cDFloat"
+  accum "stddev", "double", "cumo_cDFloat"
+  accum "var", "double", "cumo_cDFloat"
+  accum "rms", "double", "cumo_cDFloat"
 end
 
 if is_comparable

--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -101,6 +101,55 @@ struct cumo_<%=type_name%>_ptp_impl {
     }
 };
 
+<% unless is_float %>
+// mean, var, stddev and rms answer in double for the integer types, so they
+// accumulate in double too rather than in dtype.
+struct cumo_<%=type_name%>_moments_impl {
+    struct Moments {
+        double n;
+        double mean;
+        double m2;
+    };
+    __device__ Moments Identity(int64_t /*index*/) { return {0, 0, 0}; }
+    __device__ Moments MapIn(dtype in, int64_t /*index*/) { return {1, (double)in, 0}; }
+    __device__ void Reduce(Moments next, Moments& accum) {
+        if (next.n == 0) { return; }
+        if (accum.n == 0) { accum = next; return; }
+        double n = accum.n + next.n;
+        double delta = next.mean - accum.mean;
+        accum.mean += delta * (next.n / n);
+        accum.m2 += next.m2 + delta * delta * accum.n * next.n / n;
+        accum.n = n;
+    }
+};
+
+struct cumo_<%=type_name%>_var_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ double MapOut(Moments accum) { return accum.m2 / (accum.n - 1); }
+};
+
+struct cumo_<%=type_name%>_stddev_impl : cumo_<%=type_name%>_moments_impl {
+    __device__ double MapOut(Moments accum) { return sqrt(accum.m2 / (accum.n - 1)); }
+};
+
+struct cumo_<%=type_name%>_mean_impl {
+    // The reduce axis is the same length for every output, so the divisor is a
+    // constant the launcher already knows rather than a count the tree carries.
+    double n;
+    __device__ double Identity(int64_t /*index*/) { return 0; }
+    __device__ double MapIn(dtype in, int64_t /*index*/) { return (double)in; }
+    __device__ void Reduce(double next, double& accum) { accum += next; }
+    __device__ double MapOut(double accum) { return accum / n; }
+};
+
+struct cumo_<%=type_name%>_rms_impl {
+    double n;
+    __device__ double Identity(int64_t /*index*/) { return 0; }
+    __device__ double MapIn(dtype in, int64_t /*index*/) { double x = (double)in; return x * x; }
+    __device__ void Reduce(double next, double& accum) { accum += next; }
+    __device__ double MapOut(double accum) { return sqrt(accum / n); }
+};
+<% end %>
+
 <% if is_float %>
 // The nan-aware forms of the reductions above. sum, prod and their kin skip a
 // NaN, so it maps to the identity and the tree never sees it. min and max go
@@ -192,6 +241,30 @@ void cumo_<%=type_name%>_minmax_kernel_launch(cumo_na_reduction_arg_t* arg, cumo
 {
     cumo_reduce_pair_split<dtype, dtype, cumo_<%=type_name%>_minmax_impl>(*arg, *out2, cumo_<%=type_name%>_minmax_impl{});
 }
+<% unless is_float %>
+
+void cumo_<%=type_name%>_mean_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    double n = (double)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, double, cumo_<%=type_name%>_mean_impl>(*arg, cumo_<%=type_name%>_mean_impl{n});
+}
+
+void cumo_<%=type_name%>_var_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, double, cumo_<%=type_name%>_var_impl>(*arg, cumo_<%=type_name%>_var_impl{});
+}
+
+void cumo_<%=type_name%>_stddev_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    cumo_reduce_split<dtype, double, cumo_<%=type_name%>_stddev_impl>(*arg, cumo_<%=type_name%>_stddev_impl{});
+}
+
+void cumo_<%=type_name%>_rms_kernel_launch(cumo_na_reduction_arg_t* arg)
+{
+    double n = (double)(arg->in_indexer.total_size / arg->out_indexer.total_size);
+    cumo_reduce_split<dtype, double, cumo_<%=type_name%>_rms_impl>(*arg, cumo_<%=type_name%>_rms_impl{n});
+}
+<% end %>
 <% if is_float %>
 
 void cumo_<%=type_name%>_sum_nan_kernel_launch(cumo_na_reduction_arg_t* arg)

--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -722,7 +722,7 @@ class NArrayExtraTest < CumoTestBase
   end
 
   def test_cov
-    [Cumo::SFloat, Cumo::SComplex, Cumo::DFloat, Cumo::DComplex].each do |dtype|
+    TYPES.each do |dtype|
       a = dtype[1, 2, 3]
       if [Cumo::DComplex, Cumo::SComplex].include?(dtype)
         assert_equal(1.0 + 0.0i, a.cov)
@@ -731,7 +731,7 @@ class NArrayExtraTest < CumoTestBase
       end
 
       a = dtype[[1, 2], [3, 4]]
-      assert_equal(dtype[[0.5, 0.5], [0.5, 0.5]], a.cov)
+      assert_equal(Cumo::DFloat[[0.5, 0.5], [0.5, 0.5]], a.cov)
     end
 
     # xy

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -189,6 +189,7 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[2..-1][[1]] == [5] }
         assert { a.reverse == [11, 7, 5, 3, 2, 1] }
         assert { a.sum == 29 }
+        assert { (a.mean.extract_cpu - 29.0 / 6).abs < 1e-6 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0 / 6 }
           assert { a.var == 13.76666666666667 }
@@ -1429,6 +1430,31 @@ class NArrayTest < Test::Unit::TestCase
     assert { Cumo::DFloat[1].rms == 1.0 }
     assert { Cumo::SComplex[1].rms == 1.0 }
     assert { Cumo::DComplex[1].rms == 1.0 }
+
+    assert { Cumo::Int32[1].mean == 1.0 }
+    assert { Cumo::Int32[1].var.to_f.nan? }
+    assert { Cumo::Int32[1].stddev.to_f.nan? }
+    assert { Cumo::Int32[1].rms == 1.0 }
+  end
+
+  test "mean, var, stddev and rms of an integer array" do
+    int_types = types.select { |dtype| dtype.name.include?("Int") }
+    int_types.each do |dtype|
+      a = dtype[[1, 2, 3], [5, 7, 11]]
+      ref = Cumo::DFloat.cast(a)
+
+      [[], [0], [1]].each do |axis|
+        assert { a.mean(*axis).instance_of?(Cumo::DFloat) }
+        assert { (a.mean(*axis) - ref.mean(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.var(*axis) - ref.var(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.stddev(*axis) - ref.stddev(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.rms(*axis) - ref.rms(*axis)).abs.max.extract_cpu < 1e-12 }
+      end
+
+      assert { a.mean == 29.0 / 6 }
+      assert { a.mean(0) == [3, 4.5, 7] }
+      assert { a.mean(axis: 1, keepdims: true).shape == [2, 1] }
+    end
   end
 
   test "concatenate with empty arrays" do


### PR DESCRIPTION
Backports numo-narray-alt `fc7b6a0` (`mean`) and `896fcf8` / `0b0cf66` / `0e821b0` (`var`, `stddev`, `rms`). `Cumo::Int8` through `Int64` and `UInt8` through `UInt64` answer all four in `Cumo::DFloat`, as numo-narray-alt does.

alt writes a new C file per method. cumo already has the machinery: `accum` in `spec.rb` takes the result type, which the integer `sum` already uses to answer in `Int64`. So this is four `accum` lines and four reduction impls in the integer half of the kernel template -- everything else, including the axis and `keepdims` handling, is what `sum` already goes through.

- The impls accumulate in double rather than in `dtype`: Chan's parallel moments for `var` and `stddev` (the same combination the float template uses) and a plain sum for `mean` and `rms`.
- Checked against `Cumo::DFloat.cast(a)` over 4 shapes x 4 dtypes x every axis, up to 2^20 elements so the split reduction runs, and over transposed, strided and index-backed views. The test uses that same oracle, and it is an independent answer -- the float reductions come from a different template.
- Checked value for value against the numo-narray-alt 0.11.2 gem across all 8 dtypes and 20 edge cases (single element, negatives, `Int8` extremes, `2**63`, empty, `nan: true`). Identical, except that cumo's `mean` answers a zero-dimensional array where numo answers a Ruby `Float`, which is what cumo's float `mean` already does.
- Making `var` divide by `n` rather than `n - 1` fails the test.
- This is what `cov` was waiting for: `Cumo::Int32[[1, 2], [3, 4]].cov` raised `NoMethodError: mean` until now, so `test_cov` goes back to the full `TYPES` loop that numo-narray-alt's has.

`Cumo::Bit` is the other half of alt's change. Its element is one bit, so it needs its own reduction rather than this one; it is not here.
