### PR TITLE
Stop passing the sub-narray reach through the value channel

### DIFF
--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -24,29 +24,29 @@ static void
     v1 = lp->args[1].value;
     i = 0;
 
-    if (lp->args[1].ptr) {
-        if (v1 == Qtrue) {
-            // The loop counter is the destination length, but the sub-narray
-            // may be shorter. Copy only what the source actually holds, or the
-            // kernel would read past its end; the rest is zero-filled below.
-            i = lp->args[1].shape[0];
-            if (i > n) {
-                i = n;
-            }
+    if (CumoIsNArray(v1)) {
+        // shape[0] is how many elements the sub-narray offers at this row,
+        // which is zero where it does not reach. The loop counter is the
+        // destination length, so copying more would read past the row's end.
+        i = lp->args[1].shape[0];
+        if (i > n) {
+            i = n;
+        }
+        if (i > 0) {
             CUMO_NDL_CNT(lp) = i;
             iter_<%=type_name%>_store_<%=type_name%>(lp);
             CUMO_NDL_CNT(lp) = n;
-            //<% if c_iter.include? 'robject' %>
-            // The zero fill below walks from here. The kernel the other branch
-            // launches takes the offset of the first element left to fill as an
-            // argument instead, so advancing for it would count i twice.
-            if (idx1) {
-                idx1 += i;
-            } else {
-                p1 += s1 * i;
-            }
-            //<% end %>
         }
+        //<% if c_iter.include? 'robject' %>
+        // The zero fill below walks from here. The kernel the other branch
+        // launches takes the offset of the first element left to fill as an
+        // argument instead, so advancing for it would count i twice.
+        if (idx1) {
+            idx1 += i;
+        } else {
+            p1 += s1 * i;
+        }
+        //<% end %>
         goto loop_end;
     }
 

--- a/ext/cumo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_array.c
@@ -32,15 +32,15 @@ static void
     v1 = lp->args[1].value;
     i = 0;
 
-    if (lp->args[1].ptr) {
-        if (v1 == Qtrue) {
-            // The loop counter is the destination length, but the sub-narray
-            // may be shorter. Copy only what the source actually holds, or the
-            // kernel would read past its end; the rest is zero-filled below.
-            i = lp->args[1].shape[0];
-            if (i > n) {
-                i = n;
-            }
+    if (CumoIsNArray(v1)) {
+        // shape[0] is how many elements the sub-narray offers at this row,
+        // which is zero where it does not reach. The loop counter is the
+        // destination length, so copying more would read past the row's end.
+        i = lp->args[1].shape[0];
+        if (i > n) {
+            i = n;
+        }
+        if (i > 0) {
             CUMO_NDL_CNT(lp) = i;
             iter_<%=type_name%>_store_<%=type_name%>(lp);
             CUMO_NDL_CNT(lp) = n;

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -52,6 +52,7 @@ typedef struct CUMO_NA_MD_LOOP {
     int    reduce_dim;        // number of dimensions to reduce in reduction kernel, e.g., for an array of shape: [2,3,4],
                               // 3 for sum(), 1 for sum(axis: 1), 2 for sum(axis: [1,2])
     int   *trans_map;
+    size_t sub_narray_len;    // elements the sub-narray of the current row reaches with, for loop_store_subnarray
     VALUE  vargs;
     VALUE  reduce;            // dimension indicies to reduce in reduction kernel (in bits), e.g., for an array of shape:
                               // [2,3,4], 111b for sum(), 010b for sum(axis: 1), 110b for sum(axis: [1,2])
@@ -1939,8 +1940,7 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
 {
     int nd = lp->ndim;
     int i, j;
-    int empty;
-    int *reach;
+    bool *reach;
     cumo_narray_t *na;
     int *dim_map;
     size_t *saved_shape = LARG(lp,1).shape;
@@ -1968,16 +1968,15 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
     }
     ndloop_set_stepidx(lp, 1, a, dim_map, CUMO_NDL_READ);
     LITER(lp,i0,1).pos = LITER(lp,0,1).pos;
-    LARG(lp,1).shape = &(na->shape[na->ndim-1]);
+    LARG(lp,1).shape = &lp->sub_narray_len;
 
     // The sub-narray binds its own index array here, after the entry point
     // looked, so the wait for the kernel that filled it belongs here too.
     ndloop_sync_md_index(lp);
 
     // loop body
-    empty = (CUMO_NA_SIZE(na) == 0);
-    reach = ALLOCA_N(int, nd+1);
-    reach[i0] = 1;
+    reach = ALLOCA_N(bool, nd+1);
+    reach[i0] = true;
     for (i=i0;;) {
         for (; i<nd; i++) {
             reach[i+1] = reach[i] && (c[i] < na->shape[i-i0]);
@@ -1991,7 +1990,7 @@ loop_store_subnarray(cumo_ndfunc_t *nf, cumo_na_md_loop_t *lp, int i0, size_t *c
                 }
             }
         }
-        LARG(lp,1).value = empty ? Qnil : (reach[nd] ? Qtrue : Qfalse);
+        lp->sub_narray_len = reach[nd] ? na->shape[na->ndim-1] : 0;
 
         (*(nf->func))(&(lp->user));
 


### PR DESCRIPTION
`loop_store_subnarray` told the store templates whether a row was reached by putting `Qtrue`, `Qfalse` or `Qnil` into `LARG(lp,1).value`. The templates then had to tell that flag from a real value, which they did by testing the row's pointer. That test is wrong for a sub-narray with no elements, which is why #384 had to hand those rows `nil` instead.

The row now says how many elements it offers through `shape[0]`, which the templates already read, and zero says it does not reach. `LARG(lp,1).value` keeps the sub-narray, so the gate is `CumoIsNArray` and the cast temporary has an owner for as long as the loop runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
