### PR TITLE
Refuse an allocate that leaves the array without the buffer it promised

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -429,6 +429,13 @@ cumo_na_new(VALUE klass, int ndim, size_t *shape)
     volatile VALUE obj;
 
     obj = rb_funcall(klass, cumo_id_allocate, 0);
+    // allocate is a Ruby method and can hand back an array that already holds
+    // data. Taking a shape only rewrites the size, so that one would keep a
+    // buffer laid out for the shape it had.
+    if (!CumoIsNArray(obj) || CUMO_RNARRAY_TYPE(obj) != CUMO_NARRAY_DATA_T ||
+        CUMO_NA_DATA_PTR(CUMO_RNARRAY(obj)) != NULL) {
+        rb_raise(rb_eRuntimeError, "allocate did not return a new NArray");
+    }
     cumo_na_setup(obj, ndim, shape);
     return obj;
 }
@@ -632,6 +639,30 @@ cumo_na_s_eye(int argc, VALUE *argv, VALUE klass)
 #define READ 1
 #define WRITE 2
 
+// What was allocated, measured by the type rather than by the class's
+// ELEMENT_BYTE_SIZE, which a subclass can define as anything. A view keeps its
+// own count and takes the element size from the array it reads.
+static size_t
+cumo_na_honest_byte_size(VALUE self)
+{
+    const cumo_narray_type_info_t *info;
+    cumo_narray_t *na;
+    VALUE obj = self;
+
+    CumoGetNArray(self,na);
+    if (na->size == 0) {
+        return 0;
+    }
+    if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
+        obj = CUMO_NA_VIEW_DATA(na);
+    }
+    info = (const cumo_narray_type_info_t *)(RTYPEDDATA_TYPE(obj)->data);
+    if (info->element_bits > 0) {
+        return ((na->size-1)/8/sizeof(CUMO_BIT_DIGIT)+1)*sizeof(CUMO_BIT_DIGIT);
+    }
+    return na->size * info->element_bytes;
+}
+
 // Byte size of the data buffer self owns, the same expression allocate() sized
 // it with.
 size_t
@@ -751,6 +782,12 @@ cumo_na_get_pointer_for_rw(VALUE self, int flag)
             if (flag & (READ|WRITE)) {
                 rb_funcall(self, cumo_id_allocate, 0);
                 ptr = CUMO_NA_DATA_PTR(na);
+                // allocate is a Ruby method, so it is free to return without
+                // taking a buffer. Every caller here goes on to read or write
+                // through what it hands back.
+                if (ptr == NULL) {
+                    rb_raise(rb_eRuntimeError, "allocate left the NArray without data");
+                }
             }
         }
         return ptr;
@@ -1549,13 +1586,24 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
 
     vna = cumo_na_new(type, nd, shape);
     ptr = cumo_na_get_pointer_for_write(vna);
+    // Taking the pointer runs allocate, which is a Ruby method a subclass can
+    // define, and it can give the array another shape or empty the string.
+    // Both were measured before it ran.
+    if (CUMO_RNARRAY_SIZE(vna) != len || (size_t)RSTRING_LEN(vstr) < byte_size) {
+        rb_raise(rb_eRuntimeError, "NArray or string changed while reading binary data");
+    }
+    if (byte_size > cumo_na_honest_byte_size(vna)) {
+        rb_raise(rb_eArgError, "string is too long to store");
+    }
 
     // The pool hands back chunks a still-running kernel may be writing, and a
     // host write into managed memory does not wait for the stream. to_binary
     // synchronizes for the same reason on the way out.
-    CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_s_from_binary", "any");
-    cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
-    memcpy(ptr, RSTRING_PTR(vstr), byte_size);
+    if (byte_size > 0) {
+        CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("cumo_na_s_from_binary", "any");
+        cumo_cuda_runtime_check_status(cudaDeviceSynchronize());
+        memcpy(ptr, RSTRING_PTR(vstr), byte_size);
+    }
 
     return vna;
 }
@@ -1614,6 +1662,9 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
     // Both were measured before it ran.
     if (CUMO_NA_SIZE(na) != size || (size_t)RSTRING_LEN(vstr) < offset + byte_size) {
         rb_raise(rb_eRuntimeError, "NArray or string changed while storing binary data");
+    }
+    if (byte_size > cumo_na_honest_byte_size(self)) {
+        rb_raise(rb_eArgError, "string is too long to store");
     }
 
     if (CUMO_NA_TYPE(na) == CUMO_NARRAY_VIEW_T) {
@@ -1764,11 +1815,17 @@ cumo_na_marshal_load(VALUE self, VALUE a)
         if (TYPE(v) != T_ARRAY) {
             rb_raise(rb_eArgError,"RObject content should be array");
         }
-        CumoGetNArray(self,na);
         if (RARRAY_LEN(v) != (long)CUMO_NA_SIZE(na)) {
             rb_raise(rb_eArgError,"RObject content size mismatch");
         }
         ptr = cumo_na_get_pointer_for_write(self);
+        // Again after the pointer: taking one runs allocate, and a singleton
+        // method there can reshape the array or empty the content. The check
+        // above stays so a payload that never fits is refused before a buffer
+        // is taken for it.
+        if (RARRAY_LEN(v) != (long)CUMO_NA_SIZE(na)) {
+            rb_raise(rb_eArgError,"RObject content size mismatch");
+        }
         memcpy(ptr, RARRAY_PTR(v), CUMO_NA_SIZE(na)*sizeof(VALUE));
     } else {
         Check_Type(v, T_STRING);

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -2866,34 +2866,110 @@ class NArrayTest < Test::Unit::TestCase
     assert_raise(ArgumentError) { Cumo::DComplex.new(2**60).store_binary(("A" * 4096).freeze) }
   end
 
-  # Taking the pointer runs allocate, and a subclass can define it. Reshaping
-  # the array from inside it used to leave store_binary copying the byte count
-  # it measured before into whatever smaller buffer came back.
-  test "store_binary refuses an array that its own allocate reshaped" do
-    script = <<~RUBY
-      require "cumo/narray"
-      class Shrinker < Cumo::DFloat
-        def allocate
-          unless @done
-            @done = true
-            send(:initialize, 1)
-          end
-          super
+  # Taking a pointer runs allocate, which is a Ruby method. These check the
+  # three ways that can leave the copy that follows pointing somewhere else.
+  RESHAPING_ALLOCATE = <<~RUBY
+    module Reshaping
+      def allocate
+        unless @done
+          @done = true
+          send(:initialize, 1)
         end
+        super
       end
-      a = Shrinker.new(1 << 22)
-      begin
-        a.store_binary("A" * (1 << 25))
-        print "no error"
-      rescue RuntimeError
-        print "RuntimeError"
-      end
-    RUBY
+    end
+  RUBY
+
+  def run_child(script)
     lib = File.expand_path("../lib", __dir__)
     out = nil
     IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], err: [:child, :out]) { |io| out = io.read }
     assert(Process.last_status.success?, "child failed: #{out}")
-    assert_equal "RuntimeError", out
+    out
+  end
+
+  def assert_child_raises(expected, body)
+    script = <<~RUBY
+      require "cumo/narray"
+      #{RESHAPING_ALLOCATE}
+      begin
+        #{body}
+        print "no error"
+      rescue => e
+        print e.message
+      end
+    RUBY
+    assert_equal expected, run_child(script)
+  end
+
+  test "store_binary refuses an array its own allocate reshaped" do
+    assert_child_raises("NArray or string changed while storing binary data", <<~RUBY)
+      klass = Class.new(Cumo::DFloat) { prepend Reshaping }
+      klass.new(1 << 22).store_binary("A" * (1 << 25))
+    RUBY
+  end
+
+  test "from_binary refuses an array its own allocate reshaped" do
+    assert_child_raises("NArray or string changed while reading binary data", <<~RUBY)
+      klass = Class.new(Cumo::DFloat) { prepend Reshaping }
+      klass.from_binary("A" * (1 << 25), [1 << 22])
+    RUBY
+  end
+
+  # marshal_load reaches its RObject branch by exact class, so the reshaping
+  # allocate has to be a singleton method rather than a subclass.
+  test "marshal_load refuses an RObject its own allocate reshaped" do
+    assert_child_raises("RObject content size mismatch", <<~RUBY)
+      g = Cumo::RObject.new(4)
+      g.store([1, 2, 3, 4])
+      def g.allocate
+        send(:initialize, 1 << 20) unless @done
+        @done = true
+        super
+      end
+      g.marshal_load([1, [4], 0, [1, 2, 3, 4]])
+    RUBY
+  end
+
+  # An allocate that never takes a buffer leaves the pointer NULL, and every
+  # caller goes on to read or write through what it hands back.
+  test "taking a pointer refuses an allocate that took no buffer" do
+    ["klass.new(8).store_binary('A' * 64)",
+     "klass.from_binary('A' * 64, [8])",
+     "klass.new(8).seq.to_a"].each do |body|
+      assert_child_raises("allocate left the NArray without data", <<~RUBY)
+        klass = Class.new(Cumo::DFloat) { def allocate; self; end }
+        #{body}
+      RUBY
+    end
+  end
+
+  # byte_size comes from the class's ELEMENT_BYTE_SIZE, which a subclass can
+  # define as an object returning whatever it likes. The allocation goes by the
+  # type, so a larger claim used to run the copy past it.
+  test "a lying ELEMENT_BYTE_SIZE cannot stretch the copy past the allocation" do
+    ["klass.from_binary('A' * (4 * 1_000_000 + 16), [4])",
+     "klass.new(4).seq.store_binary('A' * (4 * 1_000_000 + 16))"].each do |body|
+      assert_child_raises("string is too long to store", <<~RUBY)
+        liar = Class.new do
+          def to_f = 1_000_000.0
+          def to_int = 1_000_000
+          def to_i = 1_000_000
+        end.new
+        klass = Class.new(Cumo::DFloat) { const_set(:ELEMENT_BYTE_SIZE, liar) }
+        #{body}
+      RUBY
+    end
+  end
+
+  # Taking a shape only rewrites the size, so an array that already holds data
+  # would keep a buffer laid out for the shape it had.
+  test "from_binary refuses an allocate that returns an array holding data" do
+    assert_child_raises("allocate did not return a new NArray", <<~RUBY)
+      held = Cumo::DFloat.new(2).fill(9.0)
+      klass = Class.new(Cumo::DFloat) { define_singleton_method(:allocate) { held } }
+      klass.from_binary("A" * (8 << 23), [1 << 23])
+    RUBY
   end
 
   # The bytes used to be borrowed from the marshalled string rather than


### PR DESCRIPTION
Taking a pointer runs `allocate`, a Ruby method anything can define, and the callers go on to copy through what comes back. Four ways that goes wrong, each a segfault:

- `allocate` takes no buffer, so the pointer stays NULL.
- `allocate` returns an array that already holds data. Taking a shape only rewrites the size, so the buffer stays laid out for the old one.
- `allocate` reshapes the array, so a count measured before it no longer fits the buffer that came back.
- `ELEMENT_BYTE_SIZE` is a constant, so a subclass can claim any element size it likes and stretch the copy past what was allocated.

The first two are refused where the pointer is taken and where `cumo_na_new` asks for the array. That covers every caller, and closes the same hole in `store_binary`. The third is measured again in `from_binary` and in `marshal_load`'s RObject branch, as #390 did for `store_binary`. The fourth is bounded by the size the type gives, which no class can redefine. `marshal_load` keeps its cheap check as well, so a payload that never fits is still refused before a buffer is taken for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
