### PR TITLE
Fix min, max and ptp answering a finite number for an array of infinities

### DIFF
--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -91,7 +91,14 @@ struct cumo_<%=type_name%>_ptp_impl {
         dtype min;
         dtype max;
     };
+<% if is_float %>
+    // Infinities rather than the largest finite values, so that an element
+    // which is itself an infinity still wins its comparison. An array holding
+    // nothing but +inf then answers inf - inf, which is the NaN numo answers.
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {(dtype)INFINITY, (dtype)(-INFINITY)}; }
+<% else %>
     __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
+<% end %>
     __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
     __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
         if (m_lt(next.min, accum.min)) { accum.min = next.min; }
@@ -161,6 +168,10 @@ struct cumo_<%=type_name%>_rms_impl {
 // NaN, so it maps to the identity and the tree never sees it. min and max go
 // the other way: numo answers NaN as soon as one element is NaN, and a NaN
 // absorbs in Reduce because it loses every comparison.
+//
+// min and max take an infinity for their identity rather than the largest
+// finite value, so that an element which is itself an infinity still wins.
+// numo seeds from the first element and never faces the question.
 struct cumo_<%=type_name%>_sum_nan_impl {
     __device__ <%=acc%> Identity(int64_t /*index*/) { return <%=acc_zero%>; }
     __device__ <%=acc%> MapIn(dtype in, int64_t /*index*/) { return not_nan(in) ? <%=to_acc%>(in) : <%=acc_zero%>; }
@@ -176,14 +187,14 @@ struct cumo_<%=type_name%>_prod_nan_impl {
 };
 
 struct cumo_<%=type_name%>_min_nan_impl {
-    __device__ dtype Identity(int64_t /*index*/) { return DATA_MAX; }
+    __device__ dtype Identity(int64_t /*index*/) { return (dtype)INFINITY; }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { if (!not_nan(next) || m_lt(next, accum)) { accum = next; } }
     __device__ dtype MapOut(dtype accum) { return accum; }
 };
 
 struct cumo_<%=type_name%>_max_nan_impl {
-    __device__ dtype Identity(int64_t /*index*/) { return DATA_MIN; }
+    __device__ dtype Identity(int64_t /*index*/) { return (dtype)(-INFINITY); }
     __device__ dtype MapIn(dtype in, int64_t /*index*/) { return in; }
     __device__ void Reduce(dtype next, dtype& accum) { if (!not_nan(next) || m_lt(accum, next)) { accum = next; } }
     __device__ dtype MapOut(dtype accum) { return accum; }
@@ -194,7 +205,7 @@ struct cumo_<%=type_name%>_minmax_nan_impl {
         dtype min;
         dtype max;
     };
-    __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
+    __device__ MinAndMax Identity(int64_t /*index*/) { return {(dtype)INFINITY, (dtype)(-INFINITY)}; }
     __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
     __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
         if (!not_nan(next.min) || m_lt(next.min, accum.min)) { accum.min = next.min; }

--- a/test/hfloat_test.rb
+++ b/test/hfloat_test.rb
@@ -410,6 +410,18 @@ class HFloatTest < Test::Unit::TestCase
     assert_equal 0.25, dtype.new(n).fill(0.25).mean.to_a.first
   end
 
+  test "the nan-aware min and max keep an infinity" do
+    inf = Float::INFINITY
+    assert_equal inf, dtype[inf, inf].min(nan: true).to_a.first
+    assert_equal(-inf, dtype[-inf, -inf].max(nan: true).to_a.first)
+    assert_equal [inf, inf], dtype[inf, inf].minmax(nan: true).map { |x| x.to_a.first }
+    assert_equal true, dtype[inf, inf].ptp(nan: true).to_a.first.nan?
+    assert_equal true, dtype[inf, inf].ptp.to_a.first.nan?
+    # the identity was the largest finite half, which is where 65504 came from
+    assert_equal inf, dtype.new(5000).fill(inf).min(nan: true).to_a.first
+    assert_equal(-inf, dtype.new(5000).fill(-inf).max(nan: true).to_a.first)
+  end
+
   test "the nan-aware reductions skip a NaN" do
     a = dtype[1.0, Float::NAN, 3.0]
     assert_equal 4.0, a.sum(nan: true).to_a.first

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -625,6 +625,15 @@ class NArrayTest < Test::Unit::TestCase
             assert { dtype[nan, nan].ptp.to_f.nan? }
             assert { dtype[3, nan, 1, 7].ptp(nan: true).to_f.nan? }
             assert { dtype[3, 10, 1, 7].ptp(nan: true) == 9 }
+            # an array of one infinity spans nothing, and inf - inf is NaN. The
+            # two halves of the identity are independent, so both directions.
+            inf = Float::INFINITY
+            assert { dtype[inf, inf].ptp.to_f.nan? }
+            assert { dtype[-inf, -inf].ptp.to_f.nan? }
+            assert { dtype[inf, nan].ptp.to_f.nan? }
+            assert { dtype[inf, inf].ptp(nan: true).to_f.nan? }
+            assert { dtype[-inf, -inf].ptp(nan: true).to_f.nan? }
+            assert { dtype[1, inf].ptp == inf }
           end
         end
       end
@@ -681,6 +690,35 @@ class NArrayTest < Test::Unit::TestCase
           assert { dtype[3, nan, 1, 7].min(nan: true).to_f.nan? }
           assert { dtype[3, 10, 1, 7].max(nan: true) == 10 }
           assert { dtype[3, 10, 1, 7].min(nan: true) == 1 }
+        end
+
+        # The identity has to lose to an infinity too, not just to a finite
+        # value, or an array holding nothing else answers with the largest
+        # finite number instead.
+        test "max(nan: true) and min(nan: true) keep an infinity" do
+          inf = Float::INFINITY
+          assert { dtype[inf, inf].min(nan: true) == inf }
+          assert { dtype[-inf, -inf].max(nan: true) == -inf }
+          assert { dtype[inf, inf].max(nan: true) == inf }
+          assert { dtype[-inf, -inf].min(nan: true) == -inf }
+          assert { dtype[inf, inf].minmax(nan: true).map(&:to_f) == [inf, inf] }
+          assert { dtype[-inf, -inf].minmax(nan: true).map(&:to_f) == [-inf, -inf] }
+          assert { dtype[inf, nan].min(nan: true).to_f.nan? }
+          assert { dtype[1, inf].min(nan: true) == 1 }
+        end
+
+        # More than one block, so the identity reaches the tree reduction. The
+        # min half is only exercised by an array of +inf and the max half by
+        # one of -inf, the other direction winning against either seed.
+        test "max(nan: true) and min(nan: true) keep an infinity over a large reduction" do
+          inf = Float::INFINITY
+          assert { dtype.new(5000).fill(inf).min(nan: true) == inf }
+          assert { dtype.new(5000).fill(-inf).max(nan: true) == -inf }
+          assert { dtype.new(5000).fill(inf).minmax(nan: true).map(&:to_f) == [inf, inf] }
+          assert { dtype.new(5000).fill(-inf).minmax(nan: true).map(&:to_f) == [-inf, -inf] }
+          assert { dtype.new(5000).fill(inf).ptp(nan: true).to_f.nan? }
+          b = dtype[[inf, inf], [1, 2]]
+          assert { b.min(axis: 1, nan: true).to_a == [inf, 1] }
         end
 
         test "max and min keep the earlier of two equal elements" do


### PR DESCRIPTION
`Cumo::SFloat[Float::INFINITY, Float::INFINITY].min(nan: true)` answers `3.4028234663852886e+38`, and the same array's `ptp` answers `Infinity` where it should answer `NaN`. `Cumo::DFloat` answers `DBL_MAX` and `Cumo::HFloat` answers `65504.0`.

The nan-aware min and max, and ptp in either form, seed their reduction with the largest finite value the dtype holds, and an element that is itself an infinity never wins against that seed. Seeding with an infinity fixes all of them. numo starts from the first element rather than from a seed and never faces the question, which is why it answers these correctly and cumo does not; the host loops in `real_accum.h` are numo's and are already right, so this is only the GPU reduction.

PR #219 made the same change to the plain min and max and did not reach the nan-aware pair or ptp.

The eight infinity and NaN shapes used to separate this from numo are now tests, on `narray_test.rb` for SFloat and DFloat and on `hfloat_test.rb` for half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
