### PR TITLE
Stop truncating a range subscript's length to 32 bits

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -252,7 +252,11 @@ cumo_na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, cumo_na_index_ar
 static void
 cumo_na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, cumo_na_index_arg_t *q)
 {
-    int n;
+    // The count is what the subscript names, which an int cannot hold once the
+    // dimension is longer than 2**31. The guard below only looked like it
+    // caught that: a truncated count came out negative up to 2**32 and was
+    // rounded to an empty view, and past that it came out positive and wrong.
+    ssize_t n;
     ssize_t beg, end, beg_orig, end_orig;
     const char *dot = "..", *edot = "...";
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3168,6 +3168,23 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([1, 3], [a[0, cols / 2 + 1].to_i, a[1, cols / 2].to_i])
   end
 
+  test "a range subscript longer than 2**31" do
+    cols = (1 << 31) + 512
+    a = Cumo::UInt8.new(1, cols).fill(0)
+    a[0, 0] = 7
+    a[0, (1 << 31) - 1] = 9
+    a[0, cols - 1] = 5
+
+    v = a[true, 0...(1 << 31)]
+    assert_equal([1, 1 << 31], v.shape)
+    assert_equal([7, 9], [v[0, 0].to_i, v[0, (1 << 31) - 1].to_i])
+    assert_equal(16, v.sum.to_i)
+    assert_equal([1, (1 << 31) - 1], a[true, 0...((1 << 31) - 1)].shape)
+    assert_equal([[1, 512], 5], [a[true, (1 << 31)...cols].shape, a[true, (1 << 31)...cols].sum.to_i])
+    # a range that runs backwards still names nothing
+    assert_equal([1, 0], a[true, ((1 << 31) + 1)..(1 << 31)].shape)
+  end
+
   # cumsum and cumprod had no tests at all before the scan was moved to the device
   def running(values)
     acc = nil


### PR DESCRIPTION
The count a range subscript names was held in an `int`, so a dimension longer than 2\*\*31 got a truncated one. Up to 2\*\*32 the truncation came out negative and the guard below rounded it to an empty view, which is how `a[true, 0...(2**31)]` answered a shape of 0. Past 2\*\*32 it came out positive and wrong, and the subscript silently named the low 32 bits of what was asked for: `a[true, 0...((1<<32)+5)]` on a longer dimension answered 5 elements.

The count is now an `ssize_t`. The guard stays for a range that runs backwards.

This is shared with numo-narray, and it goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
