### PR TITLE
Give a length-1 axis a stride that keeps the view's stride chain

### DIFF
--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -34,6 +34,7 @@ char* cumo_na_get_offset_pointer_for_read_write(VALUE);
 void cumo_na_copy_flags(VALUE src, VALUE dst);
 
 VALUE cumo_na_check_ladder(VALUE self, int start_dim);
+void cumo_na_set_newaxis_strides(cumo_narray_view_t *na2, const int *newaxis, int n_newaxis, int ndim, ssize_t elmsz);
 VALUE cumo_na_check_contiguous(VALUE self);
 VALUE cumo_na_as_contiguous_array(VALUE a);
 

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -519,24 +519,6 @@ cumo_na_get_strides_nadata(const cumo_narray_data_t *na, ssize_t *strides, ssize
 
 void cumo_na_index_aref_nadata_index_stride_kernel_launch(size_t *idx, ssize_t s1, uint64_t n);
 
-// A new axis holds one element, so any stride addresses it. Give it the size of
-// the block below it, to keep the chain cumo_na_check_ladder() walks: a break
-// there costs contiguous?, and cumo_na_flatten_dim() takes the last dimension's
-// stride as the flat one on the strength of that same chain.
-static void
-cumo_na_index_set_newaxis_strides(cumo_narray_view_t *na2, const int *newaxis, int n_newaxis, int ndim_new)
-{
-    int i, j;
-
-    for (i=n_newaxis-1; i>=0; i--) {
-        j = newaxis[i];
-        if (j+1 < ndim_new && CUMO_SDX_IS_STRIDE(na2->stridx[j+1])) {
-            CUMO_SDX_SET_STRIDE(na2->stridx[j],
-                    CUMO_SDX_GET_STRIDE(na2->stridx[j+1]) * (ssize_t)na2->base.shape[j+1]);
-        }
-    }
-}
-
 static void
 cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
                      cumo_na_index_arg_t *q, ssize_t elmsz, int ndim, int keep_dim)
@@ -596,7 +578,7 @@ cumo_na_index_aref_nadata(cumo_narray_data_t *na1, cumo_narray_view_t *na2,
         j++;
         total *= size;
     }
-    cumo_na_index_set_newaxis_strides(na2, newaxis, n_newaxis, j);
+    cumo_na_set_newaxis_strides(na2, newaxis, n_newaxis, j, elmsz);
     na2->base.size = total;
 }
 
@@ -701,7 +683,7 @@ cumo_na_index_aref_naview(cumo_narray_view_t *na1, cumo_narray_view_t *na2,
         j++;
         total *= size;
     }
-    cumo_na_index_set_newaxis_strides(na2, newaxis, n_newaxis, j);
+    cumo_na_set_newaxis_strides(na2, newaxis, n_newaxis, j, elmsz);
     na2->base.size = total;
 }
 

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1192,6 +1192,40 @@ cumo_na_check_fortran_contiguous(VALUE self)
     return Qtrue;
 }
 
+// A length-1 axis addresses the same element whatever its stride, but one that
+// breaks the chain cumo_na_check_ladder() walks costs the view contiguous? and
+// makes cumo_na_flatten_dim() build an index array instead of taking a stride.
+// The value that keeps the chain is the size of the block below the axis, or
+// the last real dimension's stride when the axis sits at the end.
+void
+cumo_na_set_newaxis_strides(cumo_narray_view_t *na2, const int *newaxis,
+                            int n_newaxis, int ndim, ssize_t elmsz)
+{
+    int i, j, last;
+    ssize_t tail = elmsz;
+
+    if (n_newaxis == 0) {
+        return;
+    }
+    last = ndim - 1;
+    for (i=n_newaxis-1; i>=0 && newaxis[i]==last; i--) {
+        last--;
+    }
+    if (last >= 0 && CUMO_SDX_IS_STRIDE(na2->stridx[last])) {
+        tail = CUMO_SDX_GET_STRIDE(na2->stridx[last]);
+    }
+    for (i=0; i<n_newaxis; i++) {
+        CUMO_SDX_SET_STRIDE(na2->stridx[newaxis[i]], tail);
+    }
+    for (i=n_newaxis-1; i>=0; i--) {
+        j = newaxis[i];
+        if (j+1 < ndim && CUMO_SDX_IS_STRIDE(na2->stridx[j+1])) {
+            CUMO_SDX_SET_STRIDE(na2->stridx[j],
+                    CUMO_SDX_GET_STRIDE(na2->stridx[j+1]) * (ssize_t)na2->base.shape[j+1]);
+        }
+    }
+}
+
 VALUE
 cumo_na_as_contiguous_array(VALUE a)
 {
@@ -1326,6 +1360,8 @@ cumo_na_expand_dims(VALUE self, VALUE vdim)
         xfree(na2_shape);
     }
     na2->base.ndim++;
+    cumo_na_set_newaxis_strides(na2, &dim, 1, nd+1,
+            (ssize_t)cumo_na_element_stride(self));
     return view;
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -5640,6 +5640,66 @@ class NArrayTest < Test::Unit::TestCase
     assert_equal(view.size, base.flatten.eq(9.0).count_true)
   end
 
+  test "expand_dims inserts an axis that keeps the view contiguous" do
+    b = Cumo::Int32.new(4, 3).seq
+    bases = [
+      b,
+      b[1..3, true],
+      b.reverse(0),
+      Cumo::Int32.new(4, 3, 2).seq[true, true, 0],
+      b[[3, 2, 1, 0], true],
+    ]
+
+    bases.each do |x|
+      (0..x.ndim).each do |k|
+        args = ([true] * k) + [:new] + ([true] * (x.ndim - k))
+        e = x.expand_dims(k)
+        assert { e.to_a == x[*args].to_a }
+        assert { e.contiguous? == x[*args].contiguous? }
+        assert { e.fortran_contiguous? == x[*args].fortran_contiguous? }
+        assert { e.flatten.to_a == x.flatten.to_a }
+        assert { e.to_binary == x.to_binary }
+      end
+    end
+
+    assert { b.expand_dims(0).contiguous? }
+    assert { b.expand_dims(2).contiguous? }
+    assert { !b[[3, 2, 1, 0], true].expand_dims(0).contiguous? }
+    assert { b.expand_dims(-3).to_a == b.expand_dims(0).to_a }
+    assert { Cumo::Int32.cast(5).expand_dims(0).to_a == [5] }
+    assert { b.expand_dims(1).reshape!(b.size).to_a == b.flatten.to_a }
+  end
+
+  test "a length-1 axis leaves flatten on the stride path" do
+    script = <<~'RUBY'
+      require "cumo/narray"
+      pool = Cumo::CUDA::MemoryPool
+      unless pool.enabled?
+        print "no-pool"
+        exit
+      end
+      a = Cumo::Int32.new(1024, 64).seq.reverse
+      a.flatten
+      Cumo::CUDA::Runtime.cudaDeviceSynchronize
+      pool.free_all_blocks
+      costs = (0..2).flat_map do |k|
+        args = ([true] * k) + [:new] + ([true] * (2 - k))
+        [a.expand_dims(k), a[*args]].map do |v|
+          Cumo::CUDA::Runtime.cudaDeviceSynchronize
+          before = pool.total_bytes
+          v.flatten
+          Cumo::CUDA::Runtime.cudaDeviceSynchronize
+          pool.total_bytes - before
+        end
+      end
+      print costs.inspect
+    RUBY
+    lib = File.expand_path("../lib", __dir__)
+    out = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], &:read)
+    omit("memory pool is disabled") if out == "no-pool"
+    assert_equal "[0, 0, 0, 0, 0, 0]", out
+  end
+
   test "kahan_sum keeps what a plain sum loses, in parallel" do
     nan = Float::NAN
     flat = lambda do |v|


### PR DESCRIPTION
A length-1 axis addresses the same element whatever its stride, but one that breaks the chain `cumo_na_check_ladder()` walks costs the view `contiguous?` and makes `cumo_na_flatten_dim()` build an index array instead of taking a stride. `expand_dims` wrote 0 into the axis it inserts, so `a.expand_dims(1)` was reported as not contiguous and `reshape!` raised on it while `a[true, :new, true]` was fine, and #375 gave an axis at the end the element size, which breaks the chain whenever the last dimension has a different stride.

This moves the rule into `cumo_na_set_newaxis_strides()` and calls it from both places, taking the last real dimension's stride for an axis at the end. `expand_dims` and `:new` now agree on `to_a`, `contiguous?`, `fortran_contiguous?`, `flatten`, `to_binary` and `reshape!` for every insert position over data, row-sliced, reversed, strided and index-backed bases, and flattening a reversed view with a trailing axis allocates nothing where it used to allocate 512KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
