### PR TITLE
Refuse a view whose base no longer holds what it was laid out over

### DIFF
--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -248,6 +248,11 @@ typedef struct {
                          // elm.step_unit = elm.bit_size / elm.access_unit
                          // elm.step_unit = elm.size_bits / elm.unit_bits
     cumo_stridx_t *stridx;    // stride or indices of data pointer for each dimension
+    // One past the furthest position this view can reach, in the units its
+    // offset and strides are in: bits for Cumo::Bit, bytes otherwise. Zero
+    // until it has been worked out. What a view reaches never changes, so it
+    // is worked out once, and it stays right even after the base has moved on.
+    size_t   reach_end;
     uint64_t index_sync_epoch; // synchronizes counted when the index fills were
                                // issued; UINT64_MAX when that is not known
 } cumo_narray_view_t;
@@ -371,6 +376,7 @@ _cumo_na_get_narray_t(VALUE obj, unsigned char cumo_na_type)
 #define CUMO_NA_VIEW_DATA(na)        (CUMO_NA_VIEW(na)->data)
 #define CUMO_NA_VIEW_OFFSET(na)      (CUMO_NA_VIEW(na)->offset)
 #define CUMO_NA_VIEW_STRIDX(na)      (CUMO_NA_VIEW(na)->stridx)
+#define CUMO_NA_VIEW_REACH_END(na)   (CUMO_NA_VIEW(na)->reach_end)
 
 #define CUMO_NA_IS_INDEX_AT(na,i)    (CUMO_SDX_IS_INDEX(CUMO_NA_VIEW_STRIDX(na)[i]))
 #define CUMO_NA_IS_STRIDE_AT(na,i)   (CUMO_SDX_IS_STRIDE(CUMO_NA_VIEW_STRIDX(na)[i]))
@@ -405,6 +411,10 @@ _cumo_na_get_narray_t(VALUE obj, unsigned char cumo_na_type)
 #define CUMO_NA_FL0_COLUMN_MAJOR   (0x1<<1)
 #define CUMO_NA_FL1_LOCK           (0x1<<0)
 #define CUMO_NA_FL1_INPLACE        (0x1<<1)
+// Set once an array has been given a shape smaller than one it has had. Views
+// made under the larger shape reach past what it holds now, so that is when
+// they have to be measured; until then there is nothing to measure against.
+#define CUMO_NA_FL1_SHRUNK         (0x1<<2)
 
 #define CUMO_TEST_COLUMN_MAJOR(x)   CUMO_NA_FL0_TEST(x,CUMO_NA_FL0_COLUMN_MAJOR)
 #define CUMO_SET_COLUMN_MAJOR(x)    CUMO_NA_FL0_SET(x,CUMO_NA_FL0_COLUMN_MAJOR)

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -218,6 +218,7 @@ cumo_na_s_allocate_view(VALUE klass)
     na->data = Qnil;
     na->offset = 0;
     na->stridx = NULL;
+    na->reach_end = 0;
     na->index_sync_epoch = UINT64_MAX;
     return TypedData_Wrap_Struct(klass, &cumo_na_data_type_view, (void*)na);
 }
@@ -319,8 +320,14 @@ static void
 cumo_na_setup(VALUE self, int ndim, size_t *shape)
 {
     cumo_narray_t *na;
+    size_t was;
+
     CumoGetNArray(self,na);
+    was = na->size;
     cumo_na_setup_shape(na, ndim, shape);
+    if (na->size < was) {
+        CUMO_NA_FL1_SET(self, CUMO_NA_FL1_SHRUNK);
+    }
 }
 
 
@@ -746,12 +753,69 @@ cumo_na_pointer_copy_on_write(VALUE self)
     rb_ivar_set(self, cumo_id_source, Qnil);
 }
 
-static char *
+// One past the furthest position self can reach, in the units its offset and
+// strides are in. A view is laid out against the shape its base had when it
+// was made, and it reads the data through the base's pointer, so a base that
+// takes a smaller shape leaves the view reaching past what it gets. What the
+// view reaches never changes, so it is worked out once and kept.
+//
+// A dimension addressed by an index list has to be read to be measured. Those
+// indices belong to the view, not to the base, so reading them late still
+// gives the right answer.
+static size_t
+cumo_na_view_reach_end(cumo_narray_view_t *nv, size_t unit)
+{
+    int i;
+    size_t reach;
+
+    if (nv->reach_end != 0 || nv->base.size == 0) {
+        return nv->reach_end;
+    }
+
+    reach = nv->offset;
+    for (i=0; i < nv->base.ndim; i++) {
+        size_t n = nv->base.shape[i];
+
+        if (n == 0) {
+            return 0;
+        }
+        if (CUMO_SDX_IS_STRIDE(nv->stridx[i])) {
+            ssize_t stride = CUMO_SDX_GET_STRIDE(nv->stridx[i]);
+            // A negative stride puts the start at the far end, which the
+            // offset already accounts for, so only a positive one reaches on.
+            if (stride > 0) {
+                reach += (n-1) * (size_t)stride;
+            }
+        } else {
+            size_t *idx = CUMO_SDX_GET_INDEX(nv->stridx[i]);
+            VALUE buf = rb_str_tmp_new((long)(sizeof(size_t)*n));
+            size_t *host = (size_t*)RSTRING_PTR(buf);
+            size_t k, max = 0;
+
+            cumo_na_index_wait_fill(nv);
+            cumo_cuda_runtime_check_status(
+                cudaMemcpy(host, idx, sizeof(size_t)*n, cudaMemcpyDeviceToHost));
+            for (k=0; k<n; k++) {
+                if (host[k] > max) {
+                    max = host[k];
+                }
+            }
+            RB_GC_GUARD(buf);
+            reach += max;
+        }
+    }
+    nv->reach_end = reach + unit;
+    return nv->reach_end;
+}
+
+char *
 cumo_na_get_pointer_for_rw(VALUE self, int flag)
 {
     char *ptr;
     VALUE obj;
     cumo_narray_t *na;
+    size_t reach_end;
+    int is_bit;
 
     if ((flag & WRITE) && OBJ_FROZEN(self)) {
         rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
@@ -785,9 +849,27 @@ cumo_na_get_pointer_for_rw(VALUE self, int flag)
         if (flag & WRITE) {
             cumo_na_pointer_copy_on_write(self);
         }
+        // Only a base that has been made smaller can leave a view reaching
+        // past it, and measuring a view costs a pass over its index lists, so
+        // nothing is measured until that has happened. Measured here because
+        // reading the base below replaces na.
+        if (CUMO_NA_FL1_TEST(obj, CUMO_NA_FL1_SHRUNK)) {
+            is_bit = RTEST(rb_obj_is_kind_of(self, cumo_cBit));
+            reach_end = cumo_na_view_reach_end(
+                (cumo_narray_view_t*)na,
+                is_bit ? 1 : NUM2SIZET(rb_const_get(rb_obj_class(self), cumo_id_element_byte_size)));
+        } else {
+            is_bit = 0;
+            reach_end = 0;
+        }
         CumoGetNArray(obj,na);
         switch(CUMO_NA_TYPE(na)) {
         case CUMO_NARRAY_DATA_T:
+            if (reach_end > (is_bit ? CUMO_NA_SIZE(na) : cumo_na_data_byte_size(obj))) {
+                rb_raise(rb_eRuntimeError,
+                         "this view was made when its base was larger and no "
+                         "longer fits in it");
+            }
             ptr = CUMO_NA_DATA_PTR(na);
             if (flag & (READ|WRITE)) {
                 if (CUMO_NA_SIZE(na) > 0 && ptr == NULL) {

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5967,6 +5967,106 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal([[0.0, 1.0], [2.0, 3.0]], Cumo::DFloat.new(2, 2).seq.to_a)
   end
 
+  # A view is laid out against the shape its base had when it was made, and
+  # reads the data through the base's pointer, so a base that takes a smaller
+  # shape used to leave the view reading past what it got: garbage out of an
+  # array, and writes landing wherever that reached.
+  test "a view whose base took a smaller shape is refused" do
+    [
+      [:range, ->(a) { a[0..1023] }],
+      [:index, ->(a) { a[Cumo::Int32.cast((0...1024).to_a)] }],
+      [:step, ->(a) { a[(0...1024).step(1)] }],
+      [:stride, ->(a) { a[(0..1023).step(2)] }],
+      [:reversed, ->(a) { a[1023.step(0, -1)] }]
+    ].each do |what, build|
+      a = Cumo::DFloat.new(1024).seq
+      v = build.call(a)
+      a.marshal_load([1, [2], 0, "\x00" * 16])
+      assert_raise(RuntimeError, what.to_s) { v.sum }
+      assert_raise(RuntimeError, what.to_s) { v[100] = 7.0 }
+    end
+
+    # the base was never allocated when the view was taken, so there was
+    # nothing about the buffer to go on
+    b = Cumo::DFloat.new(1024)
+    w = b[0..1023]
+    b.__send__(:initialize, [2])
+    b.seq
+    assert_raise(RuntimeError) { w.sum }
+    assert_equal([0.0, 1.0], b.to_a)
+  end
+
+  test "a view is refused on every dtype whose base shrank" do
+    [
+      Cumo::DFloat,
+      Cumo::SFloat,
+      Cumo::Int32,
+      Cumo::UInt8,
+      Cumo::DComplex,
+      Cumo::RObject,
+      Cumo::Bit
+    ].each do |dtype|
+      a = dtype.new(1024)
+      a.store(1)
+      v = a[0..1023]
+      a.__send__(:initialize, [2])
+      a.store(0)
+      assert_raise(RuntimeError, dtype.to_s) { dtype == Cumo::Bit ? v.count_true : v.sum }
+    end
+  end
+
+  # An empty subscript makes a real view that reaches nowhere, so it stays
+  # usable whatever the base does. Only an empty Array or Int32 builds one:
+  # an empty Range is turned away before it gets this far.
+  test "an empty view is left alone when its base shrinks" do
+    [
+      [:array, ->(a) { a[[]] }],
+      [:int32, ->(a) { a[Cumo::Int32.cast([])] }]
+    ].each do |what, build|
+      a = Cumo::DFloat.new(8).seq
+      v = build.call(a)
+      assert_equal([0], v.shape, what.to_s)
+      a.__send__(:initialize, [2])
+      a.seq
+      assert_equal([], v.to_a, what.to_s)
+    end
+    assert_raise(RangeError) { Cumo::DFloat.new(8).seq[0...0] }
+  end
+
+  # Once a base has been made smaller its views have to be measured from then
+  # on, including after it grows again: growing back part of the way leaves
+  # them still reaching past it.
+  test "a base that grew after shrinking is still watched" do
+    a = Cumo::DFloat.new(1024).seq
+    v = a[0..1023]
+    a.__send__(:initialize, [2])
+    a.__send__(:initialize, [512])
+    a.seq
+    assert_raise(RuntimeError) { v.sum }
+
+    b = Cumo::DFloat.new(1024).seq
+    w = b[0..1023]
+    b.__send__(:initialize, [2])
+    b.__send__(:initialize, [4096])
+    b.seq
+    # back to holding what the view reaches, so it is let through again
+    assert_equal(1024 * 1023 / 2.0, w.sum.to_a.first)
+  end
+
+  test "a view still works while its base is big enough" do
+    a = Cumo::DFloat.new(8).seq
+    assert_equal([2.0, 3.0, 4.0, 5.0], a[2..5].to_a)
+    assert_equal([3.0, 1.0, 4.0], a[Cumo::Int32.cast([3, 1, 4])].to_a)
+    assert_equal([7.0, 6.0, 5.0], a[7.step(5, -1)].to_a)
+    v = a[0..7]
+    a.__send__(:initialize, [16])
+    a.seq
+    # growing leaves every earlier view inside the base
+    assert_equal((0...8).map(&:to_f), v.to_a)
+    v[0] = 9.0
+    assert_equal(9.0, a[0].to_a.first)
+  end
+
   test "initialize leaves a frozen array alone" do
     a = Cumo::DFloat.new(4).seq
     a.freeze


### PR DESCRIPTION
A view is laid out against the shape its base had when it was made, and it reads the data through the base's pointer, so a base that takes a smaller shape leaves the view reading past whatever it gets instead. `a[0..1023]` over a 1024 element array, after the base loads a shape of 2, read 8192 bytes out of 16 and answered garbage; writing through it landed wherever that reached, which `compute-sanitizer` reports as an invalid write. Every kind of view does it, index-backed ones included, and `marshal_load` alone is enough to arrive there, on master and on the released gem.

A view now says how far it reaches, and reaching past what the base holds raises rather than reads. What a view reaches never changes, so it is worked out on first use and kept: the strides give it in one pass, and a dimension addressed by an index list is read once, which is right however late it happens because those indices belong to the view rather than to the base.

The record is one field on `cumo_narray_view_t`, set to zero in the one place a view is allocated, so there is no list of construction sites to keep in step. Keeping the base's buffer from ever shrinking was the other way, and it cannot work: a view taken before the base was allocated has no buffer to have been measured against, and holding on to buffers leaves an array reading its own former contents where it used to say it was unallocated.

Growing a base is unaffected: every view made before it still lies inside. So is a view of a base that was never given a smaller shape, which is all of them until something asks for one.

This is shared with numo-narray, and it goes into cumo first under the reversed backport direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
