### PR TITLE
Fix Bit#each_with_index crashing on a zero-dimensional array

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
@@ -25,8 +25,9 @@ static void
     int nd, md;
 
     c = (size_t*)(lp->opt_ptr);
-    nd = lp->ndim - 1;
-    md = lp->ndim + 1;
+    nd = lp->ndim;
+    if (nd > 0) {nd--;}
+    md = nd + 2;
     a = ALLOCA_N(VALUE,md);
 
     CUMO_INIT_COUNTER(lp, i);

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -851,4 +851,45 @@ class BitTest < Test::Unit::TestCase
     a[true].store_binary("\xFF".b)
     assert_equal 8, Integer(a.count_true)
   end
+
+  test "each_with_index on a zero-dimensional bit array yields one index" do
+    yielded = []
+    Cumo::Bit.cast(1).each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[1, [0]]], yielded
+  end
+
+  test "each_with_index on a zero-dimensional bit view yields one index" do
+    omit "compatible mode answers with an Integer" if Cumo.compatible_mode_enabled?
+
+    yielded = []
+    Cumo::Bit[1, 0, 1][1].each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[0, [0]]], yielded
+
+    a = Cumo::Bit.new(40).fill(0)
+    a[33] = 1
+    yielded = []
+    a[33].each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[1, [0]]], yielded
+
+    yielded = []
+    (Cumo::DFloat[1.0, 2.0, 3.0][1] > 0).each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[1, [0]]], yielded
+  end
+
+  test "each_with_index on a bit array yields one index per axis" do
+    a = Cumo::Bit[[1, 0, 1], [0, 1, 1]]
+
+    yielded = []
+    a.each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[1, [0, 0]], [0, [0, 1]], [1, [0, 2]],
+                  [0, [1, 0]], [1, [1, 1]], [1, [1, 2]]], yielded
+
+    yielded = []
+    a[true, 1..2].each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[0, [0, 0]], [1, [0, 1]], [1, [1, 0]], [1, [1, 1]]], yielded
+
+    yielded = []
+    a[[1, 0], [2, 0]].each_with_index { |x, *i| yielded << [x, i] }
+    assert_equal [[1, [0, 0]], [0, [0, 1]], [1, [1, 0]], [1, [1, 1]]], yielded
+  end
 end

--- a/test/narray_alt_coverage_test.rb
+++ b/test/narray_alt_coverage_test.rb
@@ -71,6 +71,9 @@ class NArrayAltCoverageTest < CumoTestBase
       actual = []
       a[[0, 3, 5]].each_with_index { |e, i| actual << [i, e] }
       assert_equal([[0, 1], [1, 5], [2, 11]], actual)
+      actual = []
+      dtype.cast(1).each_with_index { |e, i| actual << [i, e] }
+      assert_equal([[0, 1]], actual)
     end
   end
 
@@ -93,6 +96,9 @@ class NArrayAltCoverageTest < CumoTestBase
       assert_kind_of(dtype, actual)
       assert_equal(dtype[0, 5, 22], actual)
       assert_equal(3, calls)
+      yielded = []
+      dtype.cast(1).map_with_index { |e, i| yielded << [i, e]; e }
+      assert_equal([[0, 1]], yielded)
     end
   end
 


### PR DESCRIPTION
`lp->ndim` is 0 for a zero-dimensional array, so `nd` became -1 and `c[nd] = 0` wrote in front of the counter array, which segfaults. The numeric templates already clamp `nd` and the bit one did not, so this gives it the same three lines. Indexing a `Bit` has returned a zero-dimensional `Bit` since #341, and a comparison against an element returns one too, so ordinary code reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)