### PR TITLE
Fix an out-of-bounds access from a view whose base took a smaller shape

### DIFF
--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -231,6 +231,10 @@ typedef struct {
     cumo_narray_t base;
     char    *ptr;
     bool     owned;
+    // Bytes ptr was allocated for. The shape can be taken again, and a view
+    // made before that still reaches as far as the shape it was made under,
+    // so the buffer is never allowed to get smaller than it has been.
+    size_t   capacity;
 } cumo_narray_data_t;
 
 
@@ -368,6 +372,7 @@ _cumo_na_get_narray_t(VALUE obj, unsigned char cumo_na_type)
 #define CUMO_NA_VIEW(na)             ((cumo_narray_view_t*)(na))
 #define CUMO_NA_DATA_PTR(na)         (CUMO_NA_DATA(na)->ptr)
 #define CUMO_NA_DATA_OWNED(na)       (CUMO_NA_DATA(na)->owned)
+#define CUMO_NA_DATA_CAPACITY(na)    (CUMO_NA_DATA(na)->capacity)
 #define CUMO_NA_VIEW_DATA(na)        (CUMO_NA_VIEW(na)->data)
 #define CUMO_NA_VIEW_OFFSET(na)      (CUMO_NA_VIEW(na)->offset)
 #define CUMO_NA_VIEW_STRIDX(na)      (CUMO_NA_VIEW(na)->stridx)

--- a/ext/cumo/narray/gen/tmpl/alloc_func.c
+++ b/ext/cumo/narray/gen/tmpl/alloc_func.c
@@ -118,5 +118,6 @@ static VALUE
     na->base.reduce = INT2FIX(0);
     na->ptr = NULL;
     na->owned = FALSE;
+    na->capacity = 0;
     return TypedData_Wrap_Struct(klass, &<%=type_name%>_data_type, (void*)na);
 }

--- a/ext/cumo/narray/gen/tmpl/allocate.c
+++ b/ext/cumo/narray/gen/tmpl/allocate.c
@@ -17,24 +17,31 @@ static VALUE
             if (na->size > SIZE_MAX / sizeof(dtype)) {
                 rb_raise(rb_eRangeError, "total byte size of data is too large");
             }
+            // Never fewer bytes than this array has held: a view made under a
+            // larger shape reads through this pointer.
+            size_t bytes = sizeof(dtype) * na->size;
+            if (bytes < CUMO_NA_DATA_CAPACITY(na)) {
+                bytes = CUMO_NA_DATA_CAPACITY(na);
+            }
             <% if is_object %>
-            ptr = xmalloc(sizeof(dtype) * na->size);
+            ptr = xmalloc(bytes);
             {   size_t i;
                 VALUE *a = (VALUE*)ptr;
-                for (i=na->size; i--;) {
+                for (i=bytes/sizeof(dtype); i--;) {
                     *a++ = Qnil;
                 }
             }
             <% else %>
-            ptr = cumo_cuda_runtime_malloc(sizeof(dtype) * na->size);
+            ptr = cumo_cuda_runtime_malloc(bytes);
             <% end %>
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = TRUE;
+            CUMO_NA_DATA_CAPACITY(na) = bytes;
             <% unless is_object %>
             // Device memory never passes through ruby_xmalloc, so the GC sees a
             // few-byte object holding an arbitrarily large buffer and does not
             // run until the host itself runs out.
-            rb_gc_adjust_memory_usage(sizeof(dtype) * na->size);
+            rb_gc_adjust_memory_usage(bytes);
             <% end %>
         }
         <% if !is_object && !is_bit %>

--- a/ext/cumo/narray/gen/tmpl_bit/allocate.c
+++ b/ext/cumo/narray/gen/tmpl_bit/allocate.c
@@ -10,10 +10,17 @@ static VALUE
     case CUMO_NARRAY_DATA_T:
         ptr = CUMO_NA_DATA_PTR(na);
         if (na->size > 0 && ptr == NULL) {
-            ptr = cumo_cuda_runtime_malloc(((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT));
+            // Never fewer bytes than this array has held: a view made under a
+            // larger shape reads through this pointer.
+            size_t bytes = ((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT);
+            if (bytes < CUMO_NA_DATA_CAPACITY(na)) {
+                bytes = CUMO_NA_DATA_CAPACITY(na);
+            }
+            ptr = cumo_cuda_runtime_malloc(bytes);
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = TRUE;
-            rb_gc_adjust_memory_usage(((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT));
+            CUMO_NA_DATA_CAPACITY(na) = bytes;
+            rb_gc_adjust_memory_usage(bytes);
         }
         break;
     case CUMO_NARRAY_VIEW_T:

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -365,7 +365,7 @@ cumo_na_initialize(VALUE self, VALUE args)
     int ndim;
     cumo_narray_t *na;
     void *old_ptr;
-    size_t old_byte_size;
+    size_t old_capacity;
     bool old_owned;
 
     // Taking a shape lets go of what is held now, which is a write by any
@@ -397,20 +397,27 @@ cumo_na_initialize(VALUE self, VALUE args)
     // setup size_t shape[] from VALUE shape argument
     cumo_na_array_to_internal_shape(self, v, shape);
 
-    // Any buffer here was sized for the shape being replaced, and every read
-    // that follows goes by the new one. Note it once the conversions above
-    // have run, and let it go once the new shape has been accepted: no Ruby
-    // runs between the two, and a shape the array refuses leaves it as it was.
+    // The buffer here was sized for the shape being replaced, so it is let go
+    // once the new shape has been accepted and the write that follows asks for
+    // one that fits. Noting it down waits until the conversions above have
+    // run, and the release waits until the shape is accepted, so no Ruby runs
+    // in between and a shape the array refuses leaves the array as it was.
+    //
+    // A buffer that is already big enough stays. A view made under the old
+    // shape reaches as far as that shape did, and it reads through the base's
+    // pointer, so handing the base a smaller buffer would send the view off
+    // the end of it.
     old_ptr = CUMO_NA_DATA_PTR(na);
-    old_byte_size = cumo_na_data_byte_size(self);
     old_owned = CUMO_NA_DATA_OWNED(na);
+    old_capacity = CUMO_NA_DATA_CAPACITY(na);
 
     cumo_na_setup(self, ndim, shape);
-    if (old_ptr != NULL) {
+    if (old_ptr != NULL && cumo_na_data_byte_size(self) > old_capacity) {
         if (old_owned) {
-            cumo_na_free_owned_ptr(self, old_ptr, old_byte_size);
+            cumo_na_free_owned_ptr(self, old_ptr, old_capacity);
         }
         CUMO_NA_DATA_PTR(na) = NULL;
+        CUMO_NA_DATA_CAPACITY(na) = 0;
     }
 
     return self;
@@ -663,6 +670,23 @@ cumo_na_free_owned_ptr(VALUE self, void *ptr, size_t byte_size)
     }
 }
 
+// Bytes the buffer behind self has been allocated for, following a view to
+// what it is a view of. Zero when there is nothing behind it yet.
+static size_t
+cumo_na_held_capacity(VALUE self)
+{
+    cumo_narray_t *na;
+
+    CumoGetNArray(self,na);
+    if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+        CumoGetNArray(CUMO_NA_VIEW_DATA(na),na);
+    }
+    if (CUMO_NA_TYPE(na) != CUMO_NARRAY_DATA_T) {
+        return 0;
+    }
+    return CUMO_NA_DATA_CAPACITY(na);
+}
+
 static void
 cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
 {
@@ -678,11 +702,19 @@ cumo_na_set_pointer(VALUE self, char *ptr, size_t byte_size)
     switch(CUMO_NA_TYPE(na)) {
     case CUMO_NARRAY_DATA_T:
         if (CUMO_NA_SIZE(na) > 0) {
+            // Same reason as in initialize: a view reaches as far as the shape
+            // it was made under, so what the base points at never shrinks.
+            if (byte_size < CUMO_NA_DATA_CAPACITY(na)) {
+                rb_raise(rb_eArgError,
+                         "cannot point this NArray at %"SZF"u bytes: it has held %"SZF"u",
+                         byte_size, CUMO_NA_DATA_CAPACITY(na));
+            }
             if (CUMO_NA_DATA_PTR(na) != NULL && CUMO_NA_DATA_OWNED(na)) {
-                cumo_na_free_owned_ptr(self, CUMO_NA_DATA_PTR(na), cumo_na_data_byte_size(self));
+                cumo_na_free_owned_ptr(self, CUMO_NA_DATA_PTR(na), CUMO_NA_DATA_CAPACITY(na));
             }
             CUMO_NA_DATA_PTR(na) = ptr;
             CUMO_NA_DATA_OWNED(na) = FALSE;
+            CUMO_NA_DATA_CAPACITY(na) = byte_size;
         }
         return;
     case CUMO_NARRAY_VIEW_T:
@@ -732,12 +764,19 @@ cumo_na_pointer_copy_on_write(VALUE self)
         return;
     }
 
-    velmsz = rb_const_get(rb_obj_class(self), cumo_id_element_byte_size);
-    if (FIXNUM_P(velmsz)) {
-        byte_size = CUMO_NA_SIZE(na) * NUM2SIZET(velmsz);
-    } else {
-        byte_size = ceil(CUMO_NA_SIZE(na) * NUM2DBL(velmsz));
+    // What is being taken over is the whole buffer, not the part the shape in
+    // hand covers: a view made under a larger shape reads the rest of it.
+    byte_size = CUMO_NA_DATA_CAPACITY(na);
+    if (byte_size == 0) {
+        velmsz = rb_const_get(rb_obj_class(self), cumo_id_element_byte_size);
+        if (FIXNUM_P(velmsz)) {
+            byte_size = CUMO_NA_SIZE(na) * NUM2SIZET(velmsz);
+        } else {
+            byte_size = ceil(CUMO_NA_SIZE(na) * NUM2DBL(velmsz));
+        }
     }
+    // The capacity stays as it is so that allocate keeps the buffer at least
+    // as large as it has been.
     CUMO_NA_DATA_PTR(na) = NULL;
     rb_funcall(self, cumo_id_allocate, 0);
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_pointer_copy_on_write", "any");
@@ -1552,7 +1591,10 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "string is too short to store");
     }
 
-    if (OBJ_FROZEN(vstr)) {
+    // Pointing at the String's own bytes saves the copy, but only while they
+    // are at least as many as this array has ever held: a view made under a
+    // larger shape reads through this pointer. Copying is the way out.
+    if (OBJ_FROZEN(vstr) && byte_size >= cumo_na_held_capacity(self)) {
         cumo_na_set_pointer(self, RSTRING_PTR(vstr)+offset, byte_size);
         rb_ivar_set(self, cumo_id_source, vstr);
     } else {
@@ -2133,8 +2175,9 @@ cumo_na_free_data(VALUE self)
         // Not owned means the data belongs to something else -- store_binary()
         // points a frozen String's bytes at it -- so there is nothing to free.
         if (ptr != NULL && CUMO_NA_DATA_OWNED(na)) {
-            cumo_na_free_owned_ptr(self, ptr, cumo_na_data_byte_size(self));
+            cumo_na_free_owned_ptr(self, ptr, CUMO_NA_DATA_CAPACITY(na));
             CUMO_NA_DATA_PTR(na) = NULL;
+            CUMO_NA_DATA_CAPACITY(na) = 0;
             return Qtrue;
         }
     }

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -12,6 +12,7 @@ nst_allocate(VALUE self)
 {
     cumo_narray_t *na;
     void *ptr;
+    size_t bytes;
     VALUE velmsz;
 
     CumoGetNArray(self,na);
@@ -21,8 +22,15 @@ nst_allocate(VALUE self)
         ptr = CUMO_NA_DATA_PTR(na);
         if (na->size > 0 && ptr == NULL) {
             velmsz = rb_const_get(rb_obj_class(self), rb_intern("element_byte_size"));
-            ptr = cumo_cuda_runtime_malloc(NUM2SIZET(velmsz) * na->size);
+            // Never fewer bytes than this array has held: a view made under a
+            // larger shape reads through this pointer.
+            bytes = NUM2SIZET(velmsz) * na->size;
+            if (bytes < CUMO_NA_DATA_CAPACITY(na)) {
+                bytes = CUMO_NA_DATA_CAPACITY(na);
+            }
+            ptr = cumo_cuda_runtime_malloc(bytes);
             CUMO_NA_DATA_PTR(na) = ptr;
+            CUMO_NA_DATA_CAPACITY(na) = bytes;
         }
         break;
     case CUMO_NARRAY_VIEW_T:

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5967,6 +5967,99 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([[0.0, 1.0], [2.0, 3.0]], Cumo::DFloat.new(2, 2).seq.to_a)
   end
 
+  # A view reads through the base's pointer but keeps the shape it was made
+  # under, so handing the base a smaller buffer sent the view off the end of
+  # it: reading garbage, and writing wherever that landed.
+  test "a view still reads its base after the base takes a smaller shape" do
+    make = [
+      [:range, ->(a) { a[0..1023] }, (0...1024).to_a],
+      [:index, ->(a) { a[Cumo::Int32.cast((0...1024).to_a)] }, (0...1024).to_a],
+      [:step, ->(a) { a[(0...1024).step(1)] }, (0...1024).to_a],
+      [:stride, ->(a) { a[(0..1023).step(2)] }, (0..1023).step(2).to_a]
+    ]
+    make.each do |what, build, elements|
+      a = Cumo::DFloat.new(1024).seq
+      v = build.call(a)
+      a.marshal_load([1, [2], 0, "\x00" * 16])
+      assert_equal([2], a.shape, what)
+      # the two elements the load wrote are zero now, the rest are untouched
+      want = elements.sum { |i| i < 2 ? 0.0 : i.to_f }
+      assert_equal(want, v.sum.to_a.first, what)
+    end
+
+    b = Cumo::DFloat.new(1024).seq
+    w = b[0..1023]
+    b.__send__(:initialize, [2])
+    b.seq
+    w[1000] = 7.0
+    assert_equal(7.0, w[1000].to_a.first)
+    assert_equal([0.0, 1.0], b.to_a)
+
+    r = Cumo::RObject.new(8)
+    r.store(Array.new(8) { |i| i })
+    rv = r[0..7]
+    r.marshal_load([1, [2], 0, [+"x", +"y"]])
+    assert_equal(["x", "y", 2, 3], rv.to_a.first(4))
+  end
+
+  # Bit and RObject allocate through templates of their own, so a buffer kept
+  # at the size it has been has to be kept by each of them.
+  test "a view outlives a smaller shape on every dtype" do
+    total =
+      lambda do |v|
+        next Integer(v.count_true) if v.is_a?(Cumo::Bit)
+
+        x = v.sum.to_a.first
+        x = x.real if x.is_a?(Complex)
+        x.to_i
+      end
+    [
+      Cumo::DFloat,
+      Cumo::SFloat,
+      Cumo::Int32,
+      Cumo::UInt8,
+      Cumo::DComplex,
+      Cumo::RObject,
+      Cumo::Bit
+    ].each do |dtype|
+      a = dtype.new(1024)
+      a.store(1)
+      v = a[0..1023]
+      assert_equal(1024, total.call(v), dtype.to_s)
+      a.__send__(:initialize, [2])
+      a.store(0)
+      assert_equal(1022, total.call(v), dtype.to_s)
+    end
+    GC.start
+  end
+
+  # Taking over a borrowed buffer allocated one for the shape in hand, which
+  # is smaller than the buffer being taken over once the shape has been taken
+  # again, and the view reading the rest of it lost its data.
+  test "a view survives its base taking over a borrowed buffer" do
+    str = ([1.0] * 1024).pack("d*").freeze
+    a = Cumo::DFloat.new(1024)
+    a.store_binary(str)
+    v = a[0..1023]
+    assert_equal(1024.0, v.sum.to_a.first)
+
+    a.__send__(:initialize, [2])
+    a[0] = 42.0
+    assert_equal([42.0, 1.0], a.to_a)
+    assert_equal(1024.0 - 1 + 42, v.sum.to_a.first)
+  end
+
+  test "an array that took a smaller shape still loads a larger one later" do
+    a = Cumo::DFloat.new(1024).seq
+    a.marshal_load([1, [2], 0, "\x00" * 16])
+    assert_equal([0.0, 0.0], a.to_a)
+    a.marshal_load(Cumo::DFloat.new(4096).seq(3).marshal_dump)
+    assert_equal([4096, 3.0, 4098.0], [a.size, a[0].to_a.first, a[4095].to_a.first])
+    a.__send__(:initialize, [3])
+    a.seq(1)
+    assert_equal([1.0, 2.0, 3.0], a.to_a)
+  end
+
   test "initialize leaves a frozen array alone" do
     a = Cumo::DFloat.new(4).seq
     a.freeze


### PR DESCRIPTION
A view keeps the shape it was made under and reads the data through its base's pointer, so handing the base a smaller buffer sends the view off the end of whatever it gets instead. `a[0..1023]` over a 1024 element array, after the base loads a shape of 2, read 8192 bytes out of 16 and answered garbage; writing through it landed wherever that reached, which `compute-sanitizer` reports as an invalid write. Every kind of view does it, index-backed ones included, and `marshal_load` alone is enough to arrive there, on master and on the released gem.

The base's buffer no longer gets smaller than it has been. It is let go only when the new shape asks for more than it was allocated for, which is what the reads that prompted #355 and #361 needed, and the bytes it was allocated for are recorded so that a shape taken twice cannot walk it down in steps. `store_binary` keeps pointing an array at a frozen String's own bytes, except where that would be fewer bytes than the array has held, and copies instead. Taking over a borrowed buffer takes over all of it rather than the part the shape in hand covers, for the same reason.

The record is a field on `cumo_narray_data_t` rather than a bound on each view, because a view built from an index array would otherwise have to be walked on every access to find how far it reaches. Growing `stridx` by one to hold that bound was the other way, and it needs every one of the 13 places that allocate one to agree.

An array that has held a large buffer keeps holding it until it is freed or asked for a larger one. `free` releases it as it always has, and a view over an array that was freed and then given a smaller shape still reads past what it gets, which is how master answers today.

This is shared with numo-narray, and it goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
