### PR TITLE
Zero fill a sub-narray that stops short in an outer axis

### DIFF
--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1938,7 +1938,7 @@ static void
 loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c, VALUE a)
 {
     int nd = lp->ndim;
-    int i, j;
+    int i, j, k;
     cumo_narray_t *na;
     int *dim_map;
     VALUE a_type;
@@ -1973,16 +1973,21 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
     // loop body
     for (i=i0;;) {
         LARG(lp,1).value = Qtrue;
+        for (k=i0; k<nd; k++) {
+            if (c[k] >= na->shape[k-i0]) {
+                LARG(lp,1).value = Qfalse;
+                break;
+            }
+        }
         for (; i<nd; i++) {
-            for (j=0; j<2; j++) {
-                if (LITER(lp,i,j).idx) {
+            for (j=0; j<lp->narg; j++) {
+                if (j==1 && c[i] >= na->shape[i-i0]) {
+                    LITER(lp,i+1,j).pos = LITER(lp,i,j).pos;
+                } else if (LITER(lp,i,j).idx) {
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).idx[c[i]];
                 } else {
                     LITER(lp,i+1,j).pos = LITER(lp,i,j).pos + LITER(lp,i,j).step*c[i];
                 }
-            }
-            if (c[i] >= na->shape[i-i0]) {
-                LARG(lp,1).value = Qfalse;
             }
         }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -6742,6 +6742,44 @@ class NArrayTest < Test::Unit::TestCase
       assert_equal([(100..107).to_a, [0] * 8, [0] * 8], d[1, true, true].to_a)
     end
 
+    test "a row shorter than the plane is zero filled along every axis" do
+      zeros = lambda { |shape| shape.size == 1 ? Array.new(shape[0], 0) : Array.new(shape[0]) { zeros.call(shape[1..]) } }
+      pad = lambda do |a, shape|
+        head = shape.size == 1 ? a : a.map { |x| pad.call(x, shape[1..]) }
+        head + Array.new(shape[0] - a.size) { shape.size == 1 ? 0 : zeros.call(shape[1..]) }
+      end
+      selections = [[0...2, true, true], [true, 0...2, true], [true, true, 0...5], [[0, 1], true, true]]
+
+      store_types.each do |dtype|
+        src = dtype.new(3, 4, 8).seq
+        selections.each do |sel|
+          row = src[*sel]
+          d = dtype.new(2, 3, 4, 8).fill(9)
+          d.store([src, row])
+          assert_equal(src.to_a, d[0, true, true, true].to_a)
+          assert_equal(pad.call(row.to_a, [3, 4, 8]), d[1, true, true, true].to_a)
+        end
+      end
+
+      bsrc = Cumo::Int32.new(3, 4, 8).seq.gt(20)
+      selections.each do |sel|
+        brow = bsrc[*sel]
+        b = Cumo::Bit.new(2, 3, 4, 8).fill(1)
+        b.store([bsrc, brow])
+        assert_equal(bsrc.to_a, b[0, true, true, true].to_a)
+        assert_equal(pad.call(brow.to_a, [3, 4, 8]), b[1, true, true, true].to_a)
+      end
+
+      deep = Cumo::Int32.new(3, 4, 2, 8).seq
+      [[true, 0...2, true, true], [true, [0, 1], true, true]].each do |sel|
+        row = deep[*sel]
+        d = Cumo::Int32.new(2, 3, 4, 2, 8).fill(9)
+        d.store([deep, row])
+        assert_equal(deep.to_a, d[0, true, true, true, true].to_a)
+        assert_equal(pad.call(row.to_a, [3, 4, 2, 8]), d[1, true, true, true, true].to_a)
+      end
+    end
+
     test "a sub-narray shorter than the row leaves the rest of it zero" do
       want = [[1, 2, 3, 0, 0, 0, 0, 0], [4, 5, 6, 0, 0, 0, 0, 0]]
       rows = [Cumo::Int32[1, 2, 3], Cumo::Int32[4, 5, 6]]


### PR DESCRIPTION
The check for a row that stops short ran inside the position loop, which resumes at whatever dimension the counter last moved, so a dimension below that one was never asked again. A row shorter in an outer axis was therefore treated as still in range, and the destination got whatever lay past the row's end instead of zeros. The check now runs before the positions advance, which also stops the walk from reading the index vector of a dimension the row does not reach.

This needs a destination of three dimensions or more, which is why #382 did not reach it. `numo-narray` 95c0525 answers the same wrong result, and `compute-sanitizer` reports an invalid device read for every dtype, not only for `Cumo::Bit` where it happened to fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
