### PR TITLE
Build the block argument for a with_index walk in one place

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -183,4 +183,16 @@ cumo_na_store_rary_fetch(VALUE ary, size_t i, VALUE *x)
     return true;
 }
 
+static inline VALUE
+cumo_na_yield_with_index(VALUE x, size_t *c, VALUE *a, int nd, int md)
+{
+    int j;
+
+    a[0] = x;
+    for (j=0; j<=nd; j++) {
+        a[j+1] = SIZET2NUM(c[j]);
+    }
+    return rb_yield(rb_ary_new4(md,a));
+}
+
 #endif /* ifndef CUMO_TEMPLATE_H */

--- a/ext/cumo/narray/gen/tmpl/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/each_with_index.c
@@ -1,16 +1,3 @@
-static inline void
-yield_each_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
-{
-    int j;
-
-    a[0] = m_data_to_num(x);
-    for (j=0; j<=nd; j++) {
-        a[j+1] = SIZET2NUM(c[j]);
-    }
-    rb_yield(rb_ary_new4(md,a));
-}
-
-
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -37,14 +24,14 @@ static void
         for (; i--;) {
             if (cumo_cuda_runtime_sync_if_busy()) { CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>"); }
             CUMO_GET_DATA_INDEX(p1,idx1,dtype,x);
-            yield_each_with_index(x,c,a,nd,md);
+            cumo_na_yield_with_index(m_data_to_num(x),c,a,nd,md);
             c[nd]++;
         }
     } else {
         for (; i--;) {
             if (cumo_cuda_runtime_sync_if_busy()) { CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>"); }
             CUMO_GET_DATA_STRIDE(p1,s1,dtype,x);
-            yield_each_with_index(x,c,a,nd,md);
+            cumo_na_yield_with_index(m_data_to_num(x),c,a,nd,md);
             c[nd]++;
         }
     }

--- a/ext/cumo/narray/gen/tmpl/map_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/map_with_index.c
@@ -1,15 +1,7 @@
 static inline dtype
 yield_map_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
 {
-    int j;
-    VALUE y;
-
-    a[0] = m_data_to_num(x);
-    for (j=0; j<=nd; j++) {
-        a[j+1] = SIZET2NUM(c[j]);
-    }
-    y = rb_yield(rb_ary_new4(md,a));
-    return m_num_to_data(y);
+    return m_num_to_data(cumo_na_yield_with_index(m_data_to_num(x),c,a,nd,md));
 }
 
 static void

--- a/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
@@ -1,16 +1,3 @@
-static inline void
-yield_each_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
-{
-    int j;
-
-    a[0] = m_data_to_num(x);
-    for (j=0; j<=nd; j++) {
-        a[j+1] = SIZET2NUM(c[j]);
-    }
-    rb_yield(rb_ary_new4(md,a));
-}
-
-
 static void
 <%=c_iter%>(cumo_na_loop_t *const lp)
 {
@@ -39,14 +26,14 @@ static void
         for (; i--;) {
             if (cumo_cuda_runtime_sync_if_busy()) { CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>"); }
             CUMO_LOAD_BIT(a1, p1+*idx1, x); idx1++;
-            yield_each_with_index(x,c,a,nd,md);
+            cumo_na_yield_with_index(m_data_to_num(x),c,a,nd,md);
             c[nd]++;
         }
     } else {
         for (; i--;) {
             if (cumo_cuda_runtime_sync_if_busy()) { CUMO_SHOW_SYNCHRONIZE_WARNING_ONCE("<%=name%>", "<%=type_name%>"); }
             CUMO_LOAD_BIT(a1, p1, x); p1+=s1;
-            yield_each_with_index(x,c,a,nd,md);
+            cumo_na_yield_with_index(m_data_to_num(x),c,a,nd,md);
             c[nd]++;
         }
     }


### PR DESCRIPTION
`yield_each_with_index` is identical in `gen/tmpl` and `gen/tmpl_bit`, down to the character, and `yield_map_with_index` in `gen/tmpl` is the same eleven lines with a return value.

Only the element itself knows its dtype, so the rest moves to one `static inline` in `template.h` and each caller passes `m_data_to_num(x)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
