### PR TITLE
Keep swap_byte on a Bit array inside its packed buffer

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -129,30 +129,6 @@ cumo_na_store(VALUE self, VALUE src)
 
 // ---------------------------------------------------------------------
 
-#define m_swap_byte(q1,q2)       \
-    {                            \
-        size_t j;                \
-        memcpy(b1,q1,e);         \
-        for (j=0; j<e; j++) {    \
-            b2[e-1-j] = b1[j];   \
-        }                        \
-        memcpy(q2,b2,e);         \
-    }
-
-static void
-iter_swap_byte(cumo_na_loop_t *const lp)
-{
-    char   *b1, *b2;
-    size_t  e;
-
-    e = lp->args[0].elmsz;
-    b1 = ALLOCA_N(char, e);
-    b2 = ALLOCA_N(char, e);
-    CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("iter_swap_bytes", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    LOOP_UNARY_PTR(lp,m_swap_byte);
-}
-
 static void
 iter_swap_byte_indexer(cumo_na_loop_t *const lp)
 {
@@ -169,17 +145,19 @@ cumo_na_swap_byte(VALUE self)
     VALUE v;
     cumo_ndfunc_arg_in_t ain[1] = {{Qnil,0}};
     cumo_ndfunc_arg_out_t aout[1] = {{INT2FIX(0),0}};
-    cumo_ndfunc_t ndf = { iter_swap_byte, CUMO_FULL_LOOP|CUMO_NDF_ACCEPT_BYTESWAP,
-                     1, 1, ain, aout };
+    cumo_ndfunc_t ndf = { iter_swap_byte_indexer,
+                          CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP|CUMO_NDF_ACCEPT_BYTESWAP,
+                          1, 1, ain, aout };
 
-    // Cumo::Bit's element is one bit, which a loop stepping by the element
-    // stride cannot address; it keeps the loop it has always had.
-    if (!rb_obj_is_kind_of(self, cumo_cBit)) {
-        ndf.func = iter_swap_byte_indexer;
-        ndf.flag = CUMO_STRIDE_LOOP|CUMO_NDF_INDEXER_LOOP|CUMO_NDF_ACCEPT_BYTESWAP;
+    // Cumo::Bit's element is one bit, so swapping the bytes of an element
+    // changes nothing, and a loop stepping by the element stride would walk
+    // one byte per bit, eight times past the end of the packed buffer. Only
+    // the endian flag below needs to move.
+    if (rb_obj_is_kind_of(self, cumo_cBit)) {
+        v = CUMO_TEST_INPLACE(self) ? self : rb_funcall(self, cumo_id_copy, 0);
+    } else {
+        v = cumo_na_ndloop(&ndf, 1, self);
     }
-
-    v = cumo_na_ndloop(&ndf, 1, self);
     if (self!=v) {
         cumo_na_copy_flags(self, v);
     }

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -766,4 +766,61 @@ class BitTest < Test::Unit::TestCase
       end
     end
   end
+
+  test "swap_byte on a bit array only moves the endian flag" do
+    srand(13)
+    a = Cumo::Bit.cast(Array.new(3 * 8) { rand(2) }).reshape(3, 8)
+    values = a.to_a
+
+    s = a.swap_byte
+    assert_equal(values, s.to_a)
+    assert { s.byte_swapped? }
+    assert { !s.host_order? }
+    assert { !a.byte_swapped? }
+    assert { !s.swap_byte.byte_swapped? }
+    assert_equal(values, a.hton.to_a)
+    assert_equal(values, a.to_swapped.to_a)
+    assert { a.to_host.equal?(a) }
+    assert { a.to_swapped.to_host.host_order? }
+
+    view = a[true, 2...6]
+    assert_equal(view.to_a, view.swap_byte.to_a)
+    assert_equal(values, a.to_a)
+
+    x = a.inplace
+    assert { x.swap_byte.equal?(x) }
+    assert { x.byte_swapped? }
+    assert_equal(values, x.to_a)
+  end
+
+  # Before this guard the loop stepped one byte per bit, eight times past the
+  # end of the packed buffer, and a large array took the process down.
+  test "swap_byte on a large bit array does not run past the buffer" do
+    script = <<~RUBY
+      require "cumo/narray"
+      b = Cumo::Bit.new(1 << 26).fill(1)
+      done = %i[swap_byte hton to_network to_swapped].select do |m|
+        v = b.send(m)
+        Integer(v.count_true) == (1 << 26) && v.byte_swapped?
+      end
+      print done.join(",")
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    r, w = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, "-I#{lib}", "-e", script, out: w, err: File::NULL)
+    w.close
+    reader = Thread.new { r.read }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    until Process.waitpid(pid, Process::WNOHANG)
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+        reader.kill
+        flunk("swap_byte on a large bit array did not finish in 60 seconds")
+      end
+      sleep 0.05
+    end
+    assert { Process.last_status.success? }
+    assert_equal("swap_byte,hton,to_network,to_swapped", reader.value)
+  end
 end


### PR DESCRIPTION
`Cumo::Bit#swap_byte` walked one byte per bit, so it read and wrote eight times the packed buffer. `Cumo::Bit.new(1 << 26).swap_byte` crashed the process, and `hton`, `to_network` and `to_swapped` go through the same path. The result looks right on small arrays because the swap is an identity on a one-bit element, so nothing reported it.

A Bit array now copies itself (or returns itself when inplace) and only the endian flag moves, which keeps `byte_swapped?` and `host_order?` behaving as they did. The unused host loop is removed.

This is shared with numo-narray, and it is the first fix that goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
