### PR TITLE
Fix a crash and an out-of-bounds read in RObject#divmod

### DIFF
--- a/ext/cumo/include/cumo/types/robj_macro.h
+++ b/ext/cumo/include/cumo/types/robj_macro.h
@@ -17,9 +17,14 @@
 #define m_mul(x,y)     rb_funcall(x,'*',1,y)
 #define m_div(x,y)     rb_funcall(x,'/',1,y)
 #define m_mod(x,y)     rb_funcall(x,'%',1,y)
-#define m_divmod(x,y,a,b)                               \
-    {x = rb_funcall(x,cumo_id_divmod,1,y);                   \
-     a = RARRAY_PTR(x)[0]; b = RARRAY_PTR(x)[1];}
+// divmod is whatever the element's class defines, so the pair it is supposed
+// to answer has to be looked at before it is taken apart.
+#define m_divmod(x,y,a,b)                                               \
+    {x = rb_funcall(x,cumo_id_divmod,1,y);                              \
+     if (!RB_TYPE_P(x, T_ARRAY) || RARRAY_LEN(x) != 2) {                \
+         rb_raise(rb_eTypeError, "divmod must return a 2-element Array");\
+     }                                                                  \
+     a = RARRAY_AREF(x,0); b = RARRAY_AREF(x,1);}
 #define m_pow(x,y)     rb_funcall(x,cumo_id_pow,1,y)
 #define m_pow_int(x,y) rb_funcall(x,cumo_id_pow,1,y)
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5948,6 +5948,34 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal("true", reader.value)
   end
 
+  # divmod on RObject calls whatever the element's class defines, and the pair
+  # it answered was taken apart without being looked at, so a short Array
+  # handed back the words beyond it as Ruby objects.
+  test "divmod on RObject checks what the element answered" do
+    answers = {
+      "scalar" => 12345,
+      "short" => [1],
+      "empty" => [],
+      "string" => "ab",
+      "long" => [1, 2, 3]
+    }
+    answers.each do |what, answer|
+      klass = Class.new do
+        define_method(:divmod) { |_other| answer }
+      end
+      a = Cumo::RObject[klass.new, klass.new]
+      assert_raise(TypeError, what) { a.divmod(1) }
+    end
+
+    pair = Class.new do
+      def divmod(_other) = [7, 8]
+    end
+    q, r = Cumo::RObject[pair.new, pair.new].divmod(1)
+    assert_equal([[7, 7], [8, 8]], [q.to_a, r.to_a])
+    assert_equal([[2, -3], [1, 2]], Cumo::RObject[7, -7].divmod(3).map(&:to_a))
+    assert_equal([[3], [Rational(1, 2)]], Cumo::RObject[Rational(7, 2)].divmod(1).map(&:to_a))
+  end
+
   test "an object with to_int can be used as a subscript and as a shape" do
     o = Object.new
     def o.to_int = 3


### PR DESCRIPTION
An `Cumo::RObject` element's `divmod` is whatever its class defines, and the pair it is supposed to answer was read straight out of the Array without being looked at. A class answering a bare Integer or a String took the process down; one answering a shorter Array read the words past its end and handed them back as the quotient and the remainder, so an array of two elements came out as `[:key, 3]` and `[:nocreate, 15815071195346358]` with no error raised.

Anything that is not a pair now raises `TypeError`.

This is shared with numo-narray, and it goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
