### PR TITLE
Stop reading past a Ruby array or string that a conversion shrank

### DIFF
--- a/ext/cumo/cuda/nvrtc.c
+++ b/ext/cumo/cuda/nvrtc.c
@@ -63,7 +63,7 @@ push_strings(VALUE strings, VALUE ary, int n)
     int i;
 
     for (i = 0; i < n; i++) {
-        VALUE str = rb_str_to_str(RARRAY_AREF(ary, i));
+        VALUE str = rb_str_to_str(rb_ary_entry(ary, i));
         StringValueCStr(str);
         rb_ary_push(strings, str);
     }

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -718,8 +718,8 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
         if (RARRAY_LEN(vaxes) != 2) {
             rb_raise(rb_eArgError,"axes must be 2-element array");
         }
-        ax[0] = NUM2INT(RARRAY_AREF(vaxes,0));
-        ax[1] = NUM2INT(RARRAY_AREF(vaxes,1));
+        ax[0] = NUM2INT(rb_ary_entry(vaxes,0));
+        ax[1] = NUM2INT(rb_ary_entry(vaxes,1));
         if (ax[0]<-nd || ax[0]>=nd || ax[1]<-nd || ax[1]>=nd) {
             rb_raise(rb_eArgError,"axis out of range:[%d,%d]",ax[0],ax[1]);
         }

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -172,7 +172,7 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
     q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
     idx = ALLOC_N(size_t, n);
     for (k=0; k<n; k++) {
-        idx[k] = cumo_na_range_check(NUM2SSIZET(RARRAY_AREF(ary,k)), size, orig_dim);
+        idx[k] = cumo_na_range_check(NUM2SSIZET(rb_ary_entry(ary,k)), size, orig_dim);
     }
     status = cudaMemcpyAsync(q->idx,idx,sizeof(size_t)*n,cudaMemcpyHostToDevice,0);
     xfree(idx);

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -243,7 +243,7 @@ cumo_na_array_to_internal_shape(VALUE self, VALUE ary, size_t *shape)
         s = 1;
     }
     for (i=0; i<n; i++) {
-        v = RARRAY_AREF(ary,i);
+        v = rb_ary_entry(ary,i);
         x = NUM2SSIZET(v);
         if (x < 0) {
             rb_raise(rb_eArgError,"size must be non-negative");
@@ -1417,7 +1417,7 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
             shape = ALLOCA_N(size_t,nd);
             len = 1;
             for (i=0; i<nd; ++i) {
-                len *= shape[i] = NUM2SIZET(RARRAY_AREF(vshape,i));
+                len *= shape[i] = NUM2SIZET(rb_ary_entry(vshape,i));
             }
             break;
         default:
@@ -1432,6 +1432,9 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
         } else {
             byte_size = ceil(len * NUM2DBL(velmsz));
         }
+        // The shape went through to_int, which is Ruby code free to empty
+        // the string this length came from.
+        str_len = RSTRING_LEN(vstr);
         if (byte_size > str_len) {
             rb_raise(rb_eArgError, "specified size is too large");
         }
@@ -1482,16 +1485,18 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
 
     narg = rb_scan_args(argc,argv,"11",&vstr,&voffset);
     Check_Type(vstr,T_STRING);
-    str_len = RSTRING_LEN(vstr);
     if (narg==2) {
         offset = NUM2SIZET(voffset);
-        if (str_len < offset) {
-            rb_raise(rb_eArgError, "offset is larger than string length");
-        }
-        str_len -= offset;
     } else {
         offset = 0;
     }
+    // The offset went through to_int, which is Ruby code free to empty the
+    // string, so its length is only known once that has run.
+    str_len = RSTRING_LEN(vstr);
+    if (str_len < offset) {
+        rb_raise(rb_eArgError, "offset is larger than string length");
+    }
+    str_len -= offset;
 
     CumoGetNArray(self,na);
     size = CUMO_NA_SIZE(na);
@@ -1627,8 +1632,8 @@ cumo_na_marshal_load(VALUE self, VALUE a)
         rb_raise(rb_eArgError,"marshal shape should be array");
     }
     cumo_na_initialize(self,RARRAY_AREF(a,1));
-    CUMO_NA_FL0_SET(self,FIX2INT(RARRAY_AREF(a,2)));
-    v = RARRAY_AREF(a,3);
+    CUMO_NA_FL0_SET(self,NUM2INT(rb_ary_entry(a,2)));
+    v = rb_ary_entry(a,3);
     if (rb_obj_class(self) == cumo_cRObject) {
         cumo_narray_t *na;
         char *ptr;
@@ -1753,7 +1758,7 @@ cumo_na_get_reduce_flag_from_axes(VALUE cumo_na_obj, VALUE axes)
     reduce = Qnil;
     narg = RARRAY_LEN(axes);
     for (i=0; i<narg; i++) {
-        v = RARRAY_AREF(axes,i);
+        v = rb_ary_entry(axes,i);
         //printf("argv[%d]=",i);rb_p(v);
         if (TYPE(v)==T_FIXNUM) {
             beg = FIX2INT(v);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5798,4 +5798,148 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([5, 1, 3], a[[4, 0, 2]].copy.to_a)
     assert_equal(true, a.free)
   end
+
+  test "an object with to_int can be used as a subscript and as a shape" do
+    o = Object.new
+    def o.to_int = 3
+    a = Cumo::DFloat.new(10).seq
+    assert_equal([3, 3], Cumo::DFloat.new([o, 3]).shape)
+    assert_equal([2, 3], Cumo::DFloat.from_binary("\0" * 64, [2, o]).shape)
+    assert_equal([1.0, 3.0, 2.0], a[[1, o, 2]].to_a)
+    assert_equal([1.0, 3.0], a.at([1, o]).to_a)
+    assert_equal([0.0, 5.0, 10.0, 15.0], Cumo::DFloat.new(4, 4).seq.diagonal(0, [0, 1]).to_a)
+    d = Cumo::DFloat.allocate
+    d.marshal_load(Cumo::DFloat.new(2, 2).seq.marshal_dump)
+    assert_equal([[0.0, 1.0], [2.0, 3.0]], d.to_a)
+    two = Object.new
+    def two.to_int = 2
+    def two.<=>(_other) = 0
+    assert_equal([4], Cumo::DFloat.new(4, 4, 4).seq.sum(axis: [0, (two..two)]).shape)
+    b = Cumo::DFloat.new(4)
+    assert_equal(32, b.store_binary("\0" * 64, two))
+  end
+
+  # A subscript, a shape, an axis list, a marshal array and the string behind
+  # from_binary are each measured once and walked afterwards, and the
+  # conversion of every element is Ruby code that can empty that same object.
+  # The reads that followed went past the end of the buffer, and its contents
+  # were read back as VALUEs. Runs in a child process because a regression here
+  # takes the process down rather than failing a test.
+  test "an array or string emptied from inside a conversion is not read past its end" do
+    script = <<~RUBY
+      require "cumo/narray"
+
+      def shrinking(n)
+        ary = []
+        o = Object.new
+        o.define_singleton_method(:to_int) { ary.replace([]); GC.start; 0 }
+        ary.concat([o] + Array.new(n, 1))
+        ary
+      end
+
+      # A short array stays embedded in its own object, so it has to start
+      # long enough to own a heap buffer that replace() can hand back.
+      def shrinking_heap(len)
+        ary = Array.new(4096, 1)
+        o = Object.new
+        o.define_singleton_method(:to_int) { ary.replace([]); GC.start; 0 }
+        ary[0] = o
+        ary.slice!(len..)
+        ary
+      end
+
+      cases = {
+        "aref" => -> { Cumo::DFloat.new(10).seq[shrinking(2048)] },
+        "aref2" => -> { a = shrinking(2048); Cumo::DFloat.new(10, 10).seq[a, a] },
+        "aset" => -> { Cumo::DFloat.new(10).seq[shrinking(2048)] = 0 },
+        "at" => -> { Cumo::DFloat.new(64).seq.at(shrinking(2048)) },
+        "at2" => -> { a = shrinking(2048); Cumo::DFloat.new(8, 8).seq.at(a, a) },
+        "shape" => -> { Cumo::DFloat.new(shrinking(7)) },
+        "from_binary" => -> { Cumo::DFloat.from_binary("\\0" * 8192, shrinking(7)) },
+        "diagonal" => -> { Cumo::DFloat.new(4, 4).seq.diagonal(0, shrinking_heap(2)) },
+        "axis" => lambda {
+          axes = Array.new(4096, 0)
+          o = Object.new
+          o.define_singleton_method(:<=>) { |_| 0 }
+          o.define_singleton_method(:to_int) { axes.replace([]); GC.start; 0 }
+          axes[0] = (o..o)
+          axes.slice!(3..)
+          Cumo::DFloat.new(4, 4, 4).seq.sum(axis: axes)
+        },
+        "from_binary_string" => lambda {
+          str = "A" * (1 << 20)
+          o = Object.new
+          o.define_singleton_method(:to_int) { str.replace(""); GC.start; 8 }
+          Cumo::DFloat.from_binary(str, [o, 16384])
+        },
+        "store_binary_offset" => lambda {
+          str = "A" * (1 << 20)
+          o = Object.new
+          o.define_singleton_method(:to_int) { str.replace(""); GC.start; 0 }
+          Cumo::DFloat.new(16384).store_binary(str, o)
+        },
+        "nvrtc" => lambda {
+          opts = Array.new(4096, "-x")
+          o = Object.new
+          o.define_singleton_method(:to_str) { opts.replace([]); GC.start; "-DA=1" }
+          opts[0] = o
+          opts.slice!(8..)
+          prog = Cumo::CUDA::NVRTC.nvrtcCreateProgram("__global__ void k(){}", "k.cu", [], [])
+          Cumo::CUDA::NVRTC.nvrtcCompileProgram(prog, opts)
+        },
+        "marshal_load" => lambda {
+          a = Array.new(4096, 0)
+          o = Object.new
+          o.define_singleton_method(:to_int) { a.replace([]); GC.start; 4 }
+          a[0] = 1
+          a[1] = [o]
+          a[2] = 0
+          a[3] = "\\0" * 32
+          a.slice!(4..)
+          Cumo::DFloat.allocate.marshal_load(a)
+        }
+      }
+      got = cases.map do |name, c|
+        begin
+          c.call
+          "\#{name}=no error"
+        rescue StandardError => e
+          "\#{name}=\#{e.class}"
+        end
+      end
+      print got.join(",")
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    r, w = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, "-I#{lib}", "-e", script, out: w, err: File::NULL)
+    w.close
+    reader = Thread.new { r.read }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 120
+    until Process.waitpid(pid, Process::WNOHANG)
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+        reader.kill
+        flunk("the shrinking-array cases did not finish in 120 seconds")
+      end
+      sleep 0.05
+    end
+    assert { Process.last_status.success? }
+    want = [
+      "aref=TypeError",
+      "aref2=TypeError",
+      "aset=TypeError",
+      "at=TypeError",
+      "at2=TypeError",
+      "shape=TypeError",
+      "from_binary=TypeError",
+      "diagonal=TypeError",
+      "axis=Cumo::NArray::DimensionError",
+      "from_binary_string=ArgumentError",
+      "store_binary_offset=ArgumentError",
+      "nvrtc=TypeError",
+      "marshal_load=TypeError"
+    ]
+    assert_equal(want.join(","), reader.value)
+  end
 end


### PR DESCRIPTION
A subscript, a shape, an axis list, a marshal array and the string behind `from_binary` are each measured once and walked afterwards, and the conversion of every element is Ruby code free to empty that same object. The reads that followed went past the end of a buffer that had already been handed back, and what they found was passed on as a `VALUE`. `Cumo::DFloat.new(10).seq[ary]` took the process down when `ary` emptied itself, and so did the shape of `new`, `from_binary`, the axes of `diagonal`, `marshal_load`, an `axis:` keyword holding a Range, and the options of `nvrtcCompileProgram`.

Elements now come from `rb_ary_entry`, which answers `nil` once the array is shorter, so the conversion raises rather than reading on. The two sites that measure a String read its length again after the conversion that can shorten it. Passing an object whose `to_int` or `to_str` answers an index, a size or an option is a supported thing to do, and it still works.

Most of this is shared with numo-narray, and it goes into cumo first under the reversed backport direction. The nvrtc part is cumo's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
