### PR TITLE
Derive ptp from minmax rather than repeating the reduction

### DIFF
--- a/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl/real_accum_kernel.cu
@@ -86,32 +86,8 @@ struct cumo_<%=type_name%>_minmax_impl {
     }
 };
 
-struct cumo_<%=type_name%>_ptp_impl {
-    struct MinAndMax {
-        dtype min;
-        dtype max;
-    };
-<% if is_float %>
-    // Infinities rather than the largest finite values, so that an element
-    // which is itself an infinity still wins its comparison. An array holding
-    // nothing but +inf then answers inf - inf, which is the NaN numo answers.
-    __device__ MinAndMax Identity(int64_t /*index*/) { return {(dtype)INFINITY, (dtype)(-INFINITY)}; }
-<% else %>
-    __device__ MinAndMax Identity(int64_t /*index*/) { return {DATA_MAX, DATA_MIN}; }
-<% end %>
-    __device__ MinAndMax MapIn(dtype in, int64_t /*index*/) { return {in, in}; }
-    __device__ void Reduce(MinAndMax next, MinAndMax& accum) {
-        if (m_lt(next.min, accum.min)) { accum.min = next.min; }
-        if (m_lt(accum.max, next.max)) { accum.max = next.max; }
-    }
-    __device__ dtype MapOut(MinAndMax accum) {
-    <% if is_float %>
-        // A NaN loses both comparisons above, so every element being NaN leaves
-        // the identity untouched. An empty reduction raises before it gets here.
-        if (m_lt(accum.max, accum.min)) { return (dtype)nan(""); }
-    <% end %>
-        return m_sub(accum.max, accum.min);
-    }
+struct cumo_<%=type_name%>_ptp_impl : cumo_<%=type_name%>_minmax_impl {
+    __device__ dtype MapOut(MinAndMax accum) { return m_sub(accum.max, accum.min); }
 };
 
 <% unless is_float %>

--- a/test/hfloat_test.rb
+++ b/test/hfloat_test.rb
@@ -422,6 +422,21 @@ class HFloatTest < Test::Unit::TestCase
     assert_equal(-inf, dtype.new(5000).fill(-inf).max(nan: true).to_a.first)
   end
 
+  test "ptp and minmax keep an infinity over a large reduction" do
+    inf = Float::INFINITY
+    nan = Float::NAN
+    assert_equal true, dtype.new(5000).fill(inf).ptp.to_a.first.nan?
+    assert_equal true, dtype.new(5000).fill(-inf).ptp.to_a.first.nan?
+    assert_equal true, dtype.new(5000).fill(nan).ptp.to_a.first.nan?
+    assert_equal [inf, inf], dtype.new(5000).fill(inf).minmax.map { |x| x.to_a.first }
+    assert_equal([-inf, -inf], dtype.new(5000).fill(-inf).minmax.map { |x| x.to_a.first })
+
+    a = dtype.new(5000).fill(nan)
+    a[2500] = 7.0
+    assert_equal [7.0, 7.0], a.minmax.map { |x| x.to_a.first }
+    assert_equal 0.0, a.ptp.to_a.first
+  end
+
   test "the nan-aware reductions skip a NaN" do
     a = dtype[1.0, Float::NAN, 3.0]
     assert_equal 4.0, a.sum(nan: true).to_a.first

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -635,6 +635,35 @@ class NArrayTest < Test::Unit::TestCase
             assert { dtype[-inf, -inf].ptp(nan: true).to_f.nan? }
             assert { dtype[1, inf].ptp == inf }
           end
+
+          test "ptp and minmax keep an infinity over a large reduction" do
+            nan = Float::NAN
+            inf = Float::INFINITY
+            assert { dtype.new(5000).fill(inf).ptp.to_f.nan? }
+            assert { dtype.new(5000).fill(-inf).ptp.to_f.nan? }
+            assert { dtype.new(5000).fill(nan).ptp.to_f.nan? }
+            assert { dtype.new(5000).fill(inf).minmax.map(&:to_f) == [inf, inf] }
+            assert { dtype.new(5000).fill(-inf).minmax.map(&:to_f) == [-inf, -inf] }
+            assert { dtype.new(5000).fill(nan).minmax.map { |x| x.to_f.nan? } == [true, true] }
+
+            a = dtype.new(5000).fill(nan)
+            a[2500] = 7
+            assert { a.minmax.map(&:to_f) == [7, 7] }
+            assert { a.ptp == 0 }
+
+            b = dtype.new(5000).fill(-inf)
+            b[2500] = inf
+            assert { b.ptp.to_f == inf }
+            assert { b.minmax.map(&:to_f) == [-inf, inf] }
+
+            c = dtype.new(64, 500).fill(inf)
+            assert { c.ptp(axis: 0).to_a.all? { |x| x.nan? } }
+            assert { c.ptp(axis: 1).to_a.all? { |x| x.nan? } }
+            assert { c.minmax(axis: 0).map { |x| x.to_a.uniq } == [[inf], [inf]] }
+            d = dtype.new(64, 500).fill(nan)
+            assert { d.ptp(axis: 0).to_a.all? { |x| x.nan? } }
+            assert { d.ptp(axis: 1).to_a.all? { |x| x.nan? } }
+          end
         end
       end
     end


### PR DESCRIPTION
`ptp` and `minmax` reduce the same pair of values but kept two identities and two `Reduce` bodies, which is exactly how the bug in #372 arose: #219 corrected the identity for `min` and `max`, and the copies inside the fused pair were left behind. `ptp_impl` now inherits `minmax_impl` and overrides only `MapOut`, the shape `ptp_nan_impl` has always had, so the two cannot drift apart again.

The cost is that `DFloat#ptp` now pays what `minmax` pays: 327.6 to 350.2 us over 2^24 elements, 6.9%. `SFloat` is unchanged. An all-NaN `minmax` still answers `[NaN, NaN]` where numo answers `[NaN, 0.0]`; that predates this change and is the answer consistent with cumo's own `min` and `max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
