### PR TITLE
Ask once whether a view's offset reaches a char pointer

### DIFF
--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1647,8 +1647,22 @@ cumo_na_s_from_binary(int argc, VALUE *argv, VALUE type)
     return vna;
 }
 
+// A view whose elements are packed measures its offset in bits, so only a zero
+// one can be added to a char pointer. By the type, as the byte sizes above are.
+static int
+cumo_na_view_offset_reaches_bytes(VALUE self)
+{
+    cumo_narray_t *na;
+
+    CumoGetNArray(self,na);
+    if (na->type != CUMO_NARRAY_VIEW_T) {
+        return 1;
+    }
+    return cumo_na_type_info(self)->element_bits == 0 || CUMO_NA_VIEW_OFFSET(na) == 0;
+}
+
 /*
-  Returns a new 1-D array initialized from binary raw data in a string.
+  Stores binary raw data from a string into NArray.
   @overload store_binary(string,[offset])
   @param [String] string  Binary raw data.
   @param [Integer] (optional) offset  Byte offset in string.
@@ -1714,9 +1728,11 @@ cumo_na_store_binary(int argc, VALUE *argv, VALUE self)
         if (cumo_na_check_contiguous(self) != Qtrue) {
             rb_raise(rb_eArgError, "cannot store binary data into a non-contiguous view");
         }
-        if (RTEST(rb_obj_is_kind_of(self, cumo_cBit)) &&
-            (CUMO_NA_VIEW_OFFSET(na) != 0 || size % 8 != 0)) {
-            rb_raise(rb_eArgError, "cannot store binary data into a bit view that does not begin and end on a byte");
+        if (!cumo_na_view_offset_reaches_bytes(self)) {
+            rb_raise(rb_eArgError, "cannot store binary data into a bit view that does not begin at bit 0");
+        }
+        if (cumo_na_type_info(self)->element_bits > 0 && size % 8 != 0) {
+            rb_raise(rb_eArgError, "cannot store binary data into a bit view that does not end on a byte");
         }
     }
 
@@ -1741,14 +1757,10 @@ cumo_na_to_binary(VALUE self)
     char *ptr;
     VALUE str;
     cumo_narray_t *na;
-    int offset_in_bits;
 
     CumoGetNArray(self,na);
     if (na->type == CUMO_NARRAY_VIEW_T) {
-        // Cumo::Bit measures the offset in bits, so it cannot be added to a
-        // char pointer; kind_of because a subclass must not slip past either.
-        offset_in_bits = RTEST(rb_obj_is_kind_of(self, cumo_cBit)) && CUMO_NA_VIEW_OFFSET(na) != 0;
-        if (!offset_in_bits && cumo_na_check_contiguous(self)==Qtrue) {
+        if (cumo_na_view_offset_reaches_bytes(self) && cumo_na_check_contiguous(self)==Qtrue) {
             offset = CUMO_NA_VIEW_OFFSET(na);
         } else {
             self = rb_funcall(self,cumo_id_dup,0);

--- a/test/bit_test.rb
+++ b/test/bit_test.rb
@@ -828,7 +828,10 @@ class BitTest < Test::Unit::TestCase
 
   test "store_binary on a bit view that does not start at bit 0 is refused" do
     a = Cumo::Bit.new(16).fill(0)
-    assert_raise(ArgumentError) { a[8..15].store_binary("\xFF".b) }
+    e = assert_raise(ArgumentError) { a[8..15].store_binary("\xFF".b) }
+    assert_equal("cannot store binary data into a bit view that does not begin at bit 0", e.message)
+    e = assert_raise(ArgumentError) { a[1..8].store_binary("\xFF".b) }
+    assert_equal("cannot store binary data into a bit view that does not begin at bit 0", e.message)
     assert_equal 0, Integer(a.count_true)
   end
 
@@ -836,8 +839,10 @@ class BitTest < Test::Unit::TestCase
   # take the bits after it along, and those belong to the rest of the base.
   test "store_binary on a bit view that ends mid-byte is refused" do
     a = Cumo::Bit.new(16).fill(0)
-    assert_raise(ArgumentError) { a[0..3].store_binary("\xFF".b) }
-    assert_raise(ArgumentError) { a[0..11].store_binary("\xFF\xFF".b) }
+    e = assert_raise(ArgumentError) { a[0..3].store_binary("\xFF".b) }
+    assert_equal("cannot store binary data into a bit view that does not end on a byte", e.message)
+    e = assert_raise(ArgumentError) { a[0..11].store_binary("\xFF\xFF".b) }
+    assert_equal("cannot store binary data into a bit view that does not end on a byte", e.message)
     assert_equal 0, Integer(a.count_true)
   end
 
@@ -846,6 +851,21 @@ class BitTest < Test::Unit::TestCase
     a[0..7].store_binary("\xFF".b)
     assert_equal 8, Integer(a.count_true)
     assert_equal "1111111100000000", a.to_a.join
+  end
+
+  test "to_binary reads a whole-byte bit view from its own offset" do
+    a = Cumo::Bit.new(24).fill(0)
+    a[0..7] = 1                       # byte 0 = 0xFF
+    a[8] = 1
+    a[9] = 1                          # byte 1 = 0x03
+    a[16] = 1                         # byte 2 = 0x01
+    assert_equal([255], a[0..7].to_binary.bytes)
+    assert_equal([3], a[8..15].to_binary.bytes)
+    assert_equal([1], a[16..23].to_binary.bytes)
+    assert_equal([255], a[1..8].to_binary.bytes)
+    a[7] = 0
+    assert_equal([127], a[0..7].to_binary.bytes)
+    assert_equal([191], a[1..8].to_binary.bytes)
   end
 
   test "store_binary fills a whole bit array" do


### PR DESCRIPTION
`to_binary` and `store_binary` both spelled out the same question: whether a view's offset can be added to a `char*`, which for packed elements means whether it is zero. A change to how a packed offset is measured would have had to find both.

The question is now a named helper, asked of the type the way the byte sizes next to it are, rather than of the class. `store_binary` asked it together with whether the view ends on a byte, which is a different thing to refuse, so those are two checks with a message each, and the one about the start now says what it means: bit 0 rather than a byte boundary, which `a[8..15]` sits on and is still refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)