### PR TITLE
Refuse marshal_load unless the array holds its own data

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1641,7 +1641,11 @@ cumo_na_marshal_load(VALUE self, VALUE a)
         rb_raise(rb_eArgError,"marshal shape should be array");
     }
     CumoGetNArray(self,na);
-    if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+    // Only an array that holds its own data has a buffer to load into, and the
+    // release below reads a flag that is only where it thinks it is on that
+    // kind. A view is the one other kind that exists today; a file map would
+    // hand back its mapping's protection bits in place of that flag.
+    if (CUMO_NA_TYPE(na) != CUMO_NARRAY_DATA_T) {
         rb_raise(rb_eArgError,"cannot load marshal data into a view");
     }
 


### PR DESCRIPTION
#356 turned away a view, that being the one kind of array without a buffer of its own that can be built today. The release it guards reads the flag saying whether the buffer is this array's to free, and that flag is only where it is looked for on an array that holds its own data: `cumo_narray_filemap_t` has its mapping's protection bits in that spot, so a mapping could be handed to `free`.

Nothing sets that kind and the header says it is unimplemented, so this turns away what cannot arrive rather than what does. There is no behaviour to test that was not already covered by the view case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
