### PR TITLE
Keep a reduction's operands out of local memory and give short strided rows more elements per thread

### DIFF
--- a/ext/cumo/include/cumo/bit_reduce_kernel.h
+++ b/ext/cumo/include/cumo/bit_reduce_kernel.h
@@ -174,7 +174,7 @@ __device__ static inline uint64_t bit_count_axis(
 }
 
 __global__ static void bit_count_reduction_kernel(
-        cumo_na_bit_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, cumo_bit_word_addr_t wa, int invert,
+        CUMO_GRID_CONSTANT cumo_na_bit_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_bit_word_addr_t wa, int invert,
         int out_block_size, int reduce_block_size, int64_t unit_total_size) {
     extern __shared__ __align__(8) char sdata_raw[];
     uint64_t* sdata = reinterpret_cast<uint64_t*>(sdata_raw);
@@ -207,7 +207,7 @@ __global__ static void bit_count_reduction_kernel(
 // grid a handful of blocks however long the reduce axis is.
 template <typename TArg>
 __global__ static void bit_count_partial_kernel(
-        TArg arg, cumo_detail::cumo_reduce_addr_t ad, cumo_bit_word_addr_t wa, int invert,
+        CUMO_GRID_CONSTANT TArg arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_bit_word_addr_t wa, int invert,
         uint64_t* partial, int64_t n_split, int64_t chunk,
         int out_block_size, int reduce_block_size, int64_t unit_total_size) {
     extern __shared__ __align__(8) char sdata_raw[];
@@ -309,7 +309,7 @@ __device__ static inline double bit_stat_of_count(uint64_t count, int64_t reduce
 }
 
 __global__ static void bit_stat_reduction_kernel(
-        cumo_na_bit_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, cumo_bit_word_addr_t wa, int stat,
+        CUMO_GRID_CONSTANT cumo_na_bit_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_bit_word_addr_t wa, int stat,
         int out_block_size, int reduce_block_size, int64_t unit_total_size) {
     extern __shared__ __align__(8) char sdata_raw[];
     uint64_t* sdata = reinterpret_cast<uint64_t*>(sdata_raw);
@@ -341,7 +341,7 @@ __global__ static void bit_stat_reduction_kernel(
 
 // Second pass of a split statistic, laid out like bit_pred_combine_kernel.
 __global__ static void bit_stat_combine_kernel(
-        cumo_na_bit_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, int stat,
+        CUMO_GRID_CONSTANT cumo_na_bit_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, int stat,
         const uint64_t* partial, int64_t n_split) {
     int64_t out_total_size = arg.out_indexer.total_size;
     int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;
@@ -364,7 +364,7 @@ __device__ static inline CUMO_BIT_DIGIT bit_pred_of_count(uint64_t count, int64_
 }
 
 __global__ static void bit_pred_reduction_kernel(
-        cumo_na_bit_pred_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, cumo_bit_word_addr_t wa, int all,
+        CUMO_GRID_CONSTANT cumo_na_bit_pred_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_bit_word_addr_t wa, int all,
         int out_block_size, int reduce_block_size, int64_t unit_total_size) {
     extern __shared__ __align__(8) char sdata_raw[];
     uint64_t* sdata = reinterpret_cast<uint64_t*>(sdata_raw);
@@ -397,7 +397,7 @@ __global__ static void bit_pred_reduction_kernel(
 // Second pass of a split all? or any?. There are few outputs whenever the axis
 // was worth splitting, so one thread per output walks its chunks.
 __global__ static void bit_pred_combine_kernel(
-        cumo_na_bit_pred_reduction_arg_t arg, cumo_detail::cumo_reduce_addr_t ad, int all,
+        CUMO_GRID_CONSTANT cumo_na_bit_pred_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_detail::cumo_reduce_addr_t ad, int all,
         const uint64_t* partial, int64_t n_split) {
     int64_t out_total_size = arg.out_indexer.total_size;
     int64_t reduce_total_size = arg.in_indexer.total_size / out_total_size;

--- a/ext/cumo/include/cumo/reduce_kernel.h
+++ b/ext/cumo/include/cumo/reduce_kernel.h
@@ -8,6 +8,18 @@
 
 #include "cumo/indexer.h"
 
+// A kernel parameter that is read through a runtime index, the way the steps
+// of an operand are, is copied to local memory by the compiler unless it is
+// declared __grid_constant__, and the copy is paid by every thread: the second
+// operand of a zip reduction cost a 104-byte stack frame that put mulsum along
+// a middle axis at three times the sum of the same bytes. The qualifier needs
+// CUDA 11.7 and sm_70; below those the parameter is merely const.
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || (defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 7)))
+#define CUMO_GRID_CONSTANT const
+#else
+#define CUMO_GRID_CONSTANT const __grid_constant__
+#endif
+
 namespace cumo_detail {
 
 static constexpr int64_t max_block_size = 512;
@@ -156,7 +168,7 @@ static inline void reduce_block_split(const cumo_reduce_addr_t& ad, int64_t redu
     int64_t n = std::max(int64_t{1}, reduce_total_size);
     int64_t rbs;
     if (ad.out_inner) {
-        rbs = std::min(max_block_size / warp_size, round_up_to_power_of_2(n));
+        rbs = std::min(max_block_size / warp_size, round_up_to_power_of_2((n + min_reduce_per_thread - 1) / min_reduce_per_thread));
     } else {
         rbs = std::min(max_block_size, round_up_to_power_of_2((n + min_reduce_per_thread - 1) / min_reduce_per_thread));
     }
@@ -168,49 +180,82 @@ static inline void reduce_block_split(const cumo_reduce_addr_t& ad, int64_t redu
 // iarray's steps carry. Everything here is
 // read out of the kernel parameter and nothing is written back, which is what
 // keeps the indexer out of local memory.
+//
+// i is always below the product of the dims, so the outermost one takes what
+// is left without a division.
 template <typename TIarray>
-__device__ static inline ssize_t axes_offset(const TIarray& iarray, const cumo_na_indexer_t& indexer, int begin, int end, int64_t i) {
+__device__ static __forceinline__ ssize_t axes_offset(const TIarray& iarray, const cumo_na_indexer_t& indexer, int begin, int end, int64_t i) {
+    if (end <= begin) return 0;
     ssize_t off = 0;
-    for (int j = end; --j >= begin;) {
+    for (int j = end; --j > begin;) {
         int64_t n = static_cast<int64_t>(indexer.shape[j]);
         off += static_cast<ssize_t>(i % n) * iarray.step[j];
         i /= n;
     }
-    return off;
+    return off + static_cast<ssize_t>(i) * iarray.step[begin];
+}
+
+// The same split of i handed to two operands that share the indexer, which is
+// what the two inputs of a zip reduction are.
+template <typename TIarray>
+__device__ static __forceinline__ void axes_offset_pair(const TIarray& a, const TIarray& b, const cumo_na_indexer_t& indexer, int begin, int end, int64_t i, ssize_t* off_a, ssize_t* off_b) {
+    *off_a = 0;
+    *off_b = 0;
+    if (end <= begin) return;
+    for (int j = end; --j > begin;) {
+        int64_t n = static_cast<int64_t>(indexer.shape[j]);
+        ssize_t r = static_cast<ssize_t>(i % n);
+        *off_a += r * a.step[j];
+        *off_b += r * b.step[j];
+        i /= n;
+    }
+    *off_a += static_cast<ssize_t>(i) * a.step[begin];
+    *off_b += static_cast<ssize_t>(i) * b.step[begin];
 }
 
 // The input side takes the iarray and the indexer rather than the whole
 // reduction arg, so that mulsum can address its second operand with the same
 // indexer and a step set of its own.
 template <bool FLAT>
-__device__ static inline ssize_t reduce_in_out_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, int64_t i_out) {
+__device__ static __forceinline__ ssize_t reduce_in_out_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, int64_t i_out) {
     if (FLAT || ad.in_out_flat) return i_out * ad.in_out_step;
     if (ad.split < 0) return 0;
     return axes_offset(in, in_indexer, 0, ad.split, i_out);
 }
 
+// reduce_in_out_offset for the two operands of a zip reduction at once.
 template <bool FLAT>
-__device__ static inline ssize_t reduce_in_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ssize_t in_out_off, int64_t i_reduce, int64_t i_in) {
+__device__ static __forceinline__ void reduce_in_out_offset_pair(const cumo_na_iarray_t& in, const cumo_na_iarray_t& in2, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, const cumo_reduce_addr_t& ad2, int64_t i_out, ssize_t* off, ssize_t* off2) {
+    if (!FLAT && !ad.in_out_flat && !ad2.in_out_flat && ad.split >= 0 && ad.split == ad2.split) {
+        axes_offset_pair(in, in2, in_indexer, 0, ad.split, i_out, off, off2);
+        return;
+    }
+    *off = reduce_in_out_offset<FLAT>(in, in_indexer, ad, i_out);
+    *off2 = reduce_in_out_offset<FLAT>(in2, in_indexer, ad2, i_out);
+}
+
+template <bool FLAT>
+__device__ static __forceinline__ ssize_t reduce_in_offset(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ssize_t in_out_off, int64_t i_reduce, int64_t i_in) {
     if (FLAT || ad.in_reduce_flat) return in_out_off + i_reduce * ad.in_reduce_step;
     if (ad.split < 0) return axes_offset(in, in_indexer, 0, in_indexer.ndim, i_in);
     return in_out_off + axes_offset(in, in_indexer, ad.split, in_indexer.ndim, i_reduce);
 }
 
 template <bool FLAT>
-__device__ static inline ssize_t reduce_out_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, int64_t i_out) {
+__device__ static __forceinline__ ssize_t reduce_out_offset(const cumo_na_reduction_arg_t& arg, const cumo_reduce_addr_t& ad, int64_t i_out) {
     if (FLAT || ad.out_flat) return i_out * ad.out_step;
     return axes_offset(arg.out, arg.out_indexer, 0, arg.out_indexer.ndim, i_out);
 }
 
 template <bool FLAT>
-__device__ static inline ssize_t reduce_out2_offset(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& out2, const cumo_reduce_addr_t& ad, int64_t i_out) {
+__device__ static __forceinline__ ssize_t reduce_out2_offset(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& out2, const cumo_reduce_addr_t& ad, int64_t i_out) {
     if (FLAT || ad.out2_flat) return i_out * ad.out2_step;
     return axes_offset(out2, arg.out_indexer, 0, arg.out_indexer.ndim, i_out);
 }
 
 // Which output and which slice of its reduce axis a thread takes, in the
 // layout reduce_block_split describes.
-__device__ static inline void reduce_thread_split(const cumo_reduce_addr_t& ad, unsigned int tid, int out_block_size, int reduce_block_size, int64_t* reduce_offset, int64_t* out_offset) {
+__device__ static __forceinline__ void reduce_thread_split(const cumo_reduce_addr_t& ad, unsigned int tid, int out_block_size, int reduce_block_size, int64_t* reduce_offset, int64_t* out_offset) {
     if (!ad.out_inner) {
         *reduce_offset = tid % reduce_block_size;
         *out_offset = tid / reduce_block_size;
@@ -226,7 +271,7 @@ __device__ static inline void reduce_thread_split(const cumo_reduce_addr_t& ad, 
 // layout they are a contiguous, warp-aligned group of reduce_block_size, so a
 // step whose partners are within a warp needs only __syncwarp.
 template <typename TypeReduce, typename ReductionImpl>
-__device__ static inline TypeReduce reduce_in_block(TypeReduce accum, TypeReduce* sdata, unsigned int tid, int out_block_size, int reduce_block_size, bool reduce_major, ReductionImpl& impl) {
+__device__ static __forceinline__ TypeReduce reduce_in_block(TypeReduce accum, TypeReduce* sdata, unsigned int tid, int out_block_size, int reduce_block_size, bool reduce_major, ReductionImpl& impl) {
     if (reduce_block_size == 1) return accum;
     if (reduce_major) {
         int r = tid % reduce_block_size;
@@ -268,7 +313,7 @@ __device__ static inline TypeReduce reduce_in_block(TypeReduce accum, TypeReduce
 // the offset of the element from the start of the input, which is the index
 // (min|max)_index answers with.
 template <bool FLAT, bool ARG_INDEX, typename TypeIn, typename ReductionImpl>
-__device__ static inline auto reduce_axis(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ReductionImpl& impl,
+__device__ static __forceinline__ auto reduce_axis(const cumo_na_iarray_t& in, const cumo_na_indexer_t& in_indexer, const cumo_reduce_addr_t& ad, ReductionImpl& impl,
         ssize_t in_out_off, int64_t i_in, int64_t begin, int64_t end, int64_t reduce_offset, int64_t reduce_block_size) -> decltype(impl.Identity(0)) {
     using TypeReduce = decltype(impl.Identity(0));
 
@@ -296,7 +341,7 @@ __device__ static inline auto reduce_axis(const cumo_na_iarray_t& in, const cumo
 // an array. The pair comes out of one broadcast, so arg.in_indexer addresses
 // both and only the steps differ, which is what in2 and ad2 carry.
 template <bool FLAT, typename TypeIn, typename ReductionImpl>
-__device__ static inline auto reduce_axis_zip(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& in2,
+__device__ static __forceinline__ auto reduce_axis_zip(const cumo_na_reduction_arg_t& arg, const cumo_na_iarray_t& in2,
         const cumo_reduce_addr_t& ad, const cumo_reduce_addr_t& ad2, ReductionImpl& impl,
         ssize_t in_out_off, ssize_t in_out_off2, int64_t i_in, int64_t begin, int64_t end,
         int64_t reduce_offset, int64_t reduce_block_size) -> decltype(impl.Identity(0)) {
@@ -326,7 +371,7 @@ __device__ static inline auto reduce_axis_zip(const cumo_na_reduction_arg_t& arg
 // Note that reduction and out axis are inverse with cupy. Former axes are out axes, latters are reduce axes.
 
 template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
@@ -358,7 +403,7 @@ __global__ static void reduction_kernel(cumo_na_reduction_arg_t arg, cumo_reduce
 // Variant of reduction_kernel reading two inputs, for mulsum. See
 // reduce_axis_zip above.
 template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_zip_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, cumo_reduce_addr_t ad, cumo_reduce_addr_t ad2, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_zip_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_na_iarray_t in2, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad2, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
@@ -374,8 +419,8 @@ __global__ static void reduction_zip_kernel(cumo_na_reduction_arg_t arg, cumo_na
     int64_t out_stride = gridDim.x * out_block_size;
 
     for (int64_t i_out = out_base + out_offset; i_out < out_total_size; i_out += out_stride) {
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
-        ssize_t in_out_off2 = reduce_in_out_offset<FLAT>(in2, arg.in_indexer, ad2, i_out);
+        ssize_t in_out_off, in_out_off2;
+        reduce_in_out_offset_pair<FLAT>(arg.in, in2, arg.in_indexer, ad, ad2, i_out, &in_out_off, &in_out_off2);
         int64_t i_in = i_out * reduce_total_size + reduce_offset;
 
         TypeReduce accum = reduce_axis_zip<FLAT,TypeIn>(arg, in2, ad, ad2, impl, in_out_off, in_out_off2, i_in, 0, reduce_total_size, reduce_offset, reduce_block_size);
@@ -391,7 +436,7 @@ __global__ static void reduction_zip_kernel(cumo_na_reduction_arg_t arg, cumo_na
 // Variant of reduction_kernel for arg-reductions (argmax/argmin), which report
 // the index along the reduction axis rather than the index of an element.
 template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_arg_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
@@ -424,7 +469,7 @@ __global__ static void reduction_arg_kernel(cumo_na_reduction_arg_t arg, cumo_re
 // minmax reads the input once instead of reducing it twice. The impl stores
 // through the pointers rather than returning, since there are two of them.
 template <bool FLAT, typename TypeIn, typename TypeOut, typename ReductionImpl>
-__global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t out2_iarray, cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_pair_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_na_iarray_t out2_iarray, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     using TypeReduce = decltype(impl.Identity(0));
 
     extern __shared__ __align__(8) char sdata_raw[];
@@ -462,7 +507,7 @@ __global__ static void reduction_pair_kernel(cumo_na_reduction_arg_t arg, cumo_n
 // threads are handed out by output first, so a block still covers consecutive
 // outputs when those are the ones running along memory.
 template <bool FLAT, bool ARG, typename TypeIn, typename TypeReduce, typename ReductionImpl>
-__global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cumo_reduce_addr_t ad, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_partial_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
     unsigned int tid = threadIdx.x;
@@ -496,7 +541,7 @@ __global__ static void reduction_partial_kernel(cumo_na_reduction_arg_t arg, cum
 
 // First pass of a split zip reduction. See reduction_partial_kernel above.
 template <bool FLAT, typename TypeIn, typename TypeReduce, typename ReductionImpl>
-__global__ static void reduction_zip_partial_kernel(cumo_na_reduction_arg_t arg, cumo_na_iarray_t in2, cumo_reduce_addr_t ad, cumo_reduce_addr_t ad2, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
+__global__ static void reduction_zip_partial_kernel(CUMO_GRID_CONSTANT cumo_na_reduction_arg_t arg, CUMO_GRID_CONSTANT cumo_na_iarray_t in2, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad, CUMO_GRID_CONSTANT cumo_reduce_addr_t ad2, TypeReduce* partial, int64_t n_split, int64_t chunk, int out_block_size, int reduce_block_size, ReductionImpl impl) {
     extern __shared__ __align__(8) char sdata_raw[];
     TypeReduce* sdata = reinterpret_cast<TypeReduce*>(sdata_raw);
     unsigned int tid = threadIdx.x;
@@ -516,8 +561,8 @@ __global__ static void reduction_zip_partial_kernel(cumo_na_reduction_arg_t arg,
         int64_t begin = i_split * chunk;
         int64_t end = begin + chunk;
         if (end > reduce_total_size) end = reduce_total_size;
-        ssize_t in_out_off = reduce_in_out_offset<FLAT>(arg.in, arg.in_indexer, ad, i_out);
-        ssize_t in_out_off2 = reduce_in_out_offset<FLAT>(in2, arg.in_indexer, ad2, i_out);
+        ssize_t in_out_off, in_out_off2;
+        reduce_in_out_offset_pair<FLAT>(arg.in, in2, arg.in_indexer, ad, ad2, i_out, &in_out_off, &in_out_off2);
         int64_t i_in = i_out * reduce_total_size + begin + reduce_offset;
 
         TypeReduce accum = reduce_axis_zip<FLAT,TypeIn>(arg, in2, ad, ad2, impl, in_out_off, in_out_off2, i_in, begin, end, reduce_offset, reduce_block_size);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -855,6 +855,30 @@ class NArrayTest < Test::Unit::TestCase
         end
       end
 
+      # With two or more axes left over, the offset of an output is put together
+      # from every one of them for each operand, and the two operands do not
+      # have to share a layout.
+      test "mulsum over a middle axis of operands laid out differently" do
+        [[4, 5, 6], [3, 1100, 2], [2, 3, 4, 5]].each do |shape|
+          x = small.call(shape)
+          y = small.call(shape)
+          last = shape.size - 1
+          pairs = [
+            [x, y.reverse(0)],
+            [x.reverse(last), y],
+            [x.reverse(1), y.reverse(0)],
+            [x, y.transpose.copy.transpose],
+            [x.transpose.copy.transpose, y.reverse(1)]
+          ]
+          pairs.each do |a, b|
+            (0...shape.size).each do |axis|
+              assert { a.mulsum(b, axis: axis) == a.copy.mulsum(b.copy, axis: axis) }
+            end
+            assert { a.mulsum(b, axis: [0, last]) == a.copy.mulsum(b.copy, axis: [0, last]) }
+          end
+        end
+      end
+
       test "mulsum keeps the reduced axes when asked" do
         a = small.call([2, 3, 4])
         assert { a.mulsum(a, axis: 1, keepdims: true) == (a * a).sum(axis: 1, keepdims: true) }


### PR DESCRIPTION
`bench/cumo_shape_probe.rb` (#349) called out `mulsum` along a middle axis at 21 times its flat reduction, and the plain reductions along a short middle or first axis at 6 to 7 times. Two things were behind it.

The second operand of a zip reduction is a kernel parameter of its own, and reading its steps through a runtime index made the compiler copy it to local memory, 104 bytes per thread (`-Xptxas -v` shows the stack frame, and the sum kernel that reads the same steps out of the larger `arg` parameter has none). Declaring the parameters `__grid_constant__` keeps them where they are; below CUDA 11.7 or sm_70 the macro falls back to `const`. The two operands also share their indexer, so the offset of an output is now split once for both.

When the out axis is the one along memory, a row of n got a group of n threads with one element each and a tree to combine them. The group now shrinks so that every thread reads sixteen elements, the same rule #347 applied to the other layout.

4M SFloat, 10 launches per sync, best of 4, RTX 5070 Ti Laptop:

| case | before | after |
|---|---|---|
| [1024,4,1024].mulsum(b, axis: 1) | 386.8 us | 70.7 us |
| [512,16,512].mulsum(b, axis: 1) | 374.1 us | 29.6 us |
| [64,1024,64].mulsum(b, axis: 1) | 61.8 us | 32.3 us |
| [1024,4,1024].sum(axis: 1) | 165.1 us | 42.0 us |
| [4,1048576].sum(axis: 0) | 91.7 us | 23.4 us |
| [16,262144].sum(axis: 0) | 82.6 us | 9.8 us |

Rows of 256 and up along the first axis, and everything along the last axis, are unchanged. The reduce group of the shape sweep goes from 28 flagged cases to 4.

A test with 3-D and 4-D operands laid out differently from each other covers the shared split; the existing mulsum tests never combined two layouts past two dimensions, and a mutation that hands the second operand the first one's steps passed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
