### PR TITLE
Sweep Cumo::HFloat with the structural tests

### DIFF
--- a/test/extra_test.rb
+++ b/test/extra_test.rb
@@ -668,7 +668,7 @@ class NArrayExtraTest < CumoTestBase
       assert_equal(dtype[1, 5],           a.percentile(0, axis: 1))
       assert_equal(dtype[2, 7],           a.percentile(50, axis: 1))
       assert_equal(dtype[3, 11],          a.percentile(100, axis: 1))
-      if [Cumo::DFloat, Cumo::SFloat].include?(dtype)
+      if [Cumo::DFloat, Cumo::SFloat, Cumo::HFloat].include?(dtype)
         assert_equal(dtype[3, 4.5, 7],      a.percentile(50, axis: 0))
         assert_equal(dtype[4.6, 6.5, 10.2], a.percentile(90, axis: 0))
         assert_equal(dtype[2.8, 10.2],      a.percentile(90, axis: 1))

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -8,6 +8,7 @@ class NArrayTest < Test::Unit::TestCase
   types = [
     Cumo::DFloat,
     Cumo::SFloat,
+    Cumo::HFloat,
     Cumo::DComplex,
     Cumo::SComplex,
     Cumo::Int64,
@@ -23,7 +24,7 @@ class NArrayTest < Test::Unit::TestCase
     Cumo::DFloat,
     Cumo::DComplex,
   ]
-  store_types = types + [Cumo::HFloat, Cumo::RObject]
+  store_types = types + [Cumo::RObject]
 
   if ENV['DTYPE']
     types.select! { |type| type.to_s.downcase.include?(ENV['DTYPE'].downcase) }
@@ -193,7 +194,7 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[2..-1][[1]] == [5] }
         assert { a.reverse == [11, 7, 5, 3, 2, 1] }
         assert { a.sum == 29 }
-        assert { (a.mean.extract_cpu - 29.0 / 6).abs < 1e-6 }
+        assert { (a.mean.extract_cpu - 29.0 / 6).abs < (dtype == Cumo::HFloat ? 1e-2 : 1e-6) }
         if float_types.include?(dtype)
           assert { a.mean == 29.0 / 6 }
           assert_in_delta(13.766666666666667, a.var.extract_cpu, 1e-13)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,6 +74,7 @@ class CumoTestBase < Test::Unit::TestCase
   TYPES = [
     *FLOAT_TYPES,
     Cumo::SFloat,
+    Cumo::HFloat,
     Cumo::SComplex,
     Cumo::Int64,
     Cumo::Int32,


### PR DESCRIPTION
`Cumo::HFloat` was missing from the dtype lists the structural tests sweep, so the only thing exercising it was `hfloat_test.rb`. It is now in both lists, which adds 110 test cases and 1886 assertions across `narray_test.rb`, `extra_test.rb` and `narray_alt_coverage_test.rb`.

Two assertions had to give: the mean of `[1,2,3,5,7,11]` lands 1.3e-3 from `29.0/6` in half precision, and `percentile` returns a half that has to be compared against a half rather than a `DFloat`. `NMath` keeps its own list, which still leaves half out; `hfloat_test.rb` covers it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)