### PR TITLE
Add mean, var, stddev and rms to Cumo::Bit

### DIFF
--- a/ext/cumo/include/cumo/bit_reduce_kernel.h
+++ b/ext/cumo/include/cumo/bit_reduce_kernel.h
@@ -7,6 +7,11 @@
 #include "cumo/indexer.h"
 #include "cumo/reduce_kernel.h"
 
+#define CUMO_BIT_STAT_MEAN   0
+#define CUMO_BIT_STAT_VAR    1
+#define CUMO_BIT_STAT_STDDEV 2
+#define CUMO_BIT_STAT_RMS    3
+
 namespace cumo_bit_detail {
 
 // A Bit reduction addresses its operands the way a numeric one does -- the
@@ -287,6 +292,71 @@ static inline bit_reduce_plan make_bit_reduce_plan(const TArg& arg) {
     return p;
 }
 
+// mean, var, stddev and rms of a bit array are functions of how many bits are
+// set and how long the axis is, because every element is 0 or 1. They reduce
+// the way count does and differ only in what the store computes.
+__device__ static inline double bit_stat_of_count(uint64_t count, int64_t reduce_total_size, int stat) {
+    double k = (double)count;
+    double n = (double)reduce_total_size;
+    double mean = k / n;
+    switch (stat) {
+        case CUMO_BIT_STAT_MEAN: return mean;
+        case CUMO_BIT_STAT_RMS: return sqrt(mean);
+        // x squared is x for a bit, so the squared deviations sum to k - k * mean.
+        case CUMO_BIT_STAT_VAR: return (k - k * mean) / (n - 1);
+        default: return sqrt((k - k * mean) / (n - 1));
+    }
+}
+
+__global__ static void bit_stat_reduction_kernel(
+        cumo_na_bit_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, cumo_bit_word_addr_t wa, int stat,
+        int out_block_size, int reduce_block_size, int64_t unit_total_size) {
+    extern __shared__ __align__(8) char sdata_raw[];
+    uint64_t* sdata = reinterpret_cast<uint64_t*>(sdata_raw);
+    unsigned int tid = threadIdx.x;
+    BitCountImpl impl;
+
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+
+    int64_t reduce_offset = tid / out_block_size;
+    int64_t out_offset = tid % out_block_size;
+    int64_t out_base = blockIdx.x * out_block_size;
+    int64_t out_stride = gridDim.x * out_block_size;
+
+    for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
+        ssize_t in_out_off = bit_in_out_offset(arg, ad, i_out);
+        int64_t i_in = i_out * reduce_total_size + reduce_offset;
+
+        uint64_t accum = bit_count_axis(arg, ad, wa, 0, in_out_off, i_in, reduce_total_size,
+                                        0, unit_total_size, reduce_offset, reduce_block_size);
+
+        accum = cumo_detail::reduce_in_block(accum, sdata, tid, out_block_size, impl);
+        if (reduce_offset == 0) {
+            *reinterpret_cast<double*>(arg.out.ptr + bit_out_offset(arg, ad, i_out)) =
+                bit_stat_of_count(accum, reduce_total_size, stat);
+        }
+    }
+}
+
+// Second pass of a split statistic, laid out like bit_pred_combine_kernel.
+__global__ static void bit_stat_combine_kernel(
+        cumo_na_bit_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, int stat,
+        const uint64_t* partial, int64_t n_split) {
+    int64_t out_total_size = arg.out_indexer.total_size;
+    int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
+
+    for (int64_t i_out = blockIdx.x * blockDim.x + threadIdx.x; i_out < out_total_size;
+         i_out += (int64_t)blockDim.x * gridDim.x) {
+        uint64_t count = 0;
+        for (int64_t i_split = 0; i_split < n_split; ++i_split) {
+            count += partial[i_out * n_split + i_split];
+        }
+        *reinterpret_cast<double*>(arg.out.ptr + bit_out_offset(arg, ad, i_out)) =
+            bit_stat_of_count(count, reduce_total_size, stat);
+    }
+}
+
 // all? and any? are the count of set bits against the length of the axis and
 // against zero, so they reduce the same way and differ only here.
 __device__ static inline CUMO_BIT_DIGIT bit_pred_of_count(uint64_t count, int64_t reduce_total_size, int all) {
@@ -383,6 +453,42 @@ static inline void cumo_bit_count_reduce(cumo_na_bit_reduction_arg_t arg, int in
     combine.out = arg.out;
     combine.out_indexer = arg.out_indexer;
     cumo_reduce<uint64_t, uint64_t>(combine, cumo_bit_detail::BitCountImpl{});
+
+    cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
+}
+
+// The same for the four statistics, whose result is a DFloat of the same width
+// as the count it is computed from.
+static inline void cumo_bit_stat_reduce(cumo_na_bit_reduction_arg_t arg, int stat) {
+    if (arg.out_indexer.total_size == 0) {
+        return;
+    }
+
+    cumo_bit_detail::bit_reduce_plan p = cumo_bit_detail::make_bit_reduce_plan(arg);
+    int64_t block_size = cumo_detail::max_block_size;
+    int64_t shared_mem_size = sizeof(uint64_t) * block_size;
+
+    if (p.n_split < 2) {
+        int64_t grid_size = std::min(cumo_detail::max_grid_size, p.out_block_num);
+        cumo_bit_detail::bit_stat_reduction_kernel<<<grid_size, block_size, shared_mem_size>>>(
+            arg, p.ad, p.wa, stat, (int)p.out_block_size, (int)p.reduce_block_size, p.unit_total_size);
+        cumo_cuda_runtime_check_kernel_launch();
+        return;
+    }
+
+    int64_t partial_total_size = p.out_total_size * p.n_split;
+    uint64_t* partial = reinterpret_cast<uint64_t*>(cumo_cuda_runtime_malloc(sizeof(uint64_t) * partial_total_size));
+
+    int64_t grid_size = std::min(cumo_detail::max_grid_size, p.partial_block_num);
+    cumo_bit_detail::bit_count_partial_kernel<<<grid_size, block_size, shared_mem_size>>>(
+        arg, p.ad, p.wa, 0, partial, p.n_split, p.chunk,
+        (int)p.split_out_block_size, (int)p.split_reduce_block_size, p.unit_total_size);
+    cumo_cuda_runtime_check_kernel_launch();
+
+    int64_t combine_grid = (p.out_total_size + block_size - 1) / block_size;
+    if (combine_grid > cumo_detail::max_grid_size) combine_grid = cumo_detail::max_grid_size;
+    cumo_bit_detail::bit_stat_combine_kernel<<<combine_grid, block_size>>>(arg, p.ad, stat, partial, p.n_split);
+    cumo_cuda_runtime_check_kernel_launch();
 
     cumo_cuda_runtime_free(reinterpret_cast<char*>(partial));
 }

--- a/ext/cumo/narray/gen/narray_def.rb
+++ b/ext/cumo/narray/gen/narray_def.rb
@@ -49,6 +49,11 @@ module NArrayMethod
     def_method(meth, "bit_count_cpu")
   end
 
+  def bit_stat(meth, stat)
+    h = {stat:stat}
+    def_method(meth, "bit_stat", **h)
+  end
+
   def bit_reduce(meth, init_bit)
     h = {init_bit:init_bit}
     def_method(meth, "bit_reduce", **h)

--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -184,6 +184,10 @@ if is_bit
   def_alias "count_0_cpu", "count_false_cpu"
   bit_reduce "all?", 1
   bit_reduce "any?", 0
+  bit_stat "mean", "CUMO_BIT_STAT_MEAN"
+  bit_stat "var", "CUMO_BIT_STAT_VAR"
+  bit_stat "stddev", "CUMO_BIT_STAT_STDDEV"
+  bit_stat "rms", "CUMO_BIT_STAT_RMS"
   def_method "none?", "none_p"
   def_method "where"
   def_method "where2"

--- a/ext/cumo/narray/gen/tmpl_bit/bit_stat.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_stat.c
@@ -1,0 +1,36 @@
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_reduction_arg_t* arg);
+
+static void
+<%=c_iter%>(cumo_na_loop_t *const lp)
+{
+    cumo_na_bit_reduction_arg_t arg = cumo_na_make_bit_reduction_arg(lp, 1);
+    <%="cumo_#{c_iter}_kernel_launch"%>(&arg);
+}
+
+/*
+  <%=name%> of self, where a set bit counts as one and a clear bit as zero.
+  @overload <%=op_map%>(axis:nil, keepdims:false)
+  @param [Integer,Array,Range] axis (keyword) axes to be reduced.
+  @param [TrueClass] keepdims (keyword) If true, the reduced axes are left in the result array as dimensions with size one.
+  @return [Cumo::DFloat] returns result of <%=name%>.
+*/
+static VALUE
+<%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
+{
+    VALUE v, reduce;
+    cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{cumo_sym_reduce,0}};
+    cumo_ndfunc_arg_out_t aout[1] = {{cumo_cDFloat,0}};
+    cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_STRIDE_LOOP_NIP|CUMO_NDF_FLAT_REDUCE|CUMO_NDF_INDEXER_LOOP, 2, 1, ain, aout };
+
+    reduce = cumo_na_reduce_dimension(argc, argv, 1, &self, &ndf, 0);
+    if (cumo_na_has_idx_p(self)) {
+        // The reduction addresses its input by stride, so an index array has to
+        // go first. cumo_na_copy moves whole bytes and a Bit element is one
+        // bit, so the copy has to be this class's own.
+        VALUE copy = <%=find_tmpl("copy").c_func%>(self);
+        v = cumo_na_ndloop(&ndf, 2, copy, reduce);
+    } else {
+        v = cumo_na_ndloop(&ndf, 2, self, reduce);
+    }
+    return rb_funcall(v, rb_intern("extract"), 0);
+}

--- a/ext/cumo/narray/gen/tmpl_bit/bit_stat_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_stat_kernel.cu
@@ -1,0 +1,4 @@
+void <%="cumo_#{c_iter}_kernel_launch"%>(cumo_na_bit_reduction_arg_t* arg)
+{
+    cumo_bit_stat_reduce(*arg, <%=stat%>);
+}

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -680,4 +680,51 @@ class BitTest < Test::Unit::TestCase
       end
     end
   end
+
+  # Every element is 0 or 1, so the four statistics come out of the same bit
+  # count all? and any? reduce, and DFloat is what says the count is right.
+  test "mean, var, stddev and rms of a bit array" do
+    [[1000], [64, 129], [7, 33, 17], [1 << 22]].each do |shape|
+      srand(7)
+      a = Cumo::Bit.cast(Array.new(shape.reduce(:*)) { rand(2) }).reshape(*shape)
+      ref = Cumo::DFloat.cast(a)
+
+      ([[]] + (0...shape.size).map { |axis| [axis] }).each do |axis|
+        assert { a.mean(*axis).instance_of?(Cumo::DFloat) }
+        assert { (a.mean(*axis) - ref.mean(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.var(*axis) - ref.var(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.stddev(*axis) - ref.stddev(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (a.rms(*axis) - ref.rms(*axis)).abs.max.extract_cpu < 1e-12 }
+      end
+    end
+
+    a = Cumo::Bit[[1, 0, 1], [1, 1, 0]]
+    assert { (a.mean.extract_cpu - (2.0 / 3)).abs < 1e-15 }
+    assert { a.mean(0) == [1, 0.5, 0.5] }
+    assert { a.mean(axis: 1, keepdims: true).shape == [2, 1] }
+
+    assert { Cumo::Bit[0, 0, 0, 0].mean.extract_cpu.zero? }
+    assert { Cumo::Bit[0, 0, 0, 0].var.extract_cpu.zero? }
+    assert { (Cumo::Bit[1, 1, 1, 1].mean.extract_cpu - 1).abs < 1e-15 }
+    assert { Cumo::Bit[1, 1, 1, 1].var.extract_cpu.zero? }
+    assert { (Cumo::Bit[1].mean.extract_cpu - 1).abs < 1e-15 }
+    assert { Cumo::Bit[1].var.extract_cpu.nan? }
+    assert { Cumo::Bit[1].stddev.extract_cpu.nan? }
+    assert { (Cumo::Bit[1].rms.extract_cpu - 1).abs < 1e-15 }
+  end
+
+  test "mean, var, stddev and rms of a bit view" do
+    srand(11)
+    base = Cumo::Bit.cast(Array.new(64 * 65) { rand(2) }).reshape(64, 65)
+
+    [base[true, 1..-2], base[(0..-1).step(2), true], base[[3, 1, 2, 0], true]].each do |v|
+      ref = Cumo::DFloat.cast(v)
+      [[], [0], [1]].each do |axis|
+        assert { (v.mean(*axis) - ref.mean(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (v.var(*axis) - ref.var(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (v.stddev(*axis) - ref.stddev(*axis)).abs.max.extract_cpu < 1e-12 }
+        assert { (v.rms(*axis) - ref.rms(*axis)).abs.max.extract_cpu < 1e-12 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Finishes the backport of numo-narray-alt `fc7b6a0` / `896fcf8` / `0b0cf66` / `0e821b0`, whose integer half went in with #344. `Cumo::Bit` answers `mean`, `var`, `stddev` and `rms` in `Cumo::DFloat`.

A `Bit` element is one bit, so it cannot go through the reduction the numeric types use. It does not have to: every element is 0 or 1, so all four are functions of how many bits are set and how long the axis is.

    mean = k / n        rms = sqrt(k / n)
    var  = (k - k * mean) / (n - 1)        stddev = sqrt(var)

So this reduces exactly the way `count_true` does, and differs only in what the store computes -- the same shape `all?` and `any?` already have next to it. `bit_count_partial_kernel` is reused as is for the split path.

- Answers agree with the numo-narray-alt 0.11.2 gem across 39 cases: every axis of a 2-D array, `keepdims`, all-zero, all-one, a single element (`var` is NaN, as it is for a float), empty (`ShapeError`), a 1000-bit array whose length is not a multiple of the word size, a strided view, an index-backed view, and 4M bits.
- **One value differs, and cumo's is the more accurate one**: `var` of 1000 bits with 333 set is `0.222333333333333` here against alt's `0.222333333333324`, where the exact answer is `0.22233333333333333`. alt sums 1000 squared deviations in double; the closed form has nothing to accumulate.
- Also checked against `Cumo::DFloat.cast(a)` over 4 shapes x every axis and 3 kinds of view, which is what the test asserts.
- Three mutations fail the test: `var` dividing by `n`, `rms` without its `sqrt`, and the combine pass keeping only the last partial -- that last one fails only the 4M case, which is the one that takes the split path.

Note for anyone testing a change to `bit_reduce_kernel.h`: it is not a make prerequisite of the generated kernels (`depend.erb` lists `gen/tmpl*/` and `gen/*.rb`), so editing it alone rebuilds nothing. `touch ext/cumo/narray/gen/spec.rb` first. All three mutations above passed silently before that.
