### PR TITLE
Store binary data through a view instead of over its base

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1697,14 +1697,29 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "string is too short to store");
     }
 
-    if (OBJ_FROZEN(vstr)) {
+    // Holding the string instead of copying it replaces the whole buffer,
+    // which is only self's to replace when self is that buffer.
+    if (OBJ_FROZEN(vstr) && CUMO_NA_TYPE(na) == CUMO_NARRAY_DATA_T) {
         cumo_na_set_pointer(self, RSTRING_PTR(vstr)+offset, byte_size);
         rb_ivar_set(self, cumo_id_source, vstr);
     } else {
-        void *ptr = cumo_na_get_pointer_for_write(self);
+        char *ptr = cumo_na_get_pointer_for_write(self);
+        if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+            // Whole bytes from one address reach the view's own elements only
+            // if it walks its base in order and, for Bit, begins and ends on a
+            // byte. Contiguity is also what keeps an index list, which can name
+            // more elements than the base holds, away from the copy below.
+            if (cumo_na_check_contiguous(self) != Qtrue) {
+                rb_raise(rb_eArgError, "cannot store binary data into a non-contiguous view");
+            }
+            if (RTEST(rb_obj_is_kind_of(self, cumo_cBit)) &&
+                (CUMO_NA_VIEW_OFFSET(na) != 0 || size % 8 != 0)) {
+                rb_raise(rb_eArgError, "cannot store binary data into a bit view that does not begin and end on a byte");
+            }
+        }
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_store_binary", "any");
         cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-        memcpy(ptr, RSTRING_PTR(vstr)+offset, byte_size);
+        memcpy(ptr+cumo_na_get_offset(self), RSTRING_PTR(vstr)+offset, byte_size);
     }
 
     return SIZET2NUM(byte_size);

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -823,4 +823,32 @@ class BitTest < Test::Unit::TestCase
     assert { Process.last_status.success? }
     assert_equal("swap_byte,hton,to_network,to_swapped", reader.value)
   end
+
+  test "store_binary on a bit view that does not start at bit 0 is refused" do
+    a = Cumo::Bit.new(16).fill(0)
+    assert_raise(ArgumentError) { a[8..15].store_binary("\xFF".b) }
+    assert_equal 0, Integer(a.count_true)
+  end
+
+  # A byte is the smallest thing memcpy moves, so a view ending mid-byte would
+  # take the bits after it along, and those belong to the rest of the base.
+  test "store_binary on a bit view that ends mid-byte is refused" do
+    a = Cumo::Bit.new(16).fill(0)
+    assert_raise(ArgumentError) { a[0..3].store_binary("\xFF".b) }
+    assert_raise(ArgumentError) { a[0..11].store_binary("\xFF\xFF".b) }
+    assert_equal 0, Integer(a.count_true)
+  end
+
+  test "store_binary fills a whole byte of a bit view" do
+    a = Cumo::Bit.new(16).fill(0)
+    a[0..7].store_binary("\xFF".b)
+    assert_equal 8, Integer(a.count_true)
+    assert_equal "1111111100000000", a.to_a.join
+  end
+
+  test "store_binary fills a whole bit array" do
+    a = Cumo::Bit.new(8).fill(0)
+    a[true].store_binary("\xFF".b)
+    assert_equal 8, Integer(a.count_true)
+  end
 end

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -1496,6 +1496,51 @@ class NArrayTest < Test::Unit::TestCase
           assert_raise(TypeError) { a.store_binary(bad) }
         end
       end
+
+      test "a view is written at its own offset" do
+        a = dtype.new(8).seq
+        a[4..5].store_binary(dtype[9, 9].to_binary)
+        assert_equal dtype[0, 1, 2, 3, 9, 9, 6, 7].to_a, a.to_a
+      end
+
+      test "a frozen string is copied into a view instead of replacing the base" do
+        a = dtype.new(8).seq
+        a[4..5].store_binary(dtype[7, 7].to_binary.freeze)
+        assert_equal dtype[0, 1, 2, 3, 7, 7, 6, 7].to_a, a.to_a
+        assert_equal 8 * dtype::ELEMENT_BYTE_SIZE, a.to_binary.bytesize
+      end
+
+      test "a non-contiguous view is refused" do
+        a = dtype.new(8).seq
+        assert_raise(ArgumentError) do
+          a[(0..7).step(2)].store_binary(dtype[9, 9, 9, 9].to_binary)
+        end
+        assert_equal dtype.new(8).seq.to_a, a.to_a
+      end
+
+      test "an index view, which can name more elements than its base holds, is refused" do
+        a = dtype.new(1).seq
+        v = a[[0] * 4096]
+        assert_false v.contiguous?
+        error = assert_raise(ArgumentError) do
+          v.store_binary("\xAA".b * (4096 * dtype::ELEMENT_BYTE_SIZE))
+        end
+        assert_equal "cannot store binary data into a non-contiguous view", error.message
+        assert_equal dtype.new(1).seq.to_a, a.to_a
+      end
+
+      test "a zero-dimensional view is written at its own element" do
+        a = dtype.new(4).seq
+        a[2].store_binary(dtype[42].to_binary)
+        assert_equal dtype[0, 1, 42, 3].to_a, a.to_a
+      end
+
+      test "freezing is reported before the shape of the view is" do
+        a = dtype.new(8).seq
+        v = a[(0..7).step(2)]
+        v.freeze
+        assert_raise(RuntimeError) { v.store_binary(dtype[9, 9, 9, 9].to_binary) }
+      end
     end
   end
 


### PR DESCRIPTION
`store_binary` sized the copy from the view but wrote it at the start of the base, so `a[4..5].store_binary` landed on `a[0..1]`. An index list can name more elements than the base holds, and that same size then bounded nothing: 32768 bytes went into an 8 byte array and it reported success. A frozen string was worse, since holding it instead of copying replaced the base's whole buffer with one the size of the view.

A view now takes the offset it walks its base from, which only lines up when it is contiguous, so the ones that are not are refused. A frozen string is copied whenever `self` is a view. A bit view is refused unless it begins and ends on a byte, since a byte is the smallest thing `memcpy` moves and the bits past its end belong to the rest of the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
