### PR TITLE
Fix a double free when a shape element's to_int touches the array

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1616,10 +1616,12 @@ static VALUE cumo_na_inplace( VALUE self );
 static VALUE
 cumo_na_marshal_load(VALUE self, VALUE a)
 {
-    VALUE v;
+    VALUE v, vshape;
     cumo_narray_t *na;
     void *old_ptr;
     size_t old_byte_size;
+    size_t *shape;
+    int ndim;
     bool old_owned;
 
     if (OBJ_FROZEN(self)) {
@@ -1642,15 +1644,31 @@ cumo_na_marshal_load(VALUE self, VALUE a)
     if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
         rb_raise(rb_eArgError,"cannot load marshal data into a view");
     }
-    // Any buffer already here was sized for the shape being replaced, and the
-    // write below goes by the new one. Note it while the array can still say
-    // how large it is, and let it go once the new shape has been accepted: a
-    // shape the array refuses has to leave the array as it was.
+
+    // Read the shape first. Converting its elements runs to_int, which is Ruby
+    // free to reach this array and free or replace the buffer, so nothing may
+    // be noted down until that has finished.
+    vshape = RARRAY_AREF(a,1);
+    if (RARRAY_LEN(vshape) == 1 && TYPE(RARRAY_AREF(vshape,0)) == T_ARRAY) {
+        vshape = RARRAY_AREF(vshape,0);
+    }
+    ndim = RARRAY_LEN(vshape);
+    if (ndim > CUMO_NA_MAX_DIMENSION) {
+        rb_raise(rb_eArgError,"ndim=%d exceeds maximum dimension",ndim);
+    }
+    shape = ALLOCA_N(size_t, ndim);
+    cumo_na_array_to_internal_shape(self, vshape, shape);
+
+    // Any buffer here was sized for the shape being replaced, and the write
+    // below goes by the new one. Note it while the array can still say how
+    // large it is, and let it go once the new shape has been accepted: a shape
+    // the array refuses has to leave the array as it was. No Ruby runs between
+    // the two, so what is released is what was measured.
     old_ptr = CUMO_NA_DATA_PTR(na);
     old_byte_size = cumo_na_data_byte_size(self);
     old_owned = CUMO_NA_DATA_OWNED(na);
 
-    cumo_na_initialize(self,RARRAY_AREF(a,1));
+    cumo_na_setup(self, ndim, shape);
     if (old_ptr != NULL) {
         if (old_owned) {
             cumo_na_free_owned_ptr(self, old_ptr, old_byte_size);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5859,7 +5859,25 @@ class NArrayTest < Test::Unit::TestCase
       f.marshal_load([1, [1 << 20], 0, Array.new(1 << 20) { |i| i }])
       borrowed = f.size == (1 << 20) && f[(1 << 20) - 1].to_a.first == (1 << 20) - 1
 
-      print [grew, shrank, typed, viewed, borrowed].join(",")
+      # Converting a shape element runs to_int, which is Ruby free to reach
+      # this array and free or replace the buffer before it is released here.
+      reentered = %w[free store_binary marshal_load].map do |what|
+        g = Cumo::RObject.new(4)
+        g.store([1, 2, 3, 4])
+        o = Object.new
+        o.define_singleton_method(:to_int) do
+          case what
+          when "free" then g.free
+          when "store_binary" then g.store_binary(("\\x01" * 32).freeze)
+          else g.marshal_load([1, [2], 0, [+"x", +"y"]])
+          end
+          8
+        end
+        g.marshal_load([1, [o], 0, Array.new(8) { |i| i }])
+        g.to_a == (0...8).to_a
+      end
+
+      print [grew, shrank, typed, viewed, borrowed, *reentered].join(",")
     RUBY
     lib = File.expand_path("../lib", __dir__)
     r, w = IO.pipe
@@ -5877,7 +5895,7 @@ class NArrayTest < Test::Unit::TestCase
       sleep 0.05
     end
     assert { Process.last_status.success? }
-    assert_equal("true,true,true,ArgumentError,true", reader.value)
+    assert_equal("true,true,true,ArgumentError,true,true,true,true", reader.value)
   end
 
   test "marshal round trips an array that was never allocated" do


### PR DESCRIPTION
Converting a shape element runs `to_int`, which is Ruby free to reach the array being loaded into. #355 noted the buffer down before that conversion ran and released it afterwards, so an object whose `to_int` called `free`, `store_binary` or `marshal_load` on the same array left the release holding a pointer that was already gone: a double free, reachable three ways.

The shape is now read first, and the buffer is noted and released either side of applying it, with no Ruby in between. A shape the array refuses still leaves the array as it was, since nothing is released until the shape has been accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
