### PR TITLE
Stop marshal_load from reusing a buffer sized for the old shape

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -614,14 +614,17 @@ cumo_na_data_byte_size(VALUE self)
 // type, so the deallocator has to be picked the same way. cudaFree() on host
 // memory raises, and xfree() on device memory reads a malloc header that is not
 // there.
+// The size is passed in rather than measured here: a caller that has already
+// taken a new shape can no longer ask the array how large the buffer it is
+// letting go was.
 static void
-cumo_na_free_owned_ptr(VALUE self, void *ptr)
+cumo_na_free_owned_ptr(VALUE self, void *ptr, size_t byte_size)
 {
     if (rb_obj_is_kind_of(self, cumo_cRObject)) {
         xfree(ptr);
     } else {
         cumo_cuda_runtime_free(ptr);
-        rb_gc_adjust_memory_usage(-(ssize_t)cumo_na_data_byte_size(self));
+        rb_gc_adjust_memory_usage(-(ssize_t)byte_size);
     }
 }
 
@@ -641,7 +644,7 @@ cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
     case CUMO_NARRAY_DATA_T:
         if (CUMO_NA_SIZE(na) > 0) {
             if (CUMO_NA_DATA_PTR(na) != NULL && CUMO_NA_DATA_OWNED(na)) {
-                cumo_na_free_owned_ptr(self, CUMO_NA_DATA_PTR(na));
+                cumo_na_free_owned_ptr(self, CUMO_NA_DATA_PTR(na), cumo_na_data_byte_size(self));
             }
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = FALSE;
@@ -657,7 +660,7 @@ cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
         case CUMO_NARRAY_DATA_T:
             if (CUMO_NA_SIZE(na) > 0) {
                 if (CUMO_NA_DATA_PTR(na) != NULL && CUMO_NA_DATA_OWNED(na)) {
-                    cumo_na_free_owned_ptr(obj, CUMO_NA_DATA_PTR(na));
+                    cumo_na_free_owned_ptr(obj, CUMO_NA_DATA_PTR(na), cumo_na_data_byte_size(obj));
                 }
                 CUMO_NA_DATA_PTR(na) = ptr;
                 CUMO_NA_DATA_OWNED(na) = FALSE;
@@ -1614,6 +1617,10 @@ static VALUE
 cumo_na_marshal_load(VALUE self, VALUE a)
 {
     VALUE v;
+    cumo_narray_t *na;
+    void *old_ptr;
+    size_t old_byte_size;
+    bool old_owned;
 
     if (OBJ_FROZEN(self)) {
         rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
@@ -1631,11 +1638,28 @@ cumo_na_marshal_load(VALUE self, VALUE a)
     if (TYPE(RARRAY_AREF(a,1)) != T_ARRAY) {
         rb_raise(rb_eArgError,"marshal shape should be array");
     }
+    CumoGetNArray(self,na);
+    if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+        rb_raise(rb_eArgError,"cannot load marshal data into a view");
+    }
+    // Any buffer already here was sized for the shape being replaced, and the
+    // write below goes by the new one. Note it while the array can still say
+    // how large it is, and let it go once the new shape has been accepted: a
+    // shape the array refuses has to leave the array as it was.
+    old_ptr = CUMO_NA_DATA_PTR(na);
+    old_byte_size = cumo_na_data_byte_size(self);
+    old_owned = CUMO_NA_DATA_OWNED(na);
+
     cumo_na_initialize(self,RARRAY_AREF(a,1));
+    if (old_ptr != NULL) {
+        if (old_owned) {
+            cumo_na_free_owned_ptr(self, old_ptr, old_byte_size);
+        }
+        CUMO_NA_DATA_PTR(na) = NULL;
+    }
     CUMO_NA_FL0_SET(self,NUM2INT(rb_ary_entry(a,2)));
     v = rb_ary_entry(a,3);
     if (rb_obj_class(self) == cumo_cRObject) {
-        cumo_narray_t *na;
         char *ptr;
         if (TYPE(v) != T_ARRAY) {
             rb_raise(rb_eArgError,"RObject content should be array");
@@ -2083,7 +2107,7 @@ cumo_na_free_data(VALUE self)
         // Not owned means the data belongs to something else -- store_binary()
         // points a frozen String's bytes at it -- so there is nothing to free.
         if (ptr != NULL && CUMO_NA_DATA_OWNED(na)) {
-            cumo_na_free_owned_ptr(self, ptr);
+            cumo_na_free_owned_ptr(self, ptr, cumo_na_data_byte_size(self));
             CUMO_NA_DATA_PTR(na) = NULL;
             return Qtrue;
         }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5816,6 +5816,81 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(true, a.free)
   end
 
+  # marshal_load takes its shape from the data it is handed, but the buffer
+  # already in hand was sized for the shape being replaced, and nothing sized
+  # it again. A larger shape wrote past the end of it. Runs in a child process
+  # because a regression here corrupts the heap rather than failing a test.
+  test "marshal_load into an allocated array sizes its buffer again" do
+    script = <<~RUBY
+      require "cumo/narray"
+
+      a = Cumo::RObject.new(2)
+      a.store([+"a", +"b"])
+      a.marshal_load([1, [4096], 0, Array.new(4096) { |i| i }])
+      grew = a.size == 4096 && a[0].to_a.first == 0 && a[4095].to_a.first == 4095
+
+      b = Cumo::RObject.new(4096)
+      b.store(Array.new(4096) { +"x" })
+      b.marshal_load([1, [2], 0, [+"p", +"q"]])
+      shrank = b.to_a == ["p", "q"]
+
+      c = Cumo::DFloat.new(2).seq
+      c.marshal_load(Cumo::DFloat.new(3, 4).seq(10).marshal_dump)
+      typed = c.shape == [3, 4] && c[2, 3].to_a == [21.0]
+
+      # RObject so that a view without this guard corrupts the heap rather
+      # than quietly growing: a frozen String is swapped in whole for the
+      # other types, which hides the write.
+      e = Cumo::RObject.new(8)
+      e.store(Array.new(8) { +"a" })
+      viewed = begin
+        e[2..5].marshal_load([1, [4096], 0, Array.new(4096) { +"z" }])
+        "no error"
+      rescue ArgumentError
+        "ArgumentError"
+      end
+
+      # A buffer that belongs to a frozen String is not this array's to free,
+      # but keeping it while the shape grows makes the copy that comes next
+      # read a megabyte out of sixteen bytes.
+      f = Cumo::RObject.new(2)
+      f.store([+"a", +"b"])
+      f.store_binary(("\\x01" * 16).freeze)
+      f.marshal_load([1, [1 << 20], 0, Array.new(1 << 20) { |i| i }])
+      borrowed = f.size == (1 << 20) && f[(1 << 20) - 1].to_a.first == (1 << 20) - 1
+
+      print [grew, shrank, typed, viewed, borrowed].join(",")
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    r, w = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, "-I#{lib}", "-e", script, out: w, err: File::NULL)
+    w.close
+    reader = Thread.new { r.read }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    until Process.waitpid(pid, Process::WNOHANG)
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+        reader.kill
+        flunk("marshal_load did not finish in 60 seconds")
+      end
+      sleep 0.05
+    end
+    assert { Process.last_status.success? }
+    assert_equal("true,true,true,ArgumentError,true", reader.value)
+  end
+
+  test "marshal round trips an array that was never allocated" do
+    a = Cumo::DFloat.new(2, 3).seq
+    assert_equal(a.to_a, Marshal.load(Marshal.dump(a)).to_a)
+    r = Cumo::RObject.cast([+"a", +"b"])
+    assert_equal(%w[a b], Marshal.load(Marshal.dump(r)).to_a)
+    frozen = Cumo::RObject.new(2)
+    frozen.store([1, 2])
+    frozen.freeze
+    assert_raise(RuntimeError) { frozen.marshal_load([1, [4], 0, [1, 2, 3, 4]]) }
+  end
+
   test "an object with to_int can be used as a subscript and as a shape" do
     o = Object.new
     def o.to_int = 3


### PR DESCRIPTION
`marshal_load` takes its shape from the data it is handed, but the buffer already in hand was sized for the shape being replaced and nothing sized it again. A `Cumo::RObject` of 2 elements loading a shape of 4096 wrote past the end of it and corrupted the heap. A buffer borrowed from a frozen String is not this array's to free, and keeping it while the shape grows made the copy that comes next read a megabyte out of sixteen bytes. `Marshal.load` never reaches either, because it loads into an instance that has just been allocated.

The buffer is now let go once the new shape has been accepted, so the write allocates one that fits. It is noted beforehand, while the array can still say how large it is, so a shape the array refuses still leaves the array as it was. A view has no buffer of its own to size, so loading into one is refused rather than writing through to whatever it is a view of.

This is shared with numo-narray, and it goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
