### PR TITLE
Fix where and a masked aref writing past their index array

### DIFF
--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -1,4 +1,4 @@
-void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, char *scratch);
+void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t cap, char *scratch);
 
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
@@ -9,11 +9,13 @@ static void
     ssize_t s1, s2;
     size_t *idx1, *idx2, *pidx;
     CUMO_BIT_DIGIT x=0;
-    size_t  count;
+    size_t  count, cap, wrote;
     where_opt_t *g;
 
     g = (where_opt_t*)(lp->opt_ptr);
     count = g->count;
+    cap   = g->cap1;
+    wrote = g->wrote1;
     pidx  = (size_t*)(g->idx1);
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a, p1, s1, idx1);
@@ -22,10 +24,11 @@ static void
     s2 = lp->args[1].iter[0].step;
     idx2 = lp->args[1].iter[0].idx;
 
-    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE && g->scratch) {
         // pidx stays put: the device-side cursor in the scratch orders the
         // writes of successive calls instead.
-        cumo_bit_mask_kernel_launch(a,p1,s1,idx1,i,pidx,p2,s2,idx2,g->scratch);
+        cumo_bit_mask_kernel_launch(a,p1,s1,idx1,i,pidx,p2,s2,idx2,cap,g->scratch);
+        g->used_kernel = 1;
         return;
     }
 
@@ -38,7 +41,8 @@ static void
                 CUMO_LOAD_BIT(a, p1+*idx1, x);
                 idx1++;
                 if (x) {
-                    *(pidx++) = p2+*idx2;
+                    if (wrote < cap) { *(pidx++) = p2+*idx2; }
+                    wrote++;
                     count++;
                 }
                 idx2++;
@@ -48,7 +52,8 @@ static void
                 CUMO_LOAD_BIT(a, p1+*idx1, x);
                 idx1++;
                 if (x) {
-                    *(pidx++) = p2;
+                    if (wrote < cap) { *(pidx++) = p2; }
+                    wrote++;
                     count++;
                 }
                 p2 += s2;
@@ -60,7 +65,8 @@ static void
                 CUMO_LOAD_BIT(a, p1, x);
                 p1 += s1;
                 if (x) {
-                    *(pidx++) = p2+*idx2;
+                    if (wrote < cap) { *(pidx++) = p2+*idx2; }
+                    wrote++;
                     count++;
                 }
                 idx2++;
@@ -70,15 +76,17 @@ static void
                 CUMO_LOAD_BIT(a, p1, x);
                 p1 += s1;
                 if (x) {
-                    *(pidx++) = p2;
+                    if (wrote < cap) { *(pidx++) = p2; }
+                    wrote++;
                     count++;
                 }
                 p2 += s2;
             }
         }
     }
-    g->count = count;
-    g->idx1  = (char*)pidx;
+    g->count  = count;
+    g->idx1   = (char*)pidx;
+    g->wrote1 = wrote;
 }
 
 #if   SIZEOF_VOIDP == 8
@@ -107,6 +115,8 @@ static VALUE
     cumo_narray_t      *na, *na_mask;
     cumo_stridx_t stridx0;
     size_t n_1;
+    uint64_t cur[1];
+    cudaError_t st = cudaSuccess;
     where_opt_t g;
     cumo_ndfunc_arg_in_t ain[2] = {{cT,0},{Qnil,0}};
     cumo_ndfunc_t ndf = {<%=c_iter%>, CUMO_FULL_LOOP, 2, 0, ain, 0};
@@ -115,6 +125,9 @@ static VALUE
     if (!rb_obj_is_kind_of(val, cumo_cNArray)) {
         val = rb_funcall(cumo_cNArray, cumo_id_cast, 1, val);
     }
+    // ndloop takes this pointer too, and for a lazily cast scalar taking it runs
+    // allocate. Doing it here keeps that Ruby call before the shape check below.
+    cumo_na_get_pointer_for_read(val);
     // shapes of mask and val must be same
     CumoGetNArray(val, na);
     CumoGetNArray(mask, na_mask);
@@ -131,20 +144,30 @@ static VALUE
     idx_1 = cumo_na_new(cIndex, 1, &n_1);
     g.count = 0;
     g.elmsz = SIZEOF_VOIDP;
-    g.idx1 = cumo_na_get_pointer_for_write(idx_1);
+    bit_where_take(idx_1, &g.idx1, &g.cap1);
+    g.wrote1 = 0;
     g.idx0 = NULL;
+    g.cap0 = 0;
+    g.wrote0 = 0;
     g.scratch = NULL;
+    g.used_kernel = 0;
     if (CUMO_RNARRAY_SIZE(mask) >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
         g.scratch = cumo_bit_where_scratch_new();
     }
     cumo_na_ndloop3(&ndf, &g, 2, mask, val);
+    if (g.used_kernel) {
+        st = bit_where_cursors(g.scratch, cur, 1);
+        if (st == cudaSuccess) { g.wrote1 += (size_t)cur[0]; }
+    }
     if (g.scratch) {
         cumo_cuda_runtime_free(g.scratch);
     }
+    cumo_cuda_runtime_check_status(st);
+    bit_where_check(g.wrote1, g.cap1);
 
     view = cumo_na_s_allocate_view(rb_obj_class(val));
     CumoGetNArrayView(view, nv);
-    cumo_na_setup_shape((cumo_narray_t*)nv, 1, &n_1);
+    cumo_na_setup_shape((cumo_narray_t*)nv, 1, &g.cap1);
 
     CumoGetNArrayData(idx_1,nidx);
     CUMO_SDX_SET_INDEX(stridx0,(size_t*)nidx->ptr);

--- a/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/mask_kernel.cu
@@ -3,7 +3,7 @@
 // that offset from one loop segment to the next on the device. Only the
 // scatter differs -- it writes the position of the masked array's element
 // rather than the flat index, so the result indexes that array's data.
-__global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, uint64_t nchunks, uint64_t cpb, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t *block_sums)
+__global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, uint64_t nchunks, uint64_t cpb, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t cap, uint64_t *block_sums)
 {
     uint64_t startc = blockIdx.x * cpb;
     uint64_t endc = (nchunks - startc < cpb) ? nchunks : startc + cpb;
@@ -23,7 +23,7 @@ __global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_
             CUMO_LOAD_BIT(a, cumo_bit_pos(p, s, idx, i), x);
         }
         pre = cumo_bit_block_exscan(x, &total);
-        if (x) {
+        if (x && off + pre < cap) {
             out[off + pre] = idx2 ? p2 + idx2[i] : (size_t)((ssize_t)p2 + (ssize_t)i * s2);
         }
         off += total;
@@ -31,7 +31,7 @@ __global__ void cumo_bit_mask_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_
     }
 }
 
-void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, char *scratch)
+void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, size_t *out, size_t p2, ssize_t s2, size_t *idx2, uint64_t cap, char *scratch)
 {
     uint64_t nchunks = (n + CUMO_NB - 1) / CUMO_NB;
     int contiguous = (idx == NULL && s == 1);
@@ -47,6 +47,6 @@ void cumo_bit_mask_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t 
     cpb = (nchunks + nblocks - 1) / nblocks;
     cumo_bit_where_partial_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,0,nchunks,cpb,block_sums);
     cumo_bit_where_scan_kernel<<<1, CUMO_BIT_CHUNK_BLOCK>>>(block_sums,nblocks,running);
-    cumo_bit_mask_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,nchunks,cpb,out,p2,s2,idx2,block_sums);
+    cumo_bit_mask_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,nchunks,cpb,out,p2,s2,idx2,cap,block_sums);
     cumo_cuda_runtime_check_kernel_launch();
 }

--- a/ext/cumo/narray/gen/tmpl_bit/where.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where.c
@@ -4,12 +4,42 @@ typedef struct {
     char  *idx1;
     size_t elmsz;
     char  *scratch;
+    size_t cap1;
+    size_t cap0;
+    size_t wrote1;
+    size_t wrote0;
+    int    used_kernel;
 } where_opt_t;
 
 #define STORE_INT(ptr, esz, x) memcpy(ptr,&(x),esz)
 
 char *cumo_bit_where_scratch_new(void);
-void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t count, char *scratch);
+void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t cap, uint64_t count, char *scratch);
+
+// Taking a pointer runs allocate, which a Ruby class can redefine, so both are
+// read once every allocation has run.
+static void
+bit_where_take(VALUE idx, char **ptr, size_t *cap)
+{
+    *ptr = cumo_na_get_pointer_for_write(idx);
+    *cap = CUMO_RNARRAY_SIZE(idx);
+}
+
+// The scatter keeps counting what it wanted to write after the room ran out, so
+// the cursors say whether the walk still matched the counts that sized it.
+static cudaError_t
+bit_where_cursors(char *scratch, uint64_t *v, int n)
+{
+    return cudaMemcpy(v, scratch, n * sizeof(uint64_t), cudaMemcpyDeviceToHost);
+}
+
+static void
+bit_where_check(size_t a, size_t b)
+{
+    if (a != b) {
+        rb_raise(rb_eRuntimeError, "the bit array and its index array no longer agree");
+    }
+}
 
 // The number of ones, read back with a copy of the count rather than through
 // the managed pointer, which would fault the whole page. The one sync it costs
@@ -41,20 +71,23 @@ static void
     CUMO_BIT_DIGIT x=0;
     char   *idx1;
     size_t  count;
-    size_t  e;
+    size_t  e, cap, wrote;
     where_opt_t *g;
 
     g = (where_opt_t*)(lp->opt_ptr);
     count = g->count;
     idx1  = g->idx1;
     e     = g->elmsz;
+    cap   = g->cap1;
+    wrote = g->wrote1;
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a, p, s, idx);
-    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE && g->scratch) {
         // idx1 stays put: the device-side cursor in the scratch orders the
         // writes of successive calls instead.
-        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,count,g->scratch);
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,cap,count,g->scratch);
         g->count = count + i;
+        g->used_kernel = 1;
         return;
     }
 
@@ -66,8 +99,11 @@ static void
             CUMO_LOAD_BIT(a, p+*idx, x);
             idx++;
             if (x!=0) {
-                STORE_INT(idx1,e,count);
-                idx1 += e;
+                if (wrote < cap) {
+                    STORE_INT(idx1,e,count);
+                    idx1 += e;
+                }
+                wrote++;
             }
             count++;
         }
@@ -76,14 +112,18 @@ static void
             CUMO_LOAD_BIT(a, p, x);
             p+=s;
             if (x!=0) {
-                STORE_INT(idx1,e,count);
-                idx1 += e;
+                if (wrote < cap) {
+                    STORE_INT(idx1,e,count);
+                    idx1 += e;
+                }
+                wrote++;
             }
             count++;
         }
     }
-    g->count = count;
-    g->idx1  = idx1;
+    g->count  = count;
+    g->idx1   = idx1;
+    g->wrote1 = wrote;
 }
 
 /*
@@ -96,13 +136,15 @@ static VALUE
 {
     volatile VALUE idx_1;
     size_t size, n_1;
+    uint64_t cur[1];
+    cudaError_t st = cudaSuccess;
     where_opt_t *g;
 
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 0, ain, 0 };
 
-    size = CUMO_RNARRAY_SIZE(self);
     n_1 = bit_where_count_true(self);
+    size = CUMO_RNARRAY_SIZE(self);
     g = ALLOCA_N(where_opt_t,1);
     g->count = 0;
     if (size>4294967295ul) {
@@ -112,16 +154,27 @@ static VALUE
         idx_1 = cumo_na_new(cumo_cInt32, 1, &n_1);
         g->elmsz = 4;
     }
-    g->idx1 = cumo_na_get_pointer_for_write(idx_1);
+    bit_where_take(idx_1, &g->idx1, &g->cap1);
+    bit_where_check(CUMO_RNARRAY_SIZE(self), size);
+    g->wrote1 = 0;
     g->idx0 = NULL;
+    g->cap0 = 0;
+    g->wrote0 = 0;
     g->scratch = NULL;
+    g->used_kernel = 0;
     if (size >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
         g->scratch = cumo_bit_where_scratch_new();
     }
     cumo_na_ndloop3(&ndf, g, 1, self);
+    if (g->used_kernel) {
+        st = bit_where_cursors(g->scratch, cur, 1);
+        if (st == cudaSuccess) { g->wrote1 += (size_t)cur[0]; }
+    }
     if (g->scratch) {
         cumo_cuda_runtime_free(g->scratch);
     }
+    cumo_cuda_runtime_check_status(st);
     cumo_na_release_lock(idx_1);
+    bit_where_check(g->wrote1, g->cap1);
     return idx_1;
 }

--- a/ext/cumo/narray/gen/tmpl_bit/where2.c
+++ b/ext/cumo/narray/gen/tmpl_bit/where2.c
@@ -9,7 +9,7 @@ static void
     CUMO_BIT_DIGIT x=0;
     char   *idx0, *idx1;
     size_t  count;
-    size_t  e;
+    size_t  e, cap1, cap0, wrote1, wrote0;
     where_opt_t *g;
 
     g = (where_opt_t*)(lp->opt_ptr);
@@ -17,12 +17,17 @@ static void
     idx0  = g->idx0;
     idx1  = g->idx1;
     e     = g->elmsz;
+    cap1  = g->cap1;
+    cap0  = g->cap0;
+    wrote1 = g->wrote1;
+    wrote0 = g->wrote0;
     CUMO_INIT_COUNTER(lp, i);
     CUMO_INIT_PTR_BIT_IDX(lp, 0, a, p, s, idx);
-    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
-        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,count,g->scratch);
-        cumo_bit_where_kernel_launch(a,p,s,idx,i,1,idx0,e,count,g->scratch);
+    if (i >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE && g->scratch) {
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,0,idx1,e,cap1,count,g->scratch);
+        cumo_bit_where_kernel_launch(a,p,s,idx,i,1,idx0,e,cap0,count,g->scratch);
         g->count = count + i;
+        g->used_kernel = 1;
         return;
     }
 
@@ -34,11 +39,17 @@ static void
             CUMO_LOAD_BIT(a, p+*idx, x);
             idx++;
             if (x==0) {
-                STORE_INT(idx0,e,count);
-                idx0 += e;
+                if (wrote0 < cap0) {
+                    STORE_INT(idx0,e,count);
+                    idx0 += e;
+                }
+                wrote0++;
             } else {
-                STORE_INT(idx1,e,count);
-                idx1 += e;
+                if (wrote1 < cap1) {
+                    STORE_INT(idx1,e,count);
+                    idx1 += e;
+                }
+                wrote1++;
             }
             count++;
         }
@@ -47,18 +58,26 @@ static void
             CUMO_LOAD_BIT(a, p, x);
             p+=s;
             if (x==0) {
-                STORE_INT(idx0,e,count);
-                idx0 += e;
+                if (wrote0 < cap0) {
+                    STORE_INT(idx0,e,count);
+                    idx0 += e;
+                }
+                wrote0++;
             } else {
-                STORE_INT(idx1,e,count);
-                idx1 += e;
+                if (wrote1 < cap1) {
+                    STORE_INT(idx1,e,count);
+                    idx1 += e;
+                }
+                wrote1++;
             }
             count++;
         }
     }
-    g->count = count;
-    g->idx0  = idx0;
-    g->idx1  = idx1;
+    g->count  = count;
+    g->idx0   = idx0;
+    g->idx1   = idx1;
+    g->wrote0 = wrote0;
+    g->wrote1 = wrote1;
 }
 
 /*
@@ -71,15 +90,17 @@ static void
 static VALUE
 <%=c_func(0)%>(VALUE self)
 {
-    VALUE idx_1, idx_0;
+    volatile VALUE idx_1, idx_0;
     size_t size, n_1, n_0;
+    uint64_t cur[2];
+    cudaError_t st = cudaSuccess;
     where_opt_t *g;
 
     cumo_ndfunc_arg_in_t ain[1] = {{cT,0}};
     cumo_ndfunc_t ndf = { <%=c_iter%>, CUMO_FULL_LOOP, 1, 0, ain, 0 };
 
-    size = CUMO_RNARRAY_SIZE(self);
     n_1 = bit_where_count_true(self);
+    size = CUMO_RNARRAY_SIZE(self);
     n_0 = size - n_1;
     g = ALLOCA_N(where_opt_t,1);
     g->count = 0;
@@ -92,17 +113,33 @@ static VALUE
         idx_0 = cumo_na_new(cumo_cInt32, 1, &n_0);
         g->elmsz = 4;
     }
-    g->idx1 = cumo_na_get_pointer_for_write(idx_1);
-    g->idx0 = cumo_na_get_pointer_for_write(idx_0);
+    cumo_na_get_pointer_for_write(idx_1);
+    cumo_na_get_pointer_for_write(idx_0);
+    bit_where_take(idx_1, &g->idx1, &g->cap1);
+    bit_where_take(idx_0, &g->idx0, &g->cap0);
+    bit_where_check(CUMO_RNARRAY_SIZE(self), size);
+    g->wrote1 = 0;
+    g->wrote0 = 0;
     g->scratch = NULL;
+    g->used_kernel = 0;
     if (size >= CUMO_BIT_WHERE_MIN_KERNEL_SIZE) {
         g->scratch = cumo_bit_where_scratch_new();
     }
     cumo_na_ndloop3(&ndf, g, 1, self);
+    if (g->used_kernel) {
+        st = bit_where_cursors(g->scratch, cur, 2);
+        if (st == cudaSuccess) {
+            g->wrote1 += (size_t)cur[0];
+            g->wrote0 += (size_t)cur[1];
+        }
+    }
     if (g->scratch) {
         cumo_cuda_runtime_free(g->scratch);
     }
+    cumo_cuda_runtime_check_status(st);
     cumo_na_release_lock(idx_0);
     cumo_na_release_lock(idx_1);
+    bit_where_check(g->wrote1, g->cap1);
+    bit_where_check(g->wrote0, g->cap0);
     return rb_assoc_new(idx_1,idx_0);
 }

--- a/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
+++ b/ext/cumo/narray/gen/tmpl_bit/where_kernel.cu
@@ -2,8 +2,8 @@
 // order: each block counts the hits of a contiguous range of chunks, one scan
 // block turns the counts into output positions, and each block scatters its
 // range from its position. *running carries the output cursor from one ndloop
-// iteration to the next entirely on the device, so no launch reads anything
-// back to the host.
+// iteration to the next entirely on the device, and the caller reads it back
+// once at the end to see whether the walk filled the room it was given.
 
 // The scan kernel is one block, so it bounds the scratch the caller allocates
 // and the sequential work it does itself.
@@ -53,7 +53,7 @@ __global__ void cumo_bit_where_scan_kernel(uint64_t *block_sums, uint64_t nblock
 // The scatter takes an element per lane rather than a chunk, so that the lanes
 // that do write land next to each other. A thread that owned a whole chunk wrote
 // a run of its own, which put the lanes of a warp a run apart.
-__global__ void cumo_bit_where_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, int invert, uint64_t nchunks, uint64_t cpb, char *out, size_t elmsz, uint64_t count, uint64_t *block_sums)
+__global__ void cumo_bit_where_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, uint64_t nw, int contiguous, int invert, uint64_t nchunks, uint64_t cpb, char *out, size_t elmsz, uint64_t cap, uint64_t count, uint64_t *block_sums)
 {
     uint64_t startc = blockIdx.x * cpb;
     uint64_t endc = (nchunks - startc < cpb) ? nchunks : startc + cpb;
@@ -74,7 +74,7 @@ __global__ void cumo_bit_where_scatter_kernel(CUMO_BIT_DIGIT *a, size_t p, ssize
             if (invert) x = !x;
         }
         pre = cumo_bit_block_exscan(x, &total);
-        if (x) {
+        if (x && off + pre < cap) {
             cumo_bit_store_index(out, elmsz, off + pre, count + i);
         }
         off += total;
@@ -90,7 +90,7 @@ char *cumo_bit_where_scratch_new(void)
     return scratch;
 }
 
-void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t count, char *scratch)
+void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t *idx, uint64_t n, int invert, char *out, size_t elmsz, uint64_t cap, uint64_t count, char *scratch)
 {
     uint64_t nchunks = (n + CUMO_NB - 1) / CUMO_NB;
     int contiguous = (idx == NULL && s == 1);
@@ -104,6 +104,6 @@ void cumo_bit_where_kernel_launch(CUMO_BIT_DIGIT *a, size_t p, ssize_t s, size_t
     cpb = (nchunks + nblocks - 1) / nblocks;
     cumo_bit_where_partial_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,invert,nchunks,cpb,block_sums);
     cumo_bit_where_scan_kernel<<<1, CUMO_BIT_CHUNK_BLOCK>>>(block_sums,nblocks,running);
-    cumo_bit_where_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,invert,nchunks,cpb,out,elmsz,count,block_sums);
+    cumo_bit_where_scatter_kernel<<<nblocks, CUMO_BIT_CHUNK_BLOCK>>>(a,p,s,idx,n,nw,contiguous,invert,nchunks,cpb,out,elmsz,cap,count,block_sums);
     cumo_cuda_runtime_check_kernel_launch();
 }

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -3,6 +3,8 @@
 require_relative "test_helper"
 
 class BitTest < Test::Unit::TestCase
+  include CumoChildProcess
+
   dtype = Cumo::Bit
 
   test dtype do
@@ -850,6 +852,62 @@ class BitTest < Test::Unit::TestCase
     a = Cumo::Bit.new(8).fill(0)
     a[true].store_binary("\xFF".b)
     assert_equal 8, Integer(a.count_true)
+  end
+
+  def assert_where_refuses(n, body, setup: "")
+    assert_child_raises("the bit array and its index array no longer agree", <<~RUBY, prelude: MUTATING_ALLOCATE)
+      $a = Cumo::Bit.new(#{n}).fill(1)
+      #{setup}
+      [Cumo::Int32, Cumo::Int64].each { |k| k.prepend(Mutating) }
+      #{body}
+    RUBY
+  end
+
+  { 1024 => "host loop", 16384 => "scatter kernel" }.each do |n, path|
+    test "where refuses an index array its own allocate shrank, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(idx) { idx.send(:initialize, 1) }\n$a.where")
+    end
+
+    test "where refuses a bit array its index array's allocate shrank, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(_) { $a.send(:initialize, [4]); $a.fill(1) }\n$a.where")
+    end
+
+    test "where refuses a bit array whose bits its index array's allocate turned on, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(_) { $a.fill(1) }\n$a.where", setup: "$a.fill(0); $a[0] = 1")
+    end
+
+    test "where refuses a bit array whose bits its index array's allocate turned off, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(_) { $a.fill(0) }\n$a.where")
+    end
+
+    test "where2 refuses a bit array whose bits its index arrays' allocate turned off, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(_) { $a.fill(0) }\n$a.where2")
+    end
+
+    test "masked aref refuses a bit array whose bits its index array's allocate turned on, #{path}" do
+      assert_where_refuses(n, "$mutate = ->(_) { $a.fill(1) }\nCumo::DFloat.new(#{n}).seq[$a]",
+                           setup: "$a.fill(0); $a[0] = 1")
+    end
+
+    test "where still answers when allocate replaced the index array's buffer, #{path}" do
+      assert_child_raises("no error", <<~RUBY, prelude: MUTATING_ALLOCATE)
+        a = Cumo::Bit.new(#{n}).fill(1)
+        $mutate = ->(idx) { idx.send(:initialize, idx.size) }
+        [Cumo::Int32, Cumo::Int64].each { |k| k.prepend(Mutating) }
+        raise "wrong" unless a.where.to_a == (0...#{n}).to_a
+        raise "allocate never ran" unless $fired
+      RUBY
+    end
+  end
+
+  test "masked aref allocates a lazily cast operand before it counts" do
+    assert_child_raises("no error", <<~RUBY, prelude: MUTATING_ALLOCATE)
+      $a = Cumo::Bit.cast(0)
+      $mutate = ->(_) { $a.fill(1) }
+      Cumo::DFloat.prepend(Mutating)
+      Cumo::DFloat.cast(1.0)[$a]
+      raise "allocate never ran" unless $fired
+    RUBY
   end
 
   test "each_with_index on a zero-dimensional bit array yields one index" do

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -3,6 +3,8 @@
 require_relative "test_helper"
 
 class NArrayTest < Test::Unit::TestCase
+  include CumoChildProcess
+
   types = [
     Cumo::DFloat,
     Cumo::SFloat,
@@ -2868,40 +2870,6 @@ class NArrayTest < Test::Unit::TestCase
 
   # Taking a pointer runs allocate, which is a Ruby method. These check the
   # three ways that can leave the copy that follows pointing somewhere else.
-  RESHAPING_ALLOCATE = <<~RUBY
-    module Reshaping
-      def allocate
-        unless @done
-          @done = true
-          send(:initialize, 1)
-        end
-        super
-      end
-    end
-  RUBY
-
-  def run_child(script)
-    lib = File.expand_path("../lib", __dir__)
-    out = nil
-    IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], err: [:child, :out]) { |io| out = io.read }
-    assert(Process.last_status.success?, "child failed: #{out}")
-    out
-  end
-
-  def assert_child_raises(expected, body)
-    script = <<~RUBY
-      require "cumo/narray"
-      #{RESHAPING_ALLOCATE}
-      begin
-        #{body}
-        print "no error"
-      rescue => e
-        print e.message
-      end
-    RUBY
-    assert_equal expected, run_child(script)
-  end
-
   test "store_binary refuses an array its own allocate reshaped" do
     assert_child_raises("NArray or string changed while storing binary data", <<~RUBY)
       klass = Class.new(Cumo::DFloat) { prepend Reshaping }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,67 @@ require "cumo"
 
 require "pry"
 require "test/unit"
+require "timeout"
+
+module CumoChildProcess
+  RESHAPING_ALLOCATE = <<~RUBY
+    module Reshaping
+      def allocate
+        unless @done
+          @done = true
+          send(:initialize, 1)
+        end
+        super
+      end
+    end
+  RUBY
+
+  MUTATING_ALLOCATE = <<~RUBY
+    module Mutating
+      def allocate
+        unless $done
+          $done = true
+          $fired = true
+          $mutate.call(self)
+        end
+        super
+      end
+    end
+  RUBY
+
+  def run_child(script, timeout: 120)
+    lib = File.expand_path("../lib", __dir__)
+    out = nil
+    IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], err: [:child, :out]) do |io|
+      begin
+        Timeout.timeout(timeout) { out = io.read }
+      rescue Timeout::Error
+        Process.kill(:KILL, io.pid)
+        flunk("child did not finish in #{timeout}s")
+      end
+    end
+    assert(Process.last_status.success?, "child failed: #{out}")
+    out
+  end
+
+  def assert_child_raises(expected, body, prelude: RESHAPING_ALLOCATE)
+    script = <<~RUBY
+      require "cumo/narray"
+      #{prelude}
+      begin
+        #{body}
+        print "no error"
+      rescue => e
+        print e.message
+      end
+    RUBY
+    assert_equal expected, run_child(script)
+  end
+end
 
 class CumoTestBase < Test::Unit::TestCase
+  include CumoChildProcess
+
   FLOAT_TYPES = [
     Cumo::DFloat,
     Cumo::DComplex,


### PR DESCRIPTION
`where`, `where2` and a masked `aref` count the one bits, size an index array from that count, and then take its pointer. Taking the pointer runs `allocate`, which a Ruby class can redefine, so it can resize either array or change the bits before the walk writes one index per one bit. compute-sanitizer reports thousands of invalid device writes for that, and the room the walk never reaches hands back whatever the pool block last held.

The walk now stops at the room the index array actually has, and the call refuses to answer when the count that sized it no longer matches. Checking costs one 8 byte device to host copy per call: interleaved in one process, `where` on 4M bits goes from 66.8 to 72.6 us dense and from 64.0 to 72.5 us sparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)