### PR TITLE
Fix a memory leak when an Array subscript is rejected

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -13,8 +13,6 @@
 #endif
 
 
-// note: the memory refed by this pointer is not freed and causes memory leak.
-//
 // @example
 //     a[1..3,1] generates two cumo_na_index_arg_t(s). First is for 1..3, and second is for 1.
 typedef struct {
@@ -142,7 +140,7 @@ static void
 cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *q, int at_mode)
 {
     int k;
-    size_t* idx;
+    VALUE buf;
     cudaError_t status;
     int n = RARRAY_LEN(ary);
 
@@ -169,13 +167,19 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
     // Pinned memory would have to outlive the copy, and there is no way to
     // release it once the copy is done: a stream callback may not call the CUDA
     // API, so cudaFreeHost() there fails with cudaErrorNotPermitted and leaks.
+    // The host buffer is a String because the loop below raises on an index
+    // out of range, and on one whose to_int leaves nothing to convert: the
+    // collector takes the buffer back, where a free placed after the loop is
+    // never reached. That same to_int is Ruby, so the address is taken again
+    // each time round rather than held across it.
     q->idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-    idx = ALLOC_N(size_t, n);
+    buf = rb_str_tmp_new((long)(sizeof(size_t)*n));
     for (k=0; k<n; k++) {
-        idx[k] = cumo_na_range_check(NUM2SSIZET(rb_ary_entry(ary,k)), size, orig_dim);
+        size_t i = cumo_na_range_check(NUM2SSIZET(rb_ary_entry(ary,k)), size, orig_dim);
+        ((size_t*)RSTRING_PTR(buf))[k] = i;
     }
-    status = cudaMemcpyAsync(q->idx,idx,sizeof(size_t)*n,cudaMemcpyHostToDevice,0);
-    xfree(idx);
+    status = cudaMemcpyAsync(q->idx,RSTRING_PTR(buf),sizeof(size_t)*n,cudaMemcpyHostToDevice,0);
+    RB_GC_GUARD(buf);
     cumo_cuda_runtime_check_status(status);
 
     q->n    = n;

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5909,6 +5909,45 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(RuntimeError) { frozen.marshal_load([1, [4], 0, [1, 2, 3, 4]]) }
   end
 
+  # The host buffer an Array subscript is staged in was freed after the loop
+  # that fills it, and that loop raises on an index out of range, so every
+  # rejected subscript kept its buffer. Runs in a child process because the
+  # measurement is of the process itself.
+  test "a rejected Array subscript does not keep its staging buffer" do
+    script = <<~RUBY
+      require "cumo/narray"
+
+      def rss = File.read("/proc/self/status")[/VmRSS:\\s+(\\d+)/, 1].to_i
+
+      a = Cumo::DFloat.new(10).seq
+      bad = [0] * 100_000
+      bad[-1] = 999
+      200.times { a[bad] rescue IndexError }
+      GC.start
+      before = rss
+      2_000.times { a[bad] rescue IndexError }
+      GC.start
+      print(rss - before < 100_000)
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    r, w = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, "-I#{lib}", "-e", script, out: w, err: File::NULL)
+    w.close
+    reader = Thread.new { r.read }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 120
+    until Process.waitpid(pid, Process::WNOHANG)
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+        reader.kill
+        flunk("the rejected-subscript loop did not finish in 120 seconds")
+      end
+      sleep 0.05
+    end
+    assert { Process.last_status.success? }
+    assert_equal("true", reader.value)
+  end
+
   test "an object with to_int can be used as a subscript and as a shape" do
     o = Object.new
     def o.to_int = 3


### PR DESCRIPTION
An Array subscript is staged in a host buffer before being copied to the device, and that buffer was freed after the loop that fills it. The loop raises on an index out of range, and since #353 on one whose `to_int` leaves nothing to convert, so every rejected subscript kept its buffer: `a[bad]` rescued 3000 times over a 100000 element subscript grew the process by 2.3GB. The device buffer beside it was never part of this, being reclaimed by the ensure around the subscript.

The staging buffer is now a String, which the collector takes back along whichever path leaves the loop. Its address is taken again each time round rather than held across the `to_int` in between.

The note above `cumo_na_index_arg_t` went with it. It says the memory is never freed, which has not been true since the ensure was added upstream in 2016, and it is what made this look like a leak already accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
