### PR TITLE
Separate the cuDNN scalar and parameter types from the tensor dtype

### DIFF
--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -158,7 +158,7 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
         size_t ndim,
         int* int_stride,
         int* int_pad,
-        cudnnDataType_t cudnn_dtype) {
+        cudnnDataType_t compute_dtype) {
     cudnnStatus_t status = CUDNN_STATUS_SUCCESS;
     int int_dilation[CUMO_NA_MAX_DIMENSION];
     for (size_t idim = 0; idim < ndim; ++idim) {
@@ -178,7 +178,7 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
                 int_dilation[0],
                 int_dilation[1],
                 CUDNN_CROSS_CORRELATION,
-                cudnn_dtype);
+                compute_dtype);
     } else {
         status = cudnnSetConvolutionNdDescriptor(
                 *desc,
@@ -187,7 +187,7 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
                 int_stride,
                 int_dilation,
                 CUDNN_CROSS_CORRELATION,
-                cudnn_dtype);
+                compute_dtype);
     }
 
     return status;

--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -172,7 +172,7 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
         size_t ndim,
         int* int_stride,
         int* int_pad,
-        cudnnDataType_t cudnn_dtype);
+        cudnnDataType_t compute_dtype);
 
 cudnnStatus_t
 cumo_cuda_cudnn_CreatePoolingDescriptor(

--- a/ext/cumo/narray/gen/def/dfloat.rb
+++ b/ext/cumo/narray/gen/def/dfloat.rb
@@ -21,6 +21,11 @@ set is_double_precision: true
 set is_half:             false
 set need_align:          true
 
+set cudnn_dtype:         "CUDNN_DATA_DOUBLE"
+set cudnn_compute_dtype: "CUDNN_DATA_DOUBLE"
+set cudnn_scalar_t:      "dtype"
+set cudnn_param_class:   "cT"
+
 upcast_rb "Integer"
 upcast_rb "Float"
 upcast_rb "Complex", "DComplex"

--- a/ext/cumo/narray/gen/def/sfloat.rb
+++ b/ext/cumo/narray/gen/def/sfloat.rb
@@ -21,6 +21,11 @@ set is_double_precision: false
 set is_half:             false
 set need_align:          true
 
+set cudnn_dtype:         "CUDNN_DATA_FLOAT"
+set cudnn_compute_dtype: "CUDNN_DATA_FLOAT"
+set cudnn_scalar_t:      "dtype"
+set cudnn_param_class:   "cT"
+
 upcast_rb "Integer"
 upcast_rb "Float"
 upcast_rb "Complex", "SComplex"

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // y = x.batch_norm(gamma, beta, running_mean:, running_var:, eps:, decay:, axis:, mean:, inv_std:)
 static VALUE
@@ -20,8 +8,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype coef_one = 1;
-    dtype coef_zero = 0;
+    <%=cudnn_scalar_t%> coef_one = 1;
+    <%=cudnn_scalar_t%> coef_zero = 0;
 
     VALUE x=self, gamma, beta, running_mean, running_var, eps, decay, axis, mean, inv_std, y;
     VALUE kw_hash = Qnil;
@@ -126,12 +114,12 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, cT);
-    CUMO_CHECK_NARRAY_TYPE(beta, cT);
-    if (running_mean != Qnil) CUMO_CHECK_NARRAY_TYPE(running_mean, cT);
-    if (running_var != Qnil) CUMO_CHECK_NARRAY_TYPE(running_var, cT);
-    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, cT);
-    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, cT);
+    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
+    CUMO_CHECK_NARRAY_TYPE(beta, <%=cudnn_param_class%>);
+    if (running_mean != Qnil) CUMO_CHECK_NARRAY_TYPE(running_mean, <%=cudnn_param_class%>);
+    if (running_var != Qnil) CUMO_CHECK_NARRAY_TYPE(running_var, <%=cudnn_param_class%>);
+    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
+    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, <%=cudnn_param_class%>);
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);
@@ -166,9 +154,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_ERROR;
-    // The derived descriptor carries x's own type -- cuDNN widens only for
-    // half, which these templates are never generated for -- and the checks
-    // above hold every parameter to x's class, so none of them needs a cast.
+    // cuDNN derives the parameter descriptor as float for a half x and as x's
+    // own type otherwise, and the checks above hold every parameter to exactly
+    // that class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // gx, ggamma, gbeta = x.batch_norm_backward(gamma, gy, mean:, inv_std:, eps:, axis:)
 static VALUE
@@ -20,8 +8,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype coef_one = 1;
-    dtype coef_zero = 0;
+    <%=cudnn_scalar_t%> coef_one = 1;
+    <%=cudnn_scalar_t%> coef_zero = 0;
 
     VALUE x=self, gamma, gy, mean, inv_std, eps, axis, gx, ggamma, gbeta;
     VALUE kw_hash = Qnil;
@@ -107,10 +95,10 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, cT);
+    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
     CUMO_CHECK_NARRAY_TYPE(gy, cT);
-    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, cT);
-    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, cT);
+    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
+    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, <%=cudnn_param_class%>);
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);
@@ -133,15 +121,15 @@ static VALUE
     }
     gx_ptr = cumo_na_get_offset_pointer_for_write(gx);
     if (ggamma == Qnil) {
-        ggamma = cumo_na_new(cT, gamma_ndim, gamma_shape);
+        ggamma = cumo_na_new(<%=cudnn_param_class%>, gamma_ndim, gamma_shape);
     } else {
-        cumo_cuda_cudnn_check_output(ggamma, cT, gamma_ndim, gamma_shape);
+        cumo_cuda_cudnn_check_output(ggamma, <%=cudnn_param_class%>, gamma_ndim, gamma_shape);
     }
     ggamma_ptr = cumo_na_get_offset_pointer_for_write(ggamma);
     if (gbeta == Qnil) {
-        gbeta = cumo_na_new(cT, gamma_ndim, gamma_shape);
+        gbeta = cumo_na_new(<%=cudnn_param_class%>, gamma_ndim, gamma_shape);
     } else {
-        cumo_cuda_cudnn_check_output(gbeta, cT, gamma_ndim, gamma_shape);
+        cumo_cuda_cudnn_check_output(gbeta, <%=cudnn_param_class%>, gamma_ndim, gamma_shape);
     }
     gbeta_ptr = cumo_na_get_offset_pointer_for_write(gbeta);
 
@@ -151,9 +139,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto BATCH_NORM_BACKWARD_ERROR;
-    // The derived descriptor carries x's own type -- cuDNN widens only for
-    // half, which these templates are never generated for -- and the checks
-    // above hold every parameter to x's class, so none of them needs a cast.
+    // cuDNN derives the parameter descriptor as float for a half x and as x's
+    // own type otherwise, and the checks above hold every parameter to exactly
+    // that class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/ext/cumo/narray/gen/tmpl/conv.c
+++ b/ext/cumo/narray/gen/tmpl/conv.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // cover_all=true is not supported with CUDNN
 // dilation > 1 is not supported yet
@@ -22,8 +10,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype alpha = 1;
-    dtype beta = 0;
+    <%=cudnn_scalar_t%> alpha = 1;
+    <%=cudnn_scalar_t%> beta = 0;
 
     VALUE x=self, w, b, stride, pad, y;
     VALUE kw_hash = Qnil;
@@ -113,7 +101,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&w_desc, w_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, cudnn_dtype);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
 
     handle = cumo_cuda_cudnn_handle();

--- a/ext/cumo/narray/gen/tmpl/conv_grad_w.c
+++ b/ext/cumo/narray/gen/tmpl/conv_grad_w.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 static void
 cumo_cuda_cudnn_get_sizet_ary(size_t *sizet_ary, VALUE ary, size_t ndim)
@@ -31,8 +19,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype one = 1;
-    dtype zero = 0;
+    <%=cudnn_scalar_t%> one = 1;
+    <%=cudnn_scalar_t%> zero = 0;
 
     VALUE x=self, gy, w_shape, stride, pad, gw;
     VALUE kw_hash = Qnil;
@@ -124,7 +112,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&gw_desc, gw, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, cudnn_dtype);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
 
     handle = cumo_cuda_cudnn_handle();

--- a/ext/cumo/narray/gen/tmpl/conv_transpose.c
+++ b/ext/cumo/narray/gen/tmpl/conv_transpose.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // VALUE is Ruby Array
 static void
@@ -47,8 +35,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype alpha = 1;
-    dtype beta = 0;
+    <%=cudnn_scalar_t%> alpha = 1;
+    <%=cudnn_scalar_t%> beta = 0;
 
     VALUE x=self, w, b, stride, pad, out_size, y;
     VALUE kw_hash = Qnil;
@@ -140,7 +128,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&w_desc, w_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, cudnn_dtype);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
 
     handle = cumo_cuda_cudnn_handle();

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // y = x.fixed_batch_norm(gamma, beta, mean, var, eps:, axis:)
 static VALUE
@@ -20,8 +8,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype coef_one = 1;
-    dtype coef_zero = 0;
+    <%=cudnn_scalar_t%> coef_one = 1;
+    <%=cudnn_scalar_t%> coef_zero = 0;
 
     VALUE x=self, gamma, beta, mean, var, eps, axis, y;
     VALUE kw_hash = Qnil;
@@ -85,10 +73,10 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, cT);
-    CUMO_CHECK_NARRAY_TYPE(beta, cT);
-    CUMO_CHECK_NARRAY_TYPE(mean, cT);
-    CUMO_CHECK_NARRAY_TYPE(var, cT);
+    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
+    CUMO_CHECK_NARRAY_TYPE(beta, <%=cudnn_param_class%>);
+    CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
+    CUMO_CHECK_NARRAY_TYPE(var, <%=cudnn_param_class%>);
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);
@@ -115,9 +103,9 @@ static VALUE
     mode = cumo_cuda_cudnn_GetBatchNormMode(axis_ndim, int_axis);
     status = cumo_cuda_cudnn_CreateBNTensorDescriptor(&bn_desc, x_desc, mode);
     if (status != CUDNN_STATUS_SUCCESS) goto FIXED_BATCH_NORM_ERROR;
-    // The derived descriptor carries x's own type -- cuDNN widens only for
-    // half, which these templates are never generated for -- and the checks
-    // above hold every parameter to x's class, so none of them needs a cast.
+    // cuDNN derives the parameter descriptor as float for a half x and as x's
+    // own type otherwise, and the checks above hold every parameter to exactly
+    // that class, so none of them needs a cast.
 
     handle = cumo_cuda_cudnn_handle();
 

--- a/ext/cumo/narray/gen/tmpl/pooling_backward.c
+++ b/ext/cumo/narray/gen/tmpl/pooling_backward.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // cover_all=true is not supported with CUDNN
 // gy = x.pooling_backward(mode, y, kernel_size, stride: 1, pad: 0)
@@ -25,8 +13,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype alpha = 1;
-    dtype beta = 0;
+    <%=cudnn_scalar_t%> alpha = 1;
+    <%=cudnn_scalar_t%> beta = 0;
 
     VALUE x=self, y, gy, mode, kernel_size, stride, pad, gx;
     VALUE kw_hash = Qnil;

--- a/ext/cumo/narray/gen/tmpl/pooling_forward.c
+++ b/ext/cumo/narray/gen/tmpl/pooling_forward.c
@@ -1,17 +1,5 @@
 #ifdef CUDNN_FOUND
 
-<%
-  cudnn_dtype =
-    case type_name
-    when 'sfloat'
-      'CUDNN_DATA_FLOAT'
-    when 'dfloat'
-      'CUDNN_DATA_DOUBLE'
-    else
-      # CUDNN_DATA_HALF
-      raise 'not supported'
-    end
-%>
 
 // cover_all=true is not supported with CUDNN
 // x.pooling_forward(mode, kernel_size, stride: 1, pad: 0, y: nil)
@@ -25,8 +13,8 @@ static VALUE
     cudnnDataType_t cudnn_dtype = <%= cudnn_dtype %>;
     cudnnStatus_t status = 0;
     cudnnHandle_t handle = 0;
-    dtype alpha = 1;
-    dtype beta = 0;
+    <%=cudnn_scalar_t%> alpha = 1;
+    <%=cudnn_scalar_t%> beta = 0;
 
     VALUE x=self, mode, kernel_size, stride, pad, y;
     VALUE kw_hash = Qnil;


### PR DESCRIPTION
Groundwork for `Cumo::HFloat`'s cuDNN methods (#107, step 5).

The cuDNN templates write three things as the tensor's own dtype that are not: the alpha and beta scaling factors, the convolution's compute type, and the class of the batch norm parameters. cuDNN takes the first two in the compute type and derives the third from x, and for SFloat and DFloat all three happen to coincide with the tensor's type, so the distinction has never had to exist. Half is the first dtype where they come apart: its scaling factors are floats, and `cudnnDeriveBNTensorDescriptor` answers a float descriptor for a half x.

Naming all four in `gen/def`, where the rest of the per-dtype constants live, means a dtype whose compute type differs is added by naming it there rather than by editing eight templates. That also deletes the `case type_name` block each of those templates carried.

Nothing changes for SFloat or DFloat. The generated C differs only in line markers, one comment, and three calls that now name the enum instead of a local initialised to it, and the outputs of all eight cuDNN methods hash identically before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
