### PR TITLE
Keep a view's strides readable when a constructor raises

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -469,7 +469,7 @@ cumo_na_reshape_bang(int argc, VALUE *argv, VALUE self)
     if (na->type == CUMO_NARRAY_VIEW_T) {
         CumoGetNArrayView(self, na2);
         if (na->ndim < argc) {
-            stridx = ALLOC_N(cumo_stridx_t,argc);
+            stridx = ZALLOC_N(cumo_stridx_t,argc);
         } else {
             stridx = na2->stridx;
         }
@@ -561,7 +561,7 @@ cumo_na_flatten_dim(VALUE self, int sd)
 
     // new stride
     cumo_na_setup_shape((cumo_narray_t*)na2, sd+1, shape);
-    na2->stridx = ALLOC_N(cumo_stridx_t,sd+1);
+    na2->stridx = ZALLOC_N(cumo_stridx_t,sd+1);
 
     switch(na->type) {
     case CUMO_NARRAY_DATA_T:
@@ -582,8 +582,8 @@ cumo_na_flatten_dim(VALUE self, int sd)
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[i]);
-                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*shape[i],cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*shape[i],cudaMemcpyDeviceToDevice,0));
             } else {
                 na2->stridx[i] = na1->stridx[i];
             }
@@ -775,7 +775,7 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
 
     // new stride
     cumo_na_setup_shape((cumo_narray_t*)na2, nd-1, shape);
-    na2->stridx = ALLOC_N(cumo_stridx_t, nd-1);
+    na2->stridx = ZALLOC_N(cumo_stridx_t, nd-1);
 
     switch(na->type) {
     case CUMO_NARRAY_DATA_T:
@@ -815,8 +815,8 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
                     //     idx1[j] = idx0[j];
                     // }
                     idx1 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*na->shape[i]);
-                    cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx1,idx0,sizeof(size_t)*na->shape[i],cudaMemcpyDeviceToDevice,0));
                     CUMO_SDX_SET_INDEX(na2->stridx[k],idx1);
+                    cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx1,idx0,sizeof(size_t)*na->shape[i],cudaMemcpyDeviceToDevice,0));
                 } else {
                     na2->stridx[k] = na1->stridx[i];
                 }
@@ -827,6 +827,7 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
             idx0 = CUMO_SDX_GET_INDEX(na1->stridx[ax[0]]);
             // diag_idx = ALLOC_N(size_t, diag_size);
             diag_idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*diag_size);
+            CUMO_SDX_SET_INDEX(na2->stridx[nd-2],diag_idx);
             if (CUMO_SDX_IS_INDEX(na1->stridx[ax[1]])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[ax[1]]);
                 cumo_na_diagonal_index_index_kernel_launch(diag_idx, idx0, idx1, k0, k1, diag_size);
@@ -834,15 +835,14 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
                 stride1 = CUMO_SDX_GET_STRIDE(na1->stridx[ax[1]]);
                 cumo_na_diagonal_index_stride_kernel_launch(diag_idx, idx0, stride1, k0, k1, diag_size);
             }
-            CUMO_SDX_SET_INDEX(na2->stridx[nd-2],diag_idx);
         } else {
             stride0 = CUMO_SDX_GET_STRIDE(na1->stridx[ax[0]]);
             if (CUMO_SDX_IS_INDEX(na1->stridx[ax[1]])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[ax[1]]);
                 // diag_idx = ALLOC_N(size_t, diag_size);
                 diag_idx = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*diag_size);
-                cumo_na_diagonal_stride_index_kernel_launch(diag_idx, stride0, idx1, k0, k1, diag_size);
                 CUMO_SDX_SET_INDEX(na2->stridx[nd-2],diag_idx);
+                cumo_na_diagonal_stride_index_kernel_launch(diag_idx, stride0, idx1, k0, k1, diag_size);
             } else {
                 stride1 = CUMO_SDX_GET_STRIDE(na1->stridx[ax[1]]);
                 na2->offset += stride0*k0 + stride1*k1;

--- a/ext/cumo/narray/gen/tmpl_bit/mask.c
+++ b/ext/cumo/narray/gen/tmpl_bit/mask.c
@@ -174,7 +174,7 @@ static VALUE
     nidx->ptr = NULL;
     RB_GC_GUARD(idx_1);
 
-    nv->stridx = ALLOC_N(cumo_stridx_t,1);
+    nv->stridx = ZALLOC_N(cumo_stridx_t,1);
     nv->stridx[0] = stridx0;
     nv->offset = 0;
     cumo_na_index_mark_filled(nv);

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -171,6 +171,9 @@ cumo_na_view_free(void* ptr)
 
     assert(na->base.type == CUMO_NARRAY_VIEW_T);
 
+    // A constructor that raises partway through still reaches here, so stridx
+    // is always allocated zeroed, and a fresh index is stored before anything
+    // that can raise. A zero reads as an index of NULL, which frees nothing.
     if (na->stridx != NULL) {
         for (i=0; i<na->base.ndim; i++) {
             if (CUMO_SDX_IS_INDEX(na->stridx[i])) {
@@ -1266,7 +1269,7 @@ cumo_na_make_view(VALUE self)
     CumoGetNArrayView(view, na2);
 
     cumo_na_setup_shape((cumo_narray_t*)na2, nd, na->shape);
-    na2->stridx = ALLOC_N(cumo_stridx_t,nd);
+    na2->stridx = ZALLOC_N(cumo_stridx_t,nd);
 
     switch(na->type) {
     case CUMO_NARRAY_DATA_T:
@@ -1289,8 +1292,8 @@ cumo_na_make_view(VALUE self)
                 //     idx2[j] = idx1[j];
                 // }
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*na1->base.shape[i]);
-                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*na1->base.shape[i],cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*na1->base.shape[i],cudaMemcpyDeviceToDevice,0));
             } else {
                 na2->stridx[i] = na1->stridx[i];
             }
@@ -1346,7 +1349,7 @@ cumo_na_expand_dims(VALUE self, VALUE vdim)
     CumoGetNArrayView(view, na2);
 
     shape = ALLOC_N(size_t,nd+1);
-    stridx = ALLOC_N(cumo_stridx_t,nd+1);
+    stridx = ZALLOC_N(cumo_stridx_t,nd+1);
     na2_shape = na2->base.shape;
     na2_stridx = na2->stridx;
 
@@ -1408,7 +1411,7 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
     CumoGetNArrayView(view, na2);
 
     cumo_na_setup_shape((cumo_narray_t*)na2, nd, na->shape);
-    na2->stridx = ALLOC_N(cumo_stridx_t,nd);
+    na2->stridx = ZALLOC_N(cumo_stridx_t,nd);
 
     switch(na->type) {
     case CUMO_NARRAY_DATA_T:
@@ -1436,12 +1439,12 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
                 idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
+                CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
                 if (cumo_na_test_reduce(reduce,i)) {
                     cumo_na_index_reverse_kernel_launch(idx2,idx1,n);
                 } else {
                     cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
                 }
-                CUMO_SDX_SET_INDEX(na2->stridx[i],idx2);
             } else {
                 stride = CUMO_SDX_GET_STRIDE(na1->stridx[i]);
                 if (cumo_na_test_reduce(reduce,i)) {

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -103,7 +103,7 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
             shape[j] = nt->shape[k];
         }
         klass = rb_obj_class(dtype);
-        stridx = ALLOC_N(cumo_stridx_t, ndim);
+        stridx = ZALLOC_N(cumo_stridx_t, ndim);
         stride = cumo_na_dtype_element_stride(klass);
         for (j=ndim,k=nt->ndim; k; ) {
             CUMO_SDX_SET_STRIDE(stridx[--j],stride);
@@ -121,7 +121,7 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
                 klass = dtype;
             }
         }
-        stridx = ALLOC_N(cumo_stridx_t, ndim);
+        stridx = ZALLOC_N(cumo_stridx_t, ndim);
     }
 
     view = cumo_na_s_allocate_view(klass);
@@ -152,8 +152,8 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
                 //     idx2[i] = idx1[i];
                 // }
                 idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
                 CUMO_SDX_SET_INDEX(na2->stridx[j],idx2);
+                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
             } else {
                 na2->stridx[j] = na1->stridx[j];
             }
@@ -360,7 +360,7 @@ nstruct_add_type(VALUE type, int argc, VALUE *argv, VALUE nst)
     type = cumo_na_view_new(type,ndim,shape);
     CumoGetNArrayView(type,nt);
 
-    nt->stridx = ALLOC_N(cumo_stridx_t,ndim);
+    nt->stridx = ZALLOC_N(cumo_stridx_t,ndim);
     stride = cumo_na_dtype_element_stride(rb_obj_class(type));
     for (j=ndim; j--; ) {
         CUMO_SDX_SET_STRIDE(nt->stridx[j], stride);


### PR DESCRIPTION
`cumo_na_make_view`, `cumo_na_reverse`, `cumo_na_flatten_dim`, `cumo_na_diagonal` and `cumo_na_make_view_struct` fill `stridx` one dimension at a time, and the device work in that loop can raise. The view is already live for the GC by then, and `cumo_na_view_free` reads every dimension.

So allocate `stridx` zeroed, the way `cumo_na_aref_md_protected` already does. A zero reads as an index of NULL, which frees nothing. And store each fresh index in the view before the copy or the kernel that can raise, the way `index.c` already does, so the view owns it and frees it rather than losing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
