### PR TITLE
Make every object depend on the headers it is built from

### DIFF
--- a/ext/cumo/depend.erb
+++ b/ext/cumo/depend.erb
@@ -49,6 +49,13 @@ list_type_rb.each do |type_rb|
 
 src : <%= list_type_cu.join(" ") %> <%= list_type_c.join(" ") %>
 
+# mkmf writes no rule that makes an object depend on a header, so editing one
+# and rebuilding was a no-op that kept the previous cumo.so. Rebuilding all of
+# them is a minute and a half, so the list does not have to be per-object.
+CUMO_HDRS = <%= Dir.glob("#{__dir__}/**/*.{h,hpp}").sort.join(" ") %>
+
+$(OBJS): $(CUMO_HDRS)
+
 build-ctest : <%= __dir__ %>/cuda/memory_pool_impl_test.exe
 
 run-ctest : <%= __dir__ %>/cuda/memory_pool_impl_test.exe


### PR DESCRIPTION
No object in this extension depends on any header. mkmf writes no such rule (`HDRS` and `LOCAL_HDRS` are both empty here) and `depend.erb` only gives dependencies to the code generation, so editing a header and running `rake compile` **rebuilds nothing** and leaves the previous `cumo.so` in place.

    $ touch ext/cumo/include/cumo/narray.h ext/cumo/include/cumo/bit_reduce_kernel.h
    $ rake compile      # 0 files compiled

That is quiet in the worst way. It bit #345, where three mutations to a reduction in `bit_reduce_kernel.h` all passed the tests -- not because the tests were weak, but because the kernel under test was never rebuilt. `touch ext/cumo/narray/gen/spec.rb` was the workaround, since `gen/*.rb` *is* a prerequisite of the generated sources.

One line of `$(OBJS)` against every header in `ext/cumo` fixes it:

- **Not per-object on purpose.** A full object rebuild is 93 seconds here (`-j24`, no code generation), which is cheaper than teaching the build to narrow it. `-MMD -MP` would need a patch to `3rd_party/mkmf-cu`, whose nvcc wrapper parses an allowlist of options and drops the rest, so an unknown flag would either vanish or raise on every `.cu`.
- Verified: no change recompiles 0 files, touching one header recompiles 51 in 94 seconds, and `rake clean compile` still works (98s).
- The mutation that #345 could not catch now fails the tests without touching anything else.
