### PR TITLE
Count every wait for the device, not only the index reader's own

### DIFF
--- a/ext/cumo/cuda/runtime.c
+++ b/ext/cumo/cuda/runtime.c
@@ -10,6 +10,8 @@ VALUE cumo_cuda_mRuntime;
 
 #define check_status(status) (cumo_cuda_runtime_check_status((status)))
 
+uint64_t cumo_cuda_runtime_sync_epoch = 0;
+
 // Called right after a <<<>>> launch. cudaGetLastError() reports errors the
 // launch itself was rejected for; a fault while the kernel runs is asynchronous
 // and still surfaces at a later call.
@@ -42,7 +44,7 @@ cumo_cuda_runtime_error_flag_new(void)
 bool
 cumo_cuda_runtime_error_flag_get(int *flag)
 {
-    check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     return (*flag != 0);
 }
 
@@ -189,9 +191,7 @@ rb_cudaSetDevice(VALUE self, VALUE device)
 static VALUE
 rb_cudaDeviceSynchronize(VALUE self)
 {
-    cudaError_t status;
-    status = cudaDeviceSynchronize();
-    check_status(status);
+    cumo_cuda_runtime_device_synchronize();
     return Qnil;
 }
 

--- a/ext/cumo/include/cumo/cuda/runtime.h
+++ b/ext/cumo/include/cumo/cuda/runtime.h
@@ -13,12 +13,24 @@ extern "C" {
 
 extern VALUE cumo_cuda_eRuntimeError;
 
+// Counts the times the device has been waited to idle. Anything queued before
+// one of those has finished by the time the next starts, which is what lets a
+// reader of something the device filled skip a wait of its own.
+extern uint64_t cumo_cuda_runtime_sync_epoch;
+
 static inline void
 cumo_cuda_runtime_check_status(cudaError_t status)
 {
     if (status != 0) {
         rb_raise(cumo_cuda_eRuntimeError, "%s (error=%d)", cudaGetErrorString(status), status);
     }
+}
+
+static inline void
+cumo_cuda_runtime_device_synchronize(void)
+{
+    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_sync_epoch++;
 }
 
 static inline int

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -77,7 +77,7 @@ iter_copy_bytes(cumo_na_loop_t *const lp)
     // with nothing ordering that against the host reading it back.
     if (idx1 || idx2) {
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("copy", "any");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
     }
     e = lp->args[0].elmsz;
     LOOP_UNARY_PTR(lp,m_memcpy);

--- a/ext/cumo/narray/gen/tmpl/accum.c
+++ b/ext/cumo/narray/gen/tmpl/accum.c
@@ -23,7 +23,7 @@ static void
         p2 = lp->args[1].ptr + lp->args[1].iter[0].pos;
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         *(<%=dtype%>*)p2 = f_<%=name%><%=nan%>(n,p1,s1);
     }
     //<% elsif !indexer_ops.include?(name) %>

--- a/ext/cumo/narray/gen/tmpl/accum_arg.c
+++ b/ext/cumo/narray/gen/tmpl/accum_arg.c
@@ -20,7 +20,7 @@ static void
         o_ptr = CUMO_NDL_PTR(lp,1);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         idx = f_<%=name[3..5]%>_index<%=nan%>(n,d_ptr,d_step);
         *(idx_t*)o_ptr = (idx_t)idx;
     }

--- a/ext/cumo/narray/gen/tmpl/accum_index.c
+++ b/ext/cumo/narray/gen/tmpl/accum_index.c
@@ -21,7 +21,7 @@ static void
         o_ptr = CUMO_NDL_PTR(lp,2);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=nan%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         idx = f_<%=name%><%=nan%>(n,d_ptr,d_step);
         *(idx_t*)o_ptr = *(idx_t*)(i_ptr + i_step * idx);
     }

--- a/ext/cumo/narray/gen/tmpl/allocate.c
+++ b/ext/cumo/narray/gen/tmpl/allocate.c
@@ -48,7 +48,7 @@ static VALUE
                 // Callers that read on the host synchronize before they ask for
                 // the pointer, which is before this fill was even launched.
                 CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("allocate", "<%=type_name%>");
-                cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+                cumo_cuda_runtime_device_synchronize();
             }
         }
         <% end %>

--- a/ext/cumo/narray/gen/tmpl/aref_cpu.c
+++ b/ext/cumo/narray/gen/tmpl/aref_cpu.c
@@ -44,7 +44,7 @@ static VALUE
     } else {
         ptr = cumo_na_get_pointer_for_read(self) + pos;
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         return m_extract(ptr);
     }
 }

--- a/ext/cumo/narray/gen/tmpl/clip.c
+++ b/ext/cumo/narray/gen/tmpl/clip.c
@@ -24,7 +24,7 @@ static void
         CUMO_INIT_PTR(lp, 3, p4, s4);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         for (i=n; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
@@ -69,7 +69,7 @@ static void
         CUMO_INIT_PTR(lp, 2, p3, s3);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_min", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         for (i=n; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             CUMO_GET_DATA_STRIDE(p2,s2,dtype,min);
@@ -105,7 +105,7 @@ static void
         CUMO_INIT_PTR(lp, 2, p3, s3);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>_max", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         for (i=n; i--;) {
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             CUMO_GET_DATA_STRIDE(p2,s2,dtype,max);

--- a/ext/cumo/narray/gen/tmpl/cond_unary.c
+++ b/ext/cumo/narray/gen/tmpl/cond_unary.c
@@ -20,7 +20,7 @@ static void
         CUMO_INIT_PTR_IDX(lp, 0, p1, s1, idx1);
         CUMO_INIT_PTR_BIT(lp, 1, a2, p2, s2);
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx1) {
             for (i=0; i<n; i++) {
                 CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);

--- a/ext/cumo/narray/gen/tmpl/cum.c
+++ b/ext/cumo/narray/gen/tmpl/cum.c
@@ -26,7 +26,7 @@ static void
   <% end %>
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
 <% if is_half && name == 'cumsum' %>
     // The scan this stands in for carries float, and a running sum of halves

--- a/ext/cumo/narray/gen/tmpl/each.c
+++ b/ext/cumo/narray/gen/tmpl/each.c
@@ -14,14 +14,14 @@ static void
 
     if (idx1) {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
             y = m_data_to_num(x);
             rb_yield(y);
         }
     } else {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             y = m_data_to_num(x);
             rb_yield(y);

--- a/ext/cumo/narray/gen/tmpl/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/each_with_index.c
@@ -36,14 +36,14 @@ static void
 
     if (idx1) {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
             yield_each_with_index(x,c,a,nd,md);
             c[nd]++;
         }
     } else {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
             yield_each_with_index(x,c,a,nd,md);
             c[nd]++;

--- a/ext/cumo/narray/gen/tmpl/extract_cpu.c
+++ b/ext/cumo/narray/gen/tmpl/extract_cpu.c
@@ -17,7 +17,7 @@ static VALUE
     if (na->ndim==0) {
         ptr = cumo_na_get_pointer_for_read(self) + cumo_na_get_offset(self);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         v = m_extract(ptr);
         cumo_na_release_lock(self);
         return v;

--- a/ext/cumo/narray/gen/tmpl/extract_data.c
+++ b/ext/cumo/narray/gen/tmpl/extract_data.c
@@ -12,7 +12,7 @@ static dtype
     VALUE  r, klass;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     if (CumoIsNArray(obj)) {
         CumoGetNArray(obj,na);

--- a/ext/cumo/narray/gen/tmpl/fill.c
+++ b/ext/cumo/narray/gen/tmpl/fill.c
@@ -19,7 +19,7 @@ static void
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         // The index array is filled by a kernel; wait for it before reading it
         // from here.
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx1) {
             for (; i--;) {
                 CUMO_SET_DATA_INDEX(p1,idx1,dtype,y);

--- a/ext/cumo/narray/gen/tmpl/format.c
+++ b/ext/cumo/narray/gen/tmpl/format.c
@@ -65,6 +65,6 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP_NIP, 2, 1, ain, aout };
 
     rb_scan_args(argc, argv, "01", &fmt);
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     return cumo_na_ndloop(&ndf, 2, self, fmt);
 }

--- a/ext/cumo/narray/gen/tmpl/format_to_a.c
+++ b/ext/cumo/narray/gen/tmpl/format_to_a.c
@@ -44,6 +44,6 @@ static VALUE
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP_NIP, 3, 1, ain, aout };
 
     rb_scan_args(argc, argv, "01", &fmt);
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     return cumo_na_ndloop_cast_narray_to_rarray(&ndf, self, fmt);
 }

--- a/ext/cumo/narray/gen/tmpl/inspect.c
+++ b/ext/cumo/narray/gen/tmpl/inspect.c
@@ -17,6 +17,6 @@ static VALUE
 <%=c_func(0)%>(VALUE ary)
 {
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     return cumo_na_ndloop_inspect(ary, <%=c_iter%>, Qnil);
 }

--- a/ext/cumo/narray/gen/tmpl/map_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/map_with_index.c
@@ -35,7 +35,7 @@ static void
     CUMO_INIT_PTR_IDX(lp, 1, p2, s2, idx2);
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     c[nd] = 0;
     if (idx1) {

--- a/ext/cumo/narray/gen/tmpl/median.c
+++ b/ext/cumo/narray/gen/tmpl/median.c
@@ -36,7 +36,7 @@ static void
     buf = (dtype*)p1;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     <%=type_name%>_qsort<%=j%>(buf, n, sizeof(dtype));
 
     <% if is_float %>

--- a/ext/cumo/narray/gen/tmpl/minmax.c
+++ b/ext/cumo/narray/gen/tmpl/minmax.c
@@ -20,7 +20,7 @@ static void
         CUMO_INIT_PTR(lp, 0, p1, s1);
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%><%=j%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         f_<%=name%><%=j%>(n,p1,s1,&xmin,&xmax);
 
         *(dtype*)(lp->args[1].ptr + lp->args[1].iter[0].pos) = xmin;

--- a/ext/cumo/narray/gen/tmpl/poly.c
+++ b/ext/cumo/narray/gen/tmpl/poly.c
@@ -27,7 +27,7 @@ static void
     dtype  x, y, a;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     n = lp->narg - 2;
     x = *(dtype*)CUMO_NDL_PTR(lp,0);
     y = *(dtype*)CUMO_NDL_PTR(lp,n);

--- a/ext/cumo/narray/gen/tmpl/qsort.c
+++ b/ext/cumo/narray/gen/tmpl/qsort.c
@@ -126,7 +126,7 @@ static void
         r,
         swaptype,
         presorted;
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
  loop:SWAPINIT(a, es);
     if (n < 7)

--- a/ext/cumo/narray/gen/tmpl/rand.c
+++ b/ext/cumo/narray/gen/tmpl/rand.c
@@ -107,7 +107,7 @@ static void
         dtype x;
 
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx1) {
             for (; i--;) {
                 x = m_add(<%=m_rand%>,low);

--- a/ext/cumo/narray/gen/tmpl/sort.c
+++ b/ext/cumo/narray/gen/tmpl/sort.c
@@ -42,7 +42,7 @@ static void
     CUMO_INIT_COUNTER(lp, n);
     CUMO_INIT_PTR(lp, 0, ptr, step);
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     <%=type_name%>_qsort<%=j%>(ptr, n, step);
 }
 <% end %>

--- a/ext/cumo/narray/gen/tmpl/sort_index.c
+++ b/ext/cumo/narray/gen/tmpl/sort_index.c
@@ -154,7 +154,7 @@ static VALUE
     buf = rb_alloc_tmp_buffer(&tmp, size);
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cudaDeviceSynchronize();
+    cumo_cuda_runtime_device_synchronize();
 
     res = cumo_na_ndloop3(&ndf, buf, 3, self, idx, reduce);
     rb_free_tmp_buffer(&tmp);

--- a/ext/cumo/narray/gen/tmpl/store_array.c
+++ b/ext/cumo/narray/gen/tmpl/store_array.c
@@ -63,7 +63,7 @@ static void
     //<% if c_iter.include? 'robject' %>
     {
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("store_<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
 
         if (idx1) {
             for (i=i1=0; i1<n1 && i<n; i1++) {

--- a/ext/cumo/narray/gen/tmpl/store_bit.c
+++ b/ext/cumo/narray/gen/tmpl/store_bit.c
@@ -23,7 +23,7 @@ static void
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         // The index arrays are filled by a kernel; wait for it before reading
         // them from here.
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx2) {
             if (idx1) {
                 for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl/store_from.c
+++ b/ext/cumo/narray/gen/tmpl/store_from.c
@@ -34,7 +34,7 @@ static void
     // until that has finished. Cumo::RObject is the only dtype whose loop runs
     // on the host and still sees the index; every other one hands it to a
     // kernel of its own, which the stream already orders.
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     {
         <%=dtype%> x;
         dtype y;

--- a/ext/cumo/narray/gen/tmpl/to_a.c
+++ b/ext/cumo/narray/gen/tmpl/to_a.c
@@ -38,6 +38,6 @@ static VALUE
     cumo_ndfunc_arg_out_t aout[1] = {{rb_cArray,0}}; // dummy?
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP_NIP, 3, 1, ain, aout };
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     return cumo_na_ndloop_cast_narray_to_rarray(&ndf, self, Qnil);
 }

--- a/ext/cumo/narray/gen/tmpl/unary.c
+++ b/ext/cumo/narray/gen/tmpl/unary.c
@@ -109,7 +109,7 @@ static VALUE
     <% end %>
 
     <% if name == 'map' %>
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     <% end %>
     return cumo_na_ndloop(&ndf, 1, self);
 }

--- a/ext/cumo/narray/gen/tmpl/unary2.c
+++ b/ext/cumo/narray/gen/tmpl/unary2.c
@@ -20,7 +20,7 @@ static void
         dtype x;
         <%=dtype%> y;
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx1) {
             if (idx2) {
                 for (i=0; i<n; i++) {

--- a/ext/cumo/narray/gen/tmpl/unary_s.c
+++ b/ext/cumo/narray/gen/tmpl/unary_s.c
@@ -18,7 +18,7 @@ static void
         CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
         // The index arrays are filled by a kernel; wait for it before reading
         // them from here.
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         if (idx1) {
             if (idx2) {
                 for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl_bit/aref_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/aref_cpu.c
@@ -50,7 +50,7 @@ static VALUE
     } else {
         ptr = cumo_na_get_pointer_for_read(self);
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         CUMO_LOAD_BIT(ptr,pos,x);
         return m_data_to_num(x);
     }

--- a/ext/cumo/narray/gen/tmpl_bit/bit_count_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/bit_count_cpu.c
@@ -14,7 +14,7 @@ static void
     int_t   y;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);

--- a/ext/cumo/narray/gen/tmpl_bit/each.c
+++ b/ext/cumo/narray/gen/tmpl_bit/each.c
@@ -12,7 +12,7 @@ static void
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     if (idx1) {
         for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
@@ -37,14 +37,14 @@ static void
 
     if (idx1) {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_LOAD_BIT(a1, p1+*idx1, x); idx1++;
             yield_each_with_index(x,c,a,nd,md);
             c[nd]++;
         }
     } else {
         for (; i--;) {
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             CUMO_LOAD_BIT(a1, p1, x); p1+=s1;
             yield_each_with_index(x,c,a,nd,md);
             c[nd]++;

--- a/ext/cumo/narray/gen/tmpl_bit/extract_cpu.c
+++ b/ext/cumo/narray/gen/tmpl_bit/extract_cpu.c
@@ -19,7 +19,7 @@ static VALUE
         ptr = (CUMO_BIT_DIGIT*)cumo_na_get_pointer_for_read(self);
 
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
 
         {
             // Reading through the managed pointer faults the whole page back from

--- a/ext/cumo/narray/gen/tmpl_bit/format.c
+++ b/ext/cumo/narray/gen/tmpl_bit/format.c
@@ -23,7 +23,7 @@ static void
     VALUE  fmt = lp->option;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);

--- a/ext/cumo/narray/gen/tmpl_bit/format_to_a.c
+++ b/ext/cumo/narray/gen/tmpl_bit/format_to_a.c
@@ -44,7 +44,7 @@ static VALUE
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP_NIP, 3,1, ain,aout};
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     rb_scan_args(argc, argv, "01", &fmt);
     return cumo_na_ndloop_cast_narray_to_rarray(&ndf, self, fmt);

--- a/ext/cumo/narray/gen/tmpl_bit/inspect.c
+++ b/ext/cumo/narray/gen/tmpl_bit/inspect.c
@@ -15,7 +15,7 @@ static VALUE
 <%=c_func(0)%>(VALUE ary)
 {
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     return cumo_na_ndloop_inspect(ary, <%=c_iter%>, Qnil);
 }

--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -30,7 +30,7 @@ static void
     }
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     if (idx1) {
         if (idx2) {

--- a/ext/cumo/narray/gen/tmpl_bit/store_from.c
+++ b/ext/cumo/narray/gen/tmpl_bit/store_from.c
@@ -15,7 +15,7 @@ static void
     CUMO_BIT_DIGIT  y;
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("store_<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);

--- a/ext/cumo/narray/gen/tmpl_bit/to_a.c
+++ b/ext/cumo/narray/gen/tmpl_bit/to_a.c
@@ -10,7 +10,7 @@ static void
     VALUE      a, y;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);

--- a/ext/cumo/narray/gen/tmpl_bit/where.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where.c
@@ -59,7 +59,7 @@ static void
     }
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     if (idx) {
         for (; i--;) {

--- a/ext/cumo/narray/gen/tmpl_bit/where2.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where2.c
@@ -27,7 +27,7 @@ static void
     }
 
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("<%=name%>", "<%=type_name%>");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     if (idx) {
         for (; i--;) {

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -107,36 +107,33 @@ cumo_na_range_check(ssize_t pos, ssize_t size, int dim)
 
 // A view's index arrays are written once, by the kernels that build the view,
 // and never again, so a host read of one entry has to wait for those and for
-// nothing else. cudaDeviceSynchronize is the only way to ask, and it waits for
-// everything queued: a scalar read of a[idx, true] cost 70us behind twenty
-// kernels, against 0.2us for the same read on a view built from a range.
+// nothing else. Waiting for the device to idle is the only way to ask, and it
+// waits for everything queued: a scalar read of a[idx, true] cost 70us behind
+// twenty kernels, against 0.2us for the same read on a view built from a range.
 //
-// What it does give is that one of them settles every view built before it. So
-// count them, have a view remember the count its fills were issued at, and skip
-// the wait once the count has moved on. A view whose count is unknown waits as
-// it did before, which is what makes missing a place that builds one cost speed
+// What it does give is that one of them settles every view built before it, so
+// a view that remembers the count its fills were issued at can skip the wait
+// once the count has moved on. A view whose count is unknown waits as it did
+// before, which is what makes missing a place that builds one cost speed
 // rather than correctness.
-static uint64_t cumo_na_sync_epoch = 0;
-
 void
 cumo_na_index_mark_filled(cumo_narray_view_t *nv)
 {
-    nv->index_sync_epoch = cumo_na_sync_epoch;
+    nv->index_sync_epoch = cumo_cuda_runtime_sync_epoch;
 }
 
 void
 cumo_na_index_wait_fill(cumo_narray_view_t *nv)
 {
-    if (nv->index_sync_epoch < cumo_na_sync_epoch) {
+    if (nv->index_sync_epoch < cumo_cuda_runtime_sync_epoch) {
         return;
     }
     CUMO_SHOW_SYNCHRONIZE_FIXME_WARNING_ONCE("index", "cumo_na_index_wait_fill");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    cumo_na_sync_epoch++;
+    cumo_cuda_runtime_device_synchronize();
     // This view is settled now whatever its constructor recorded. Without
     // saying so, one that recorded nothing waits again on every read, and
     // once per index dimension within a read.
-    nv->index_sync_epoch = cumo_na_sync_epoch - 1;
+    nv->index_sync_epoch = cumo_cuda_runtime_sync_epoch - 1;
 }
 
 // copy ruby array to idx

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1374,7 +1374,7 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
                 if (cumo_na_test_reduce(reduce,i)) {
                     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_reverse", "any");
-                    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+                    cumo_cuda_runtime_device_synchronize();
                     for (j=0; j<n; j++) {
                         idx2[n-1-j] = idx1[j];
                     }
@@ -1554,7 +1554,7 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
     // host write into managed memory does not wait for the stream. to_binary
     // synchronizes for the same reason on the way out.
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_s_from_binary", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
     memcpy(ptr, RSTRING_PTR(vstr), byte_size);
 
     return vna;
@@ -1632,7 +1632,7 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
 
     if (byte_size > 0) {
         CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_store_binary", "any");
-        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        cumo_cuda_runtime_device_synchronize();
         memcpy(ptr+cumo_na_get_offset(self), RSTRING_PTR(vstr)+offset, byte_size);
     }
 
@@ -1669,7 +1669,7 @@ cumo_na_to_binary(VALUE self)
     // After the dup above, not before it: the copy is a kernel and the string
     // is built by reading its result from the host.
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_to_binary", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     ptr = cumo_na_get_pointer_for_read(self);
     str = rb_usascii_str_new(ptr+offset,len);
@@ -1688,7 +1688,7 @@ cumo_na_marshal_dump(VALUE self)
     VALUE a;
 
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_marshal_dump", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 
     a = rb_ary_new();
     rb_ary_push(a, INT2FIX(1));     // version

--- a/ext/cumo/narray/ndloop.c
+++ b/ext/cumo/narray/ndloop.c
@@ -1273,7 +1273,7 @@ ndloop_sync_src_index(cumo_na_buffer_copy_t *lp)
     for (i=0; i<lp->ndim; i++) {
         if (LITER_SRC(lp,i).idx) {
             CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop buffer copy", "any");
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             return;
         }
     }
@@ -1291,7 +1291,7 @@ ndloop_sync_user_index(cumo_na_md_loop_t *lp)
             if (LARG(lp,j).iter[i].idx == NULL) continue;
             if (cumo_cuda_runtime_is_device_memory(LARG(lp,j).ptr)) break;
             CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop", "any");
-            cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+            cumo_cuda_runtime_device_synchronize();
             return;
         }
     }
@@ -1525,7 +1525,7 @@ static void
 ndloop_sync_device(void)
 {
     CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("ndloop", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+    cumo_cuda_runtime_device_synchronize();
 }
 
 static void


### PR DESCRIPTION
`cumo_na_index_wait_fill` skips its wait when the device has settled since the index was filled, which it knows from a count it kept itself. It was the only place raising that count, so the sixty other settles the library performs went unrecorded and a reader waited again right behind one of them.

All of them go through `cumo_cuda_runtime_device_synchronize` now, which raises a count the runtime owns. Reading a fresh index view with a `to_a` or an `inspect` in between drops from twenty waits over twenty reads to none.

**It does not show in wall clock.** A view that needs the wait costs several hundred microseconds to build, far more than the wait it saves, and the difference stayed inside the run to run spread. The reason to make the change is that the count now means what it says, which is also what a per-row reader of it would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
