### PR TITLE
Fix memory growth when indexing by an Array

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -179,6 +179,10 @@ cumo_na_parse_array(VALUE ary, int orig_dim, ssize_t size, cumo_na_index_arg_t *
         ((size_t*)RSTRING_PTR(buf))[k] = i;
     }
     status = cudaMemcpyAsync(q->idx,RSTRING_PTR(buf),sizeof(size_t)*n,cudaMemcpyHostToDevice,0);
+    // Hand the bytes back here rather than at the next collection: a subscript
+    // is small but every one of them stages a buffer, and waiting for the
+    // collector to catch up costs more than the buffer does.
+    rb_str_resize(buf, 0);
     RB_GC_GUARD(buf);
     cumo_cuda_runtime_check_status(status);
 


### PR DESCRIPTION
#357 moved the buffer an Array subscript is staged in to a String so that it survives the loop raising, and left it to the collector on the way out too. A subscript is small, but one is staged per indexing, so the garbage outpaced the collector: 20000 indexings of a 500 element subscript grew the process by 57MB, enough to fail `indexing by an array does not leak host memory`, the test that watches this very path.

The bytes go back as soon as the copy to the device has taken them, which is where they went before #357. The String stays for the collector to take, which is what keeps the raising path clean. The same measurement is now 1MB, and the leak #357 fixed stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
