### PR TITLE
Fix a new axis before an index-backed dimension addressing out of bounds

### DIFF
--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -486,7 +486,9 @@ cumo_na_index_parse_args(VALUE args, cumo_narray_t *na, cumo_na_index_arg_t *q, 
         }
         // new dimension
         else if (v==cumo_sym_new) {
-            cumo_na_index_parse_each(v, 1, k, &q[j], at_mode);
+            // Past the last dimension, which is how the aref functions below tell
+            // a new axis from a real one.
+            cumo_na_index_parse_each(v, 1, na->ndim, &q[j], at_mode);
             j++;
         }
         // other dimension
@@ -517,6 +519,24 @@ cumo_na_get_strides_nadata(const cumo_narray_data_t *na, ssize_t *strides, ssize
 
 void cumo_na_index_aref_nadata_index_stride_kernel_launch(size_t *idx, ssize_t s1, uint64_t n);
 
+// A new axis holds one element, so any stride addresses it. Give it the size of
+// the block below it, to keep the chain cumo_na_check_ladder() walks: a break
+// there costs contiguous?, and cumo_na_flatten_dim() takes the last dimension's
+// stride as the flat one on the strength of that same chain.
+static void
+cumo_na_index_set_newaxis_strides(cumo_narray_view_t *na2, const int *newaxis, int n_newaxis, int ndim_new)
+{
+    int i, j;
+
+    for (i=n_newaxis-1; i>=0; i--) {
+        j = newaxis[i];
+        if (j+1 < ndim_new && CUMO_SDX_IS_STRIDE(na2->stridx[j+1])) {
+            CUMO_SDX_SET_STRIDE(na2->stridx[j],
+                    CUMO_SDX_GET_STRIDE(na2->stridx[j+1]) * (ssize_t)na2->base.shape[j+1]);
+        }
+    }
+}
+
 static void
 cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
                      cumo_na_index_arg_t *q, ssize_t elmsz, int ndim, int keep_dim)
@@ -527,8 +547,10 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
     ssize_t *strides_na1;
     size_t  *index;
     ssize_t beg, step;
+    int *newaxis, n_newaxis=0;
     VALUE m;
 
+    newaxis = ALLOCA_N(int, ndim);
     strides_na1 = ALLOCA_N(ssize_t, na1->base.ndim);
     cumo_na_get_strides_nadata(na1, strides_na1, elmsz);
 
@@ -556,6 +578,7 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
 
         if (orig_dim >= na1->base.ndim) {
             // new dimension
+            newaxis[n_newaxis++] = j;
             CUMO_SDX_SET_STRIDE(na2->stridx[j], elmsz);
         }
         // array index
@@ -573,6 +596,7 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
         j++;
         total *= size;
     }
+    cumo_na_index_set_newaxis_strides(na2, newaxis, n_newaxis, j);
     na2->base.size = total;
 }
 
@@ -588,6 +612,9 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
 {
     int i, j;
     ssize_t total=1;
+    int *newaxis, n_newaxis=0;
+
+    newaxis = ALLOCA_N(int, ndim);
 
     for (i=j=0; i<ndim; i++) {
         int orig_dim = q[i].orig_dim;
@@ -621,6 +648,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
 
         if (orig_dim >= na1->base.ndim) {
             // new dimension
+            newaxis[n_newaxis++] = j;
             CUMO_SDX_SET_STRIDE(na2->stridx[j], elmsz);
         }
         else if (q[i].idx != NULL && CUMO_SDX_IS_INDEX(sdx1)) {
@@ -673,6 +701,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
         j++;
         total *= size;
     }
+    cumo_na_index_set_newaxis_strides(na2, newaxis, n_newaxis, j);
     na2->base.size = total;
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1910,6 +1910,42 @@ class NArrayTest < Test::Unit::TestCase
     assert { u[true, :new, true] == [[[1, 2]], [[5, 6]], [[9, 10]]] }
   end
 
+  test "adding a new axis in front of an index-backed dimension" do
+    b = Cumo::Int32.new(4, 3).seq
+    v = b[[3, 2, 1, 0], true]
+    assert { v.to_a == [[9, 10, 11], [6, 7, 8], [3, 4, 5], [0, 1, 2]] }
+
+    assert { v[:new, true, true].shape == [1, 4, 3] }
+    assert { v[:new, true, true] == [v.to_a] }
+    assert { v[:new, false] == [v.to_a] }
+    assert { v[:new, :new, true, true] == [[v.to_a]] }
+    assert { v[:new, 0, true] == [[9, 10, 11]] }
+    assert { v[:new, true, 1] == [[10, 7, 4, 1]] }
+    assert { v[:new, 1..2, true] == [[[6, 7, 8], [3, 4, 5]]] }
+
+    w = b[true, [2, 0]]
+    assert { w[true, :new, true] == w.to_a.map { |row| [row] } }
+
+    x = b[[2, 0], [1, 2]]
+    assert { x[:new, true, true] == [x.to_a] }
+
+    c = Cumo::Int32.new(8, 3).seq
+    u = c[7.step(0, -1).to_a, true]
+    assert { u[:new, true, true] == [u.to_a] }
+
+    a = Cumo::Int32.new(4, 8).seq
+    assert { a.dot(u) == a.dot(u.dup) }
+
+    y = Cumo::Int32.new(8, 3).seq
+    y[[3, 2, 1, 0], true][:new, true, true] = Cumo::Int32.new(1, 4, 3).seq(100)
+    assert { y[0..3, true] == [[109, 110, 111], [106, 107, 108], [103, 104, 105], [100, 101, 102]] }
+    assert { y[4..7, true] == [[12, 13, 14], [15, 16, 17], [18, 19, 20], [21, 22, 23]] }
+
+    assert { b[:new, 0, true].contiguous? }
+    assert { b[:new, :new, true, true].contiguous? }
+    assert { b[true, :new, :new, true].contiguous? }
+  end
+
   test "at() rejects :new" do
     # :new leaves q[i].orig_dim == ndim, which made cumo_na_index_at_naview read
     # one element past the end of the view's stridx array. That union member was


### PR DESCRIPTION
`:new` was parsed with the number of the dimension it sits in front of, so only a trailing one was recognized as a new axis. In front of an index-backed dimension it became an index dimension of its own holding `index1[0]`, and that offset was added to every address the view produced: `victim[idx, true][:new, true, true] = x` put 252 of its 256 cells into the next allocation, and `Int32#dot` answered from memory it does not own. Pointing the new axis past the last dimension fixes that, and giving it the size of the block below keeps the chain `cumo_na_check_ladder()` walks, so `contiguous?` answers true for such a view instead of depending on which dimension the axis happened to alias.

numo has the same code and the same defect, and answers from uninitialized memory rather than from a neighbour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
