### PR TITLE
Name the message the gemm row count tests are there for

### DIFF
--- a/test/hfloat_test.rb
+++ b/test/hfloat_test.rb
@@ -694,7 +694,8 @@ class HFloatTest < Test::Unit::TestCase
       test "#{dtype}, a row count cuBLAS cannot take is refused" do
         a = dtype.new(2_147_483_648, 2)
         b = dtype.new(2, 1)
-        assert_raise(RangeError) { a.dot(b) }
+        e = assert_raise(RangeError) { a.dot(b) }
+        assert_equal("row size of a=2147483648 is too large for cuBLAS", e.message)
       end
     end
 


### PR DESCRIPTION
The three tests #399 added for a row count cuBLAS cannot take only asked for a `RangeError`, and before that PR one arrives anyway: the truncated row count lands in the shape, and `cumo_na_new` turns it away with `total byte size of data is too large`. They pass on either side of the fix as written, so they now name the message they are there for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)