### PR TITLE
Add the cuDNN methods to Cumo::HFloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,19 @@ export CUMO_SHOW_WARNING=ON
 export CUMO_SHOW_WARNING_ONCE=OFF
 ```
 
+### Raise the cuDNN workspace ceiling
+
+cuDNN picks a convolution algorithm by benchmarking the ones that fit in a scratch buffer, and the ceiling on that buffer is 8MB.
+The fastest half precision algorithms, the ones that reach the tensor cores, ask for more than that and are left out of the search.
+To let them in:
+
+```
+export CUMO_CUDNN_MAX_WORKSPACE_SIZE=67108864
+```
+
+The value is in bytes and only bounds the search; each convolution reserves what its chosen algorithm actually needs.
+`Cumo::CUDA::CUDNN.max_workspace_size` reads back the value in force.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/sonots/cumo.

--- a/ext/cumo/cuda/cudnn.c
+++ b/ext/cumo/cuda/cudnn.c
@@ -1,6 +1,9 @@
 #include "cumo/cuda/cudnn.h"
 
 #include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
 #include <ruby.h>
 #include "cumo/narray.h"
 #include "cumo/template.h"
@@ -19,6 +22,35 @@ cumo_cuda_cudnn_check_status(cudnnStatus_t status)
     if (status != CUDNN_STATUS_SUCCESS) {
         rb_raise(cumo_cuda_eCUDNNError, "%s (error=%d)", cudnnGetErrorString(status), status);
     }
+}
+
+static size_t cudnn_max_workspace_size = CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE;
+
+size_t
+cumo_cuda_cudnn_max_workspace_size()
+{
+    return cudnn_max_workspace_size;
+}
+
+static void
+init_max_workspace_size(void)
+{
+    const char* env = getenv("CUMO_CUDNN_MAX_WORKSPACE_SIZE");
+    char* end = NULL;
+    unsigned long long v;
+
+    if (env == NULL || *env == '\0') return;
+    // strtoull takes a leading minus and wraps it, so reject the sign itself
+    if (*env == '-' || *env == '+') goto BAD;
+    errno = 0;
+    v = strtoull(env, &end, 10);
+    if (errno != 0 || end == env || *end != '\0' || v == 0 || v > (unsigned long long)SIZE_MAX) goto BAD;
+    cudnn_max_workspace_size = (size_t)v;
+    return;
+
+BAD:
+    rb_warn("CUMO_CUDNN_MAX_WORKSPACE_SIZE=%s is not a positive byte count, using %"PRIuSIZE,
+            env, cudnn_max_workspace_size);
 }
 
 // Lazily initialize cudnn handle, and cache it
@@ -51,6 +83,20 @@ cumo_cuda_cudnn_handle()
 
   @return [Boolean] Returns true if cuDNN is available
  */
+#ifdef CUDNN_FOUND
+/*
+  Returns the ceiling cuDNN may use when it searches for a convolution
+  algorithm, set by CUMO_CUDNN_MAX_WORKSPACE_SIZE.
+
+  @return [Integer] bytes
+ */
+static VALUE
+rb_cudnn_max_workspace_size(VALUE self)
+{
+    return SIZET2NUM(cumo_cuda_cudnn_max_workspace_size());
+}
+#endif // CUDNN_FOUND
+
 static VALUE
 rb_cudnn_available_p(VALUE self)
 {
@@ -76,6 +122,8 @@ Init_cumo_cuda_cudnn(void)
 
     rb_define_singleton_method(mCUDNN, "available?", rb_cudnn_available_p, 0);
 #ifdef CUDNN_FOUND
+    init_max_workspace_size();
+    rb_define_singleton_method(mCUDNN, "max_workspace_size", rb_cudnn_max_workspace_size, 0);
     rb_define_const(mCUDNN, "CUDNN_POOLING_MAX", INT2NUM(CUDNN_POOLING_MAX));
     rb_define_const(mCUDNN, "CUDNN_POOLING_MAX_DETERMINISTIC", INT2NUM(CUDNN_POOLING_MAX_DETERMINISTIC));
     rb_define_const(mCUDNN, "CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING", INT2NUM(CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING));

--- a/ext/cumo/cuda/cudnn_impl.cpp
+++ b/ext/cumo/cuda/cudnn_impl.cpp
@@ -158,7 +158,8 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
         size_t ndim,
         int* int_stride,
         int* int_pad,
-        cudnnDataType_t compute_dtype) {
+        cudnnDataType_t compute_dtype,
+        cudnnMathType_t math_type) {
     cudnnStatus_t status = CUDNN_STATUS_SUCCESS;
     int int_dilation[CUMO_NA_MAX_DIMENSION];
     for (size_t idim = 0; idim < ndim; ++idim) {
@@ -189,8 +190,12 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
                 CUDNN_CROSS_CORRELATION,
                 compute_dtype);
     }
+    if (status != CUDNN_STATUS_SUCCESS) return status;
 
-    return status;
+    // Tensor cores are not reached under CUDNN_DEFAULT_MATH, and asking for
+    // them where they do not apply is not an error, so every dtype names what
+    // it wants.
+    return cudnnSetConvolutionMathType(*desc, math_type);
 }
 
 cudnnStatus_t
@@ -304,9 +309,49 @@ struct AlgoCacheKeyHash {
     }
 };
 
-using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionFwdAlgo_t, size_t>, AlgoCacheKeyHash>;
-using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionBwdDataAlgo_t, size_t>, AlgoCacheKeyHash>;
-using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionBwdFilterAlgo_t, size_t>, AlgoCacheKeyHash>;
+// The math type belongs with the algorithm: the descriptor's own setting is
+// only a permission, and cuDNN reports which one the chosen algorithm actually
+// used. Handing that algorithm to the convolution under a different math type
+// is rejected, or answers something else.
+// A template cannot be declared with C linkage, and this file's exports are
+// wrapped in extern "C".
+extern "C++" {
+template <typename Algo>
+struct AlgoCacheEntry {
+    Algo algo;
+    size_t memory;
+    cudnnMathType_t math_type;
+};
+}
+
+using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey, AlgoCacheEntry<cudnnConvolutionFwdAlgo_t>, AlgoCacheKeyHash>;
+using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey, AlgoCacheEntry<cudnnConvolutionBwdDataAlgo_t>, AlgoCacheKeyHash>;
+using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey, AlgoCacheEntry<cudnnConvolutionBwdFilterAlgo_t>, AlgoCacheKeyHash>;
+
+// Every search builds the same key. Leaving each of the three to do it by hand
+// is how the device id came to be set in one of them and not the others.
+static AlgoCacheKey
+MakeAlgoCacheKey(
+        cumo_narray_t* nx, cumo_narray_t* nw, cumo_narray_t* ny,
+        int* int_stride, int* int_pad, size_t ndim,
+        cudnnDataType_t cudnn_dtype, size_t max_workspace_size)
+{
+    auto key = AlgoCacheKey{};
+    cumo_cuda_runtime_check_status(cudaGetDevice(&(key.device_id)));
+    key.ndim = ndim;
+    for (size_t idim = 0; idim < ndim + 2; ++idim) {
+        key.x_shape[idim] = nx->shape[idim];
+        key.w_shape[idim] = nw->shape[idim];
+        key.y_shape[idim] = ny->shape[idim];
+    }
+    for (size_t idim = 0; idim < ndim; ++idim) {
+        key.pad[idim] = int_pad[idim];
+        key.stride[idim] = int_stride[idim];
+    }
+    key.dtype = cudnn_dtype;
+    key.max_workspace_size = max_workspace_size;
+    return key;
+}
 
 static FwdAlgoCacheMap fwd_algo_cache_map_{};
 static BwdDataAlgoCacheMap bwd_data_algo_cache_map_{};
@@ -335,28 +380,19 @@ cumo_cuda_cudnn_FindConvolutionForwardAlgorithm(
     CumoGetNArray(w, nw);
     CumoGetNArray(y, ny);
 
-    auto key = AlgoCacheKey{};
-    cumo_cuda_runtime_check_status(cudaGetDevice(&(key.device_id)));
-    key.ndim = ndim;
-    for (size_t idim = 0; idim < ndim + 2; ++idim) {
-        key.x_shape[idim] = nx->shape[idim];
-        key.w_shape[idim] = nw->shape[idim];
-        key.y_shape[idim] = ny->shape[idim];
-    }
-    for (size_t idim = 0; idim < ndim; ++idim) {
-        key.pad[idim]= int_pad[idim];
-        key.stride[idim]= int_stride[idim];
-    }
-    key.dtype = cudnn_dtype;
-    key.max_workspace_size = max_workspace_size;
+    auto key = MakeAlgoCacheKey(nx, nw, ny, int_stride, int_pad, ndim,
+                                cudnn_dtype, max_workspace_size);
 
     auto& algo_cache_map = fwd_algo_cache_map_;
     // TODO: thread-safe
     auto it = algo_cache_map.find(key);
     if (it != algo_cache_map.end()) {
-        auto pair = it->second;
-        perf_result->algo = pair.first;
-        perf_result->memory = pair.second;
+        auto entry = it->second;
+        // clear the fields the search would have filled but the cache drops
+        *perf_result = {};
+        perf_result->algo = entry.algo;
+        perf_result->memory = entry.memory;
+        perf_result->mathType = entry.math_type;
         return CUDNN_STATUS_SUCCESS;
     }
 
@@ -382,10 +418,13 @@ cumo_cuda_cudnn_FindConvolutionForwardAlgorithm(
                 max_workspace_size);
     cumo_cuda_runtime_free(workspace);
     if (status != CUDNN_STATUS_SUCCESS) return status;
-    assert(returned_algo_count == 1);
+    // A search that answers success with nothing to report would leave
+    // perf_result untouched, and its algo and math type are used below.
+    if (returned_algo_count < 1) return CUDNN_STATUS_NOT_SUPPORTED;
+    if (perf_result->status != CUDNN_STATUS_SUCCESS) return perf_result->status;
 
     // TODO: thread-safe
-    algo_cache_map[key] = {perf_result->algo, perf_result->memory};
+    algo_cache_map[key] = {perf_result->algo, perf_result->memory, perf_result->mathType};
     return status;
 }
 
@@ -412,27 +451,19 @@ cumo_cuda_cudnn_FindConvolutionBackwardDataAlgorithm(
     CumoGetNArray(w, nw);
     CumoGetNArray(y, ny);
 
-    auto key = AlgoCacheKey{};
-    key.ndim = ndim;
-    for (size_t idim = 0; idim < ndim + 2; ++idim) {
-        key.x_shape[idim] = nx->shape[idim];
-        key.w_shape[idim] = nw->shape[idim];
-        key.y_shape[idim] = ny->shape[idim];
-    }
-    for (size_t idim = 0; idim < ndim; ++idim) {
-        key.pad[idim]= int_pad[idim];
-        key.stride[idim]= int_stride[idim];
-    }
-    key.dtype = cudnn_dtype;
-    key.max_workspace_size = max_workspace_size;
+    auto key = MakeAlgoCacheKey(nx, nw, ny, int_stride, int_pad, ndim,
+                                cudnn_dtype, max_workspace_size);
 
     auto& algo_cache_map = bwd_data_algo_cache_map_;
     // TODO: thread-safe
     auto it = algo_cache_map.find(key);
     if (it != algo_cache_map.end()) {
-        auto pair = it->second;
-        perf_result->algo = pair.first;
-        perf_result->memory = pair.second;
+        auto entry = it->second;
+        // clear the fields the search would have filled but the cache drops
+        *perf_result = {};
+        perf_result->algo = entry.algo;
+        perf_result->memory = entry.memory;
+        perf_result->mathType = entry.math_type;
         return CUDNN_STATUS_SUCCESS;
     }
 
@@ -458,10 +489,13 @@ cumo_cuda_cudnn_FindConvolutionBackwardDataAlgorithm(
                 max_workspace_size);
     cumo_cuda_runtime_free(workspace);
     if (status != CUDNN_STATUS_SUCCESS) return status;
-    assert(returned_algo_count == 1);
+    // A search that answers success with nothing to report would leave
+    // perf_result untouched, and its algo and math type are used below.
+    if (returned_algo_count < 1) return CUDNN_STATUS_NOT_SUPPORTED;
+    if (perf_result->status != CUDNN_STATUS_SUCCESS) return perf_result->status;
 
     // TODO: thread-safe
-    algo_cache_map[key] = {perf_result->algo, perf_result->memory};
+    algo_cache_map[key] = {perf_result->algo, perf_result->memory, perf_result->mathType};
     return status;
 }
 
@@ -488,27 +522,19 @@ cumo_cuda_cudnn_FindConvolutionBackwardFilterAlgorithm(
     CumoGetNArray(gy, ngy);
     CumoGetNArray(gw, ngw);
 
-    auto key = AlgoCacheKey{};
-    key.ndim = ndim;
-    for (size_t idim = 0; idim < ndim + 2; ++idim) {
-        key.x_shape[idim] = nx->shape[idim];
-        key.w_shape[idim] = ngw->shape[idim];
-        key.y_shape[idim] = ngy->shape[idim];
-    }
-    for (size_t idim = 0; idim < ndim; ++idim) {
-        key.pad[idim]= int_pad[idim];
-        key.stride[idim]= int_stride[idim];
-    }
-    key.dtype = cudnn_dtype;
-    key.max_workspace_size = max_workspace_size;
+    auto key = MakeAlgoCacheKey(nx, ngw, ngy, int_stride, int_pad, ndim,
+                                cudnn_dtype, max_workspace_size);
 
     auto& algo_cache_map = bwd_filter_algo_cache_map_;
     // TODO: thread-safe
     auto it = algo_cache_map.find(key);
     if (it != algo_cache_map.end()) {
-        auto pair = it->second;
-        perf_result->algo = pair.first;
-        perf_result->memory = pair.second;
+        auto entry = it->second;
+        // clear the fields the search would have filled but the cache drops
+        *perf_result = {};
+        perf_result->algo = entry.algo;
+        perf_result->memory = entry.memory;
+        perf_result->mathType = entry.math_type;
         return CUDNN_STATUS_SUCCESS;
     }
 
@@ -534,10 +560,13 @@ cumo_cuda_cudnn_FindConvolutionBackwardFilterAlgorithm(
                 max_workspace_size);
     cumo_cuda_runtime_free(workspace);
     if (status != CUDNN_STATUS_SUCCESS) return status;
-    assert(returned_algo_count == 1);
+    // A search that answers success with nothing to report would leave
+    // perf_result untouched, and its algo and math type are used below.
+    if (returned_algo_count < 1) return CUDNN_STATUS_NOT_SUPPORTED;
+    if (perf_result->status != CUDNN_STATUS_SUCCESS) return perf_result->status;
 
     // TODO: thread-safe
-    algo_cache_map[key] = {perf_result->algo, perf_result->memory};
+    algo_cache_map[key] = {perf_result->algo, perf_result->memory, perf_result->mathType};
     return status;
 }
 

--- a/ext/cumo/include/cumo/cuda/cudnn.h
+++ b/ext/cumo/include/cumo/cuda/cudnn.h
@@ -21,7 +21,14 @@ extern VALUE cumo_cuda_eCUDNNError;
 
 extern VALUE cumo_na_eShapeError;
 
-#define CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE 8 * 1024 * 1024
+#define CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE (8 * 1024 * 1024)
+
+// How much scratch cuDNN may use to pick a convolution algorithm. The fastest
+// half algorithms are the ones that need the most, so the default keeps every
+// dtype on the algorithms it has always used and CUMO_CUDNN_MAX_WORKSPACE_SIZE
+// raises the ceiling for whoever wants them.
+size_t
+cumo_cuda_cudnn_max_workspace_size();
 
 // An output array given by the caller is written through a descriptor built
 // from another operand, or as if it were contiguous, so cuDNN never learns how
@@ -73,6 +80,17 @@ cumo_cuda_cudnn_check_input(VALUE in, VALUE type, size_t ndim, size_t *shape)
     CUMO_CHECK_DIM_EQ((size_t)(na->ndim), ndim);
     for (size_t idim = 0; idim < ndim; ++idim) {
         CUMO_CHECK_SIZE_EQ(na->shape[idim], shape[idim]);
+    }
+}
+
+// cuDNN derives the batch norm parameter descriptor from x, and widens it to
+// float for a half x, so the parameters do not always take x's own class.
+static inline void
+cumo_cuda_cudnn_check_param_type(VALUE param, VALUE type, const char* name)
+{
+    if (rb_obj_class(param) != type) {
+        rb_raise(rb_eTypeError, "%s must be %s, not %s",
+                 name, rb_class2name(type), rb_obj_classname(param));
     }
 }
 
@@ -172,7 +190,8 @@ cumo_cuda_cudnn_CreateConvolutionDescriptor(
         size_t ndim,
         int* int_stride,
         int* int_pad,
-        cudnnDataType_t compute_dtype);
+        cudnnDataType_t compute_dtype,
+        cudnnMathType_t math_type);
 
 cudnnStatus_t
 cumo_cuda_cudnn_CreatePoolingDescriptor(

--- a/ext/cumo/include/cumo/types/hfloat.h
+++ b/ext/cumo/include/cumo/types/hfloat.h
@@ -9,6 +9,7 @@ typedef cumo_half rtype;
 #include "half_macro.h"
 #include "cublas_v2.h"
 #include "cumo/cuda/cublas.h"
+#include "cumo/cuda/cudnn.h"
 
 #define m_extract(x) rb_float_new(cumo_half2float(*(cumo_half*)x))
 #define m_nearly_eq(x,y) (fabsf(cumo_half2float(x)-cumo_half2float(y))<=(fabsf(cumo_half2float(x))+fabsf(cumo_half2float(y)))*CUMO_HALF_EPSILON*2)

--- a/ext/cumo/narray/gen/def/dfloat.rb
+++ b/ext/cumo/narray/gen/def/dfloat.rb
@@ -25,6 +25,7 @@ set cudnn_dtype:         "CUDNN_DATA_DOUBLE"
 set cudnn_compute_dtype: "CUDNN_DATA_DOUBLE"
 set cudnn_scalar_t:      "dtype"
 set cudnn_param_class:   "cT"
+set cudnn_math_type:     "CUDNN_DEFAULT_MATH"
 
 upcast_rb "Integer"
 upcast_rb "Float"

--- a/ext/cumo/narray/gen/def/hfloat.rb
+++ b/ext/cumo/narray/gen/def/hfloat.rb
@@ -21,6 +21,12 @@ set is_double_precision: false
 set is_half:             true
 set need_align:          true
 
+set cudnn_dtype:         "CUDNN_DATA_HALF"
+set cudnn_compute_dtype: "CUDNN_DATA_FLOAT"
+set cudnn_scalar_t:      "float"
+set cudnn_param_class:   "cumo_cSFloat"
+set cudnn_math_type:     "CUDNN_TENSOR_OP_MATH"
+
 upcast_rb "Integer"
 upcast_rb "Float"
 upcast_rb "Complex", "SComplex"

--- a/ext/cumo/narray/gen/def/sfloat.rb
+++ b/ext/cumo/narray/gen/def/sfloat.rb
@@ -25,6 +25,7 @@ set cudnn_dtype:         "CUDNN_DATA_FLOAT"
 set cudnn_compute_dtype: "CUDNN_DATA_FLOAT"
 set cudnn_scalar_t:      "dtype"
 set cudnn_param_class:   "cT"
+set cudnn_math_type:     "CUDNN_DEFAULT_MATH"
 
 upcast_rb "Integer"
 upcast_rb "Float"

--- a/ext/cumo/narray/gen/spec.rb
+++ b/ext/cumo/narray/gen/spec.rb
@@ -59,7 +59,7 @@ if (is_float || is_complex) && !is_object
   def_id "gemm"
 end
 # cudnn
-if is_float && !is_complex && !is_object && !is_half
+if is_float && !is_complex && !is_object
   def_id "conv"
   def_id "conv_transpose"
   def_id "conv_grad_w"
@@ -367,7 +367,7 @@ if (is_float || is_complex) && !is_object
 end
 
 # cudnn
-if is_float && !is_complex && !is_object && !is_half
+if is_float && !is_complex && !is_object
   def_method "conv"
   def_method "conv_transpose" # conv_backward_data
   def_method "conv_grad_w" # conv_backward_filter

--- a/ext/cumo/narray/gen/tmpl/batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm.c
@@ -114,12 +114,12 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
-    CUMO_CHECK_NARRAY_TYPE(beta, <%=cudnn_param_class%>);
-    if (running_mean != Qnil) CUMO_CHECK_NARRAY_TYPE(running_mean, <%=cudnn_param_class%>);
-    if (running_var != Qnil) CUMO_CHECK_NARRAY_TYPE(running_var, <%=cudnn_param_class%>);
-    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
-    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, <%=cudnn_param_class%>);
+    cumo_cuda_cudnn_check_param_type(gamma, <%=cudnn_param_class%>, "gamma");
+    cumo_cuda_cudnn_check_param_type(beta, <%=cudnn_param_class%>, "beta");
+    if (running_mean != Qnil) cumo_cuda_cudnn_check_param_type(running_mean, <%=cudnn_param_class%>, "running_mean");
+    if (running_var != Qnil) cumo_cuda_cudnn_check_param_type(running_var, <%=cudnn_param_class%>, "running_var");
+    if (mean != Qnil) cumo_cuda_cudnn_check_param_type(mean, <%=cudnn_param_class%>, "mean");
+    if (inv_std != Qnil) cumo_cuda_cudnn_check_param_type(inv_std, <%=cudnn_param_class%>, "inv_std");
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);

--- a/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
+++ b/ext/cumo/narray/gen/tmpl/batch_norm_backward.c
@@ -95,10 +95,10 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
+    cumo_cuda_cudnn_check_param_type(gamma, <%=cudnn_param_class%>, "gamma");
     CUMO_CHECK_NARRAY_TYPE(gy, cT);
-    if (mean != Qnil) CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
-    if (inv_std != Qnil) CUMO_CHECK_NARRAY_TYPE(inv_std, <%=cudnn_param_class%>);
+    if (mean != Qnil) cumo_cuda_cudnn_check_param_type(mean, <%=cudnn_param_class%>, "mean");
+    if (inv_std != Qnil) cumo_cuda_cudnn_check_param_type(inv_std, <%=cudnn_param_class%>, "inv_std");
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);

--- a/ext/cumo/narray/gen/tmpl/conv.c
+++ b/ext/cumo/narray/gen/tmpl/conv.c
@@ -33,7 +33,7 @@ static VALUE
 
     cudnnConvolutionFwdAlgoPerf_t perf_result;
     cudnnConvolutionFwdAlgo_t algo;
-    size_t max_workspace_size = CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE;
+    size_t max_workspace_size = cumo_cuda_cudnn_max_workspace_size();
     size_t workspace_size;
     char* workspace = 0;
 
@@ -101,7 +101,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&w_desc, w_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>, <%=cudnn_math_type%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
 
     handle = cumo_cuda_cudnn_handle();
@@ -123,10 +123,16 @@ static VALUE
             ndim,
             cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
+    // The descriptor asked for a math type; use the one the search settled on.
+    status = cudnnSetConvolutionMathType(conv_desc, perf_result.mathType);
+    if (status != CUDNN_STATUS_SUCCESS) goto CONV_ERROR;
+
     algo = perf_result.algo;
     workspace_size = perf_result.memory;
 
-    workspace = cumo_cuda_runtime_malloc(max_workspace_size);
+    // The search may look at algorithms needing up to max_workspace_size,
+    // but only the one it picked has to be paid for.
+    if (workspace_size > 0) workspace = cumo_cuda_runtime_malloc(workspace_size);
     status = cudnnConvolutionForward(
             handle,
             (void*)&alpha,

--- a/ext/cumo/narray/gen/tmpl/conv_grad_w.c
+++ b/ext/cumo/narray/gen/tmpl/conv_grad_w.c
@@ -39,7 +39,7 @@ static VALUE
 
     cudnnConvolutionBwdFilterAlgoPerf_t perf_result;
     cudnnConvolutionBwdFilterAlgo_t algo;
-    size_t max_workspace_size = CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE;
+    size_t max_workspace_size = cumo_cuda_cudnn_max_workspace_size();
     size_t workspace_size;
     char* workspace = 0;
 
@@ -112,7 +112,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&gw_desc, gw, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>, <%=cudnn_math_type%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
 
     handle = cumo_cuda_cudnn_handle();
@@ -134,10 +134,16 @@ static VALUE
             ndim,
             cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
+    // The descriptor asked for a math type; use the one the search settled on.
+    status = cudnnSetConvolutionMathType(conv_desc, perf_result.mathType);
+    if (status != CUDNN_STATUS_SUCCESS) goto CONV_GRAD_W_ERROR;
+
     algo = perf_result.algo;
     workspace_size = perf_result.memory;
 
-    workspace = cumo_cuda_runtime_malloc(max_workspace_size);
+    // The search may look at algorithms needing up to max_workspace_size,
+    // but only the one it picked has to be paid for.
+    if (workspace_size > 0) workspace = cumo_cuda_runtime_malloc(workspace_size);
     status = cudnnConvolutionBackwardFilter(
             handle,
             (void*)&one,

--- a/ext/cumo/narray/gen/tmpl/conv_transpose.c
+++ b/ext/cumo/narray/gen/tmpl/conv_transpose.c
@@ -58,7 +58,7 @@ static VALUE
 
     cudnnConvolutionBwdDataAlgoPerf_t perf_result;
     cudnnConvolutionBwdDataAlgo_t algo;
-    size_t max_workspace_size = CUMO_CUDA_CUDNN_DEFAULT_MAX_WORKSPACE_SIZE;
+    size_t max_workspace_size = cumo_cuda_cudnn_max_workspace_size();
     size_t workspace_size;
     char* workspace = 0;
 
@@ -128,7 +128,7 @@ static VALUE
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
     status = cumo_cuda_cudnn_CreateFilterDescriptor(&w_desc, w_cont, cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
-    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>);
+    status = cumo_cuda_cudnn_CreateConvolutionDescriptor(&conv_desc, ndim, int_stride, int_pad, <%=cudnn_compute_dtype%>, <%=cudnn_math_type%>);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
 
     handle = cumo_cuda_cudnn_handle();
@@ -150,10 +150,16 @@ static VALUE
             ndim,
             cudnn_dtype);
     if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
+    // The descriptor asked for a math type; use the one the search settled on.
+    status = cudnnSetConvolutionMathType(conv_desc, perf_result.mathType);
+    if (status != CUDNN_STATUS_SUCCESS) goto CONV_TRANSPOSE_ERROR;
+
     algo = perf_result.algo;
     workspace_size = perf_result.memory;
 
-    workspace = cumo_cuda_runtime_malloc(max_workspace_size);
+    // The search may look at algorithms needing up to max_workspace_size,
+    // but only the one it picked has to be paid for.
+    if (workspace_size > 0) workspace = cumo_cuda_runtime_malloc(workspace_size);
     status = cudnnConvolutionBackwardData(
             handle,
             (void*)&alpha,

--- a/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
+++ b/ext/cumo/narray/gen/tmpl/fixed_batch_norm.c
@@ -73,10 +73,10 @@ static VALUE
     }
 
     CUMO_CHECK_NARRAY_TYPE(x, cT);
-    CUMO_CHECK_NARRAY_TYPE(gamma, <%=cudnn_param_class%>);
-    CUMO_CHECK_NARRAY_TYPE(beta, <%=cudnn_param_class%>);
-    CUMO_CHECK_NARRAY_TYPE(mean, <%=cudnn_param_class%>);
-    CUMO_CHECK_NARRAY_TYPE(var, <%=cudnn_param_class%>);
+    cumo_cuda_cudnn_check_param_type(gamma, <%=cudnn_param_class%>, "gamma");
+    cumo_cuda_cudnn_check_param_type(beta, <%=cudnn_param_class%>, "beta");
+    cumo_cuda_cudnn_check_param_type(mean, <%=cudnn_param_class%>, "mean");
+    cumo_cuda_cudnn_check_param_type(var, <%=cudnn_param_class%>, "var");
 
     x_cont = cumo_na_as_contiguous_array(x);
     gamma_cont = cumo_na_as_contiguous_array(gamma);

--- a/lib/cumo/cuda/cudnn.rb
+++ b/lib/cumo/cuda/cudnn.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Cumo
-  [SFloat, DFloat].each do |klass|
+  [HFloat, SFloat, DFloat].each do |klass|
     klass.class_eval do
       alias_method :conv_backward_data, :conv_transpose
       alias_method :conv_backward_filter, :conv_grad_w

--- a/test/cudnn_test.rb
+++ b/test/cudnn_test.rb
@@ -4,6 +4,7 @@ require_relative "test_helper"
 
 class CUDNNTest < Test::Unit::TestCase
   float_types = [
+    Cumo::HFloat,
     Cumo::SFloat,
     Cumo::DFloat,
   ]
@@ -13,6 +14,10 @@ class CUDNNTest < Test::Unit::TestCase
   end
 
   float_types.each do |dtype|
+    # cuDNN derives the batch norm parameter descriptor from x and widens it to
+    # float for a half x, so those arrays take this class rather than x's own
+    param_type = dtype == Cumo::HFloat ? Cumo::SFloat : dtype
+
     sub_test_case "conv_2d" do
       setup do
         @batch_size = 2
@@ -248,8 +253,8 @@ class CUDNNTest < Test::Unit::TestCase
         @x_shape = [@batch_size, @in_channels].concat(@in_dims)
         @reduced_shape = [1].concat(@x_shape[1..-1])
         @x = dtype.ones(*@x_shape) * 3
-        @gamma = dtype.ones(*@reduced_shape) * 2
-        @beta = dtype.ones(*@reduced_shape)
+        @gamma = param_type.ones(*@reduced_shape) * 2
+        @beta = param_type.ones(*@reduced_shape)
       end
 
       test "x.batch_norm(gamma, beta) #{dtype}" do
@@ -264,23 +269,23 @@ class CUDNNTest < Test::Unit::TestCase
 
       test "x.batch_norm(gamma, beta, axis: [0, 2, 3]) #{dtype}" do
         reduced_shape = [1, @x_shape[1], 1, 1]
-        gamma = dtype.ones(reduced_shape) * 2
-        beta = dtype.ones(reduced_shape)
+        gamma = param_type.ones(reduced_shape) * 2
+        beta = param_type.ones(reduced_shape)
         y = @x.batch_norm(gamma, beta, axis: [0, 2, 3])
         assert { y.shape == @x_shape }
       end
 
       test "x.batch_norm(gamma, beta, running_mean, running_var) #{dtype}" do
-        running_mean = dtype.ones(*@reduced_shape)
-        running_var = dtype.ones(*@reduced_shape)
+        running_mean = param_type.ones(*@reduced_shape)
+        running_var = param_type.ones(*@reduced_shape)
         y = @x.batch_norm(@gamma, @beta, running_mean: running_mean, running_var: running_var)
         assert { y.shape == @x_shape }
         assert_in_delta(y, dtype.ones(*@x_shape), 1e-3)
       end
 
       test "x.batch_norm(gamma, beta, mean, inv_std) #{dtype}" do
-        mean = dtype.new(*@reduced_shape)
-        inv_std = dtype.new(*@reduced_shape)
+        mean = param_type.new(*@reduced_shape)
+        inv_std = param_type.new(*@reduced_shape)
         y = @x.batch_norm(@gamma, @beta, mean: mean, inv_std: inv_std)
         assert { y.shape == @x_shape }
         assert { mean.shape == @reduced_shape }
@@ -291,8 +296,8 @@ class CUDNNTest < Test::Unit::TestCase
     sub_test_case "batch_norm with an axis that folds the channel away" do
       setup do
         @x = dtype.new(8, 256).seq
-        @one = dtype.ones(1)
-        @zero = dtype.zeros(1)
+        @one = param_type.ones(1)
+        @zero = param_type.zeros(1)
       end
 
       # cuDNN derives its parameter descriptor from x with a SPATIAL mode and
@@ -317,8 +322,8 @@ class CUDNNTest < Test::Unit::TestCase
       end
 
       test "the same shapes with the default axis still go through #{dtype}" do
-        gamma = dtype.ones(1, 256)
-        beta = dtype.zeros(1, 256)
+        gamma = param_type.ones(1, 256)
+        beta = param_type.zeros(1, 256)
         assert { @x.batch_norm(gamma, beta).shape == [8, 256] }
         assert { @x.fixed_batch_norm(gamma, beta, beta, gamma).shape == [8, 256] }
         assert { @x.batch_norm_backward(gamma, dtype.ones(8, 256)).first.shape == [8, 256] }
@@ -329,16 +334,16 @@ class CUDNNTest < Test::Unit::TestCase
     # axis that names nothing in x answers as though a different one had been
     # given rather than failing. The sizes below are the ones that reach the
     # kernel, so nothing else can raise first.
-    # cuDNN derives the parameter descriptor from x and gives it x's own type,
-    # widening only for half, which these methods are never generated for. What
-    # makes that enough is that every parameter is held to x's class here, so
-    # the descriptor and the buffer behind it can never disagree.
+    # cuDNN derives the parameter descriptor from x, giving it x's own type
+    # except for a half x, where it widens to float. What keeps the descriptor
+    # and the buffer behind it in step is that every parameter is held to
+    # exactly the class that descriptor carries.
     sub_test_case "a parameter of another dtype" do
       setup do
-        @other = (dtype == Cumo::SFloat) ? Cumo::DFloat : Cumo::SFloat
+        @other = (param_type == Cumo::DFloat) ? Cumo::SFloat : Cumo::DFloat
         @x = dtype.new(2, 4, 3, 3).seq(1)
-        @gamma = dtype.ones(4)
-        @beta = dtype.zeros(4)
+        @gamma = param_type.ones(4)
+        @beta = param_type.zeros(4)
         @gy = dtype.ones(2, 4, 3, 3)
         @axis = [0, 2, 3]
       end
@@ -375,18 +380,18 @@ class CUDNNTest < Test::Unit::TestCase
     sub_test_case "an axis that does not name x's dimensions" do
       setup do
         @x = dtype.new(2, 4, 3, 3).seq(1)
-        @gamma = dtype.ones(4)
-        @beta = dtype.zeros(4)
+        @gamma = param_type.ones(4)
+        @beta = param_type.zeros(4)
         @gy = dtype.ones(2, 4, 3, 3)
       end
 
       test "batch_norm rejects an axis outside x #{dtype}" do
-        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(72), dtype.zeros(72), axis: [5]) }
-        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(72), dtype.zeros(72), axis: [-1]) }
+        assert_raise(ArgumentError) { @x.batch_norm(param_type.ones(72), param_type.zeros(72), axis: [5]) }
+        assert_raise(ArgumentError) { @x.batch_norm(param_type.ones(72), param_type.zeros(72), axis: [-1]) }
       end
 
       test "batch_norm rejects a repeated or unordered axis #{dtype}" do
-        assert_raise(ArgumentError) { @x.batch_norm(dtype.ones(36), dtype.zeros(36), axis: [0, 0]) }
+        assert_raise(ArgumentError) { @x.batch_norm(param_type.ones(36), param_type.zeros(36), axis: [0, 0]) }
         assert_raise(ArgumentError) { @x.batch_norm(@gamma, @beta, axis: [3, 0, 2]) }
         assert_raise(ArgumentError) { @x.batch_norm(@gamma, @beta, axis: [0, 3, 2]) }
       end
@@ -421,8 +426,8 @@ class CUDNNTest < Test::Unit::TestCase
         @x_shape = [@batch_size, @in_channels].concat(@in_dims)
         @reduced_shape = [1].concat(@x_shape[1..-1])
         @x = dtype.ones(*@x_shape) * 3
-        @gamma = dtype.ones(*@reduced_shape) * 2
-        @beta = dtype.ones(*@reduced_shape)
+        @gamma = param_type.ones(*@reduced_shape) * 2
+        @beta = param_type.ones(*@reduced_shape)
         @gy = dtype.ones(*@x_shape)
       end
 
@@ -436,8 +441,8 @@ class CUDNNTest < Test::Unit::TestCase
 
       test "x.batch_norm_backward(gamma, gy, axis: [0,2,3]) #{dtype}" do
         @reduced_shape = [1, @x_shape[1], 1, 1]
-        @gamma = dtype.ones(@reduced_shape) * 2
-        @beta = dtype.ones(@reduced_shape)
+        @gamma = param_type.ones(@reduced_shape) * 2
+        @beta = param_type.ones(@reduced_shape)
         @x.batch_norm(@gamma, @beta, axis: [0, 2, 3])
         gx, ggamma, gbeta = @x.batch_norm_backward(@gamma, @gy, axis: [0, 2, 3])
         assert { gx.shape == @x_shape }
@@ -446,8 +451,8 @@ class CUDNNTest < Test::Unit::TestCase
       end
 
       test "x.batch_norm_backward(gamma, gy, mean:, inv_std:) #{dtype}" do
-        mean = dtype.new(*@reduced_shape)
-        inv_std = dtype.new(*@reduced_shape)
+        mean = param_type.new(*@reduced_shape)
+        inv_std = param_type.new(*@reduced_shape)
         @x.batch_norm(@gamma, @beta, mean: mean, inv_std: inv_std)
         gx, ggamma, gbeta = @x.batch_norm_backward(@gamma, @gy, mean: mean, inv_std: inv_std)
         assert { gx.shape == @x_shape }
@@ -464,10 +469,10 @@ class CUDNNTest < Test::Unit::TestCase
         @x_shape = [@batch_size, @in_channels].concat(@in_dims)
         @reduced_shape = [1].concat(@x_shape[1..-1])
         @x = dtype.ones(*@x_shape) * 3
-        @gamma = dtype.ones(*@reduced_shape) * 2
-        @beta = dtype.ones(*@reduced_shape)
-        @mean = dtype.ones(*@reduced_shape)
-        @var = dtype.ones(*@reduced_shape)
+        @gamma = param_type.ones(*@reduced_shape) * 2
+        @beta = param_type.ones(*@reduced_shape)
+        @mean = param_type.ones(*@reduced_shape)
+        @var = param_type.ones(*@reduced_shape)
       end
 
       test "x.fixed_batch_norm(gamma, beta, mean, var) #{dtype}" do
@@ -482,10 +487,10 @@ class CUDNNTest < Test::Unit::TestCase
 
       test "x.fixed_batch_norm(gamma, beta, mean, var, axis: [0, 2, 3]) #{dtype}" do
         reduced_shape = [1, @x_shape[1], 1, 1]
-        gamma = dtype.ones(reduced_shape) * 2
-        beta = dtype.ones(reduced_shape)
-        mean = dtype.ones(reduced_shape) * 2
-        var = dtype.ones(reduced_shape)
+        gamma = param_type.ones(reduced_shape) * 2
+        beta = param_type.ones(reduced_shape)
+        mean = param_type.ones(reduced_shape) * 2
+        var = param_type.ones(reduced_shape)
         y = @x.fixed_batch_norm(gamma, beta, mean, var, axis: [0, 2, 3])
         assert { y.shape == @x_shape }
         # TODO: check output values
@@ -713,10 +718,10 @@ class CUDNNTest < Test::Unit::TestCase
         @w_shape = [2, 3, 2, 3]
         @ksize = [3, 3]
         @x = dtype.ones(*@x_shape) * 3
-        @gamma = dtype.ones(*@reduced_shape) * 2
-        @beta = dtype.ones(*@reduced_shape)
-        @mean = dtype.ones(*@reduced_shape)
-        @var = dtype.ones(*@reduced_shape)
+        @gamma = param_type.ones(*@reduced_shape) * 2
+        @beta = param_type.ones(*@reduced_shape)
+        @mean = param_type.ones(*@reduced_shape)
+        @var = param_type.ones(*@reduced_shape)
         @gy = dtype.ones(*@x_shape)
         @w = dtype.ones(*@w_shape)
       end
@@ -738,11 +743,11 @@ class CUDNNTest < Test::Unit::TestCase
       test "batch_norm_backward(gx:, ggamma:, gbeta:) #{dtype}" do
         @x.batch_norm(@gamma, @beta)
         assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, gx: dtype.zeros(1)) }
-        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, ggamma: dtype.zeros(1)) }
-        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, gbeta: dtype.zeros(1)) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, ggamma: param_type.zeros(1)) }
+        assert_raise(Cumo::NArray::ShapeError) { @x.batch_norm_backward(@gamma, @gy, gbeta: param_type.zeros(1)) }
         gx = dtype.zeros(*@x_shape)
-        ggamma = dtype.zeros(*@reduced_shape)
-        gbeta = dtype.zeros(*@reduced_shape)
+        ggamma = param_type.zeros(*@reduced_shape)
+        gbeta = param_type.zeros(*@reduced_shape)
         assert { @x.batch_norm_backward(@gamma, @gy, gx: gx, ggamma: ggamma, gbeta: gbeta) == [gx, ggamma, gbeta] }
       end
 
@@ -780,5 +785,86 @@ class CUDNNTest < Test::Unit::TestCase
         assert_raise(Cumo::NArray::ShapeError) { @x.conv_transpose(@w, y: dtype.zeros(1)) }
       end
     end
+  end
+
+  if float_types.include?(Cumo::HFloat)
+   hf = Cumo::HFloat
+   sf = Cumo::SFloat
+
+   sub_test_case "HFloat" do
+
+    def seq(klass, shape, modulo)
+      klass.cast(Cumo::Int32.new(*shape).seq % modulo)
+    end
+
+    # cuDNN picks its algorithm by benchmarking, and half is allowed tensor
+    # cores, so which one wins varies between processes and so does the last
+    # place of the answer. Everything here is compared against SFloat within
+    # half's own precision rather than to the bit.
+    def assert_close_to_sfloat(got, ref)
+      scale = [ref.abs.max.to_a.first, 1.0].max
+      assert_in_delta 0.0, (Cumo::SFloat.cast(got) - ref).abs.max.to_a.first, scale * 2.0**-9
+    end
+
+    test "a convolution answers what SFloat answers" do
+      x = seq(hf, [2, 8, 6, 6], 4)
+      w = seq(hf, [8, 8, 1, 1], 3)
+      b = seq(hf, [8], 3)
+      assert_close_to_sfloat x.conv(w), sf.cast(x).conv(sf.cast(w))
+      assert_close_to_sfloat x.conv(w, b: b), sf.cast(x).conv(sf.cast(w), b: sf.cast(b))
+    end
+
+    test "a 3x3 convolution and its two gradients answer what SFloat answers" do
+      x = seq(hf, [2, 8, 8, 8], 4)
+      w = seq(hf, [8, 8, 3, 3], 3)
+      assert_close_to_sfloat x.conv(w), sf.cast(x).conv(sf.cast(w))
+      gy = seq(hf, x.conv(w).shape, 3)
+      assert_close_to_sfloat x.conv_grad_w(gy, w.shape), sf.cast(x).conv_grad_w(sf.cast(gy), w.shape)
+      assert_close_to_sfloat gy.conv_transpose(w, out_size: [8, 8]),
+                             sf.cast(gy).conv_transpose(sf.cast(w), out_size: [8, 8])
+    end
+
+    test "pooling answers what SFloat answers, to the bit" do
+      x = seq(hf, [2, 3, 8, 8], 7)
+      y = x.max_pool(2, stride: 2)
+      assert_equal sf.cast(x).max_pool(2, stride: 2).to_a, y.to_a
+      gy = seq(hf, y.shape, 3)
+      assert_equal sf.cast(x).max_pool_backward(sf.cast(y), sf.cast(gy), 2, stride: 2).to_a,
+                   x.max_pool_backward(y, gy, 2, stride: 2).to_a
+      assert_equal sf.cast(x).avg_pool(2, stride: 2).to_a, x.avg_pool(2, stride: 2).to_a
+    end
+
+    test "the batch norm parameters are SFloat, not HFloat" do
+      x = seq(hf, [2, 4, 3, 3], 5)
+      g = sf.ones(4)
+      b = sf.zeros(4)
+      axis = [0, 2, 3]
+      assert_equal hf, x.batch_norm(g, b, axis: axis).class
+      assert_close_to_sfloat x.batch_norm(g, b, axis: axis), sf.cast(x).batch_norm(g, b, axis: axis)
+      gx, ggamma, gbeta = x.batch_norm_backward(g, seq(hf, x.shape, 3), axis: axis)
+      assert_equal [hf, sf, sf], [gx.class, ggamma.class, gbeta.class]
+    end
+
+    test "a parameter of x's own class is refused by name" do
+      x = seq(hf, [2, 4, 3, 3], 5)
+      e = assert_raise(TypeError) { x.batch_norm(hf.ones(4), sf.zeros(4), axis: [0, 2, 3]) }
+      assert_equal "gamma must be Cumo::SFloat, not Cumo::HFloat", e.message
+      e = assert_raise(TypeError) { x.batch_norm(sf.ones(4), hf.zeros(4), axis: [0, 2, 3]) }
+      assert_equal "beta must be Cumo::SFloat, not Cumo::HFloat", e.message
+    end
+
+    test "the workspace ceiling is a positive byte count or the default" do
+      assert_operator Cumo::CUDA::CUDNN.max_workspace_size, :>, 0
+      assert_equal ENV["CUMO_CUDNN_MAX_WORKSPACE_SIZE"].to_i, Cumo::CUDA::CUDNN.max_workspace_size if
+        ENV["CUMO_CUDNN_MAX_WORKSPACE_SIZE"].to_s =~ /\A[1-9][0-9]*\z/
+    end
+
+    test "the convolution accumulates over more channels than half can count" do
+      # 40000 ones summed in half would stop at 2048
+      x = hf.ones(1, 40_000, 1, 1)
+      w = hf.ones(1, 40_000, 1, 1)
+      assert_equal 40_000.0, x.conv(w).to_a.flatten.first
+    end
+   end
   end
 end

--- a/test/hfloat_test.rb
+++ b/test/hfloat_test.rb
@@ -270,10 +270,6 @@ class HFloatTest < Test::Unit::TestCase
     assert_equal 0, a.ne(1.5).count_true
   end
 
-  test "the methods a later step brings are not claimed yet" do
-    assert_raise(NoMethodError) { dtype.new(1, 1, 2, 2).seq.conv(dtype.new(1, 1, 2, 2).seq) }
-  end
-
   test "sort orders as SFloat does" do
     a = dtype[3.0, -1.0, 2.5, 0.0]
     assert_equal [-1.0, 0.0, 2.5, 3.0], a.sort.to_a


### PR DESCRIPTION
Step 5 of `Cumo::HFloat` (#107): the cuDNN methods.

#369 gave the three things that are not the tensor's dtype a name of their own in `gen/def`, so this fills in half's row: float scaling factors, a float convolution compute type, and batch norm parameters in the class cuDNN derives for them. The last one is visible from Ruby. `cudnnDeriveBNTensorDescriptor` answers a float descriptor for a half x, so `gamma`, `beta` and the running statistics are `SFloat` where x is `HFloat`, which is also what keeps a momentum update off an 11-bit mantissa.

Tensor cores are never selected under `CUDNN_DEFAULT_MATH`, so half asks for them by name. The math type the algorithm search settles on then has to be put back on the descriptor before the convolution runs, and kept in the algorithm cache next to the algorithm: the descriptor's own setting is only a permission, and running an algorithm under a different math type is either rejected with `CUDNN_STATUS_BAD_PARAM` or answers something else.

The workspace ceiling that bounds the search becomes `CUMO_CUDNN_MAX_WORKSPACE_SIZE`, default unchanged, because the fastest half algorithms are the ones that ask for the most and 8MB leaves them out of the search. A convolution now reserves what its chosen algorithm needs rather than the ceiling, so raising it costs nothing per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
