### PR TITLE
Ask one helper for the dimensions a with_index walk yields

### DIFF
--- a/ext/cumo/include/cumo/template.h
+++ b/ext/cumo/include/cumo/template.h
@@ -183,6 +183,15 @@ cumo_na_store_rary_fetch(VALUE ary, size_t i, VALUE *x)
     return true;
 }
 
+// A 0-dimensional walk still yields one index, so the depth floors at 0 rather
+// than going negative and writing c[-1].
+static inline void
+cumo_na_with_index_dims(int ndim, int *nd, int *md)
+{
+    *nd = (ndim > 0) ? ndim - 1 : ndim;
+    *md = *nd + 2;
+}
+
 static inline VALUE
 cumo_na_yield_with_index(VALUE x, size_t *c, VALUE *a, int nd, int md)
 {

--- a/ext/cumo/narray/gen/tmpl/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/each_with_index.c
@@ -10,9 +10,7 @@ static void
     int nd, md;
 
     c = (size_t*)(lp->opt_ptr);
-    nd = lp->ndim;
-    if (nd > 0) {nd--;}
-    md = nd + 2;
+    cumo_na_with_index_dims(lp->ndim, &nd, &md);
     a = ALLOCA_N(VALUE,md);
 
     CUMO_INIT_COUNTER(lp, i);

--- a/ext/cumo/narray/gen/tmpl/map_with_index.c
+++ b/ext/cumo/narray/gen/tmpl/map_with_index.c
@@ -17,9 +17,7 @@ static void
     int nd, md;
 
     c = (size_t*)(lp->opt_ptr);
-    nd = lp->ndim;
-    if (nd > 0) {nd--;}
-    md = nd + 2;
+    cumo_na_with_index_dims(lp->ndim, &nd, &md);
     a = ALLOCA_N(VALUE,md);
 
     CUMO_INIT_COUNTER(lp, i);

--- a/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
+++ b/ext/cumo/narray/gen/tmpl_bit/each_with_index.c
@@ -12,9 +12,7 @@ static void
     int nd, md;
 
     c = (size_t*)(lp->opt_ptr);
-    nd = lp->ndim;
-    if (nd > 0) {nd--;}
-    md = nd + 2;
+    cumo_na_with_index_dims(lp->ndim, &nd, &md);
     a = ALLOCA_N(VALUE,md);
 
     CUMO_INIT_COUNTER(lp, i);


### PR DESCRIPTION
The two lines that clamp a 0-dimensional walk sit by hand in all three `*_with_index` templates, and a fourth one that forgets them writes `c[-1]`. That is the corruption #396 fixed, and it reached `tmpl_bit` eight years after `tmpl`.

`cumo_na_with_index_dims` in `template.h` now answers both the depth and the block's arity, so a new template asks for them rather than restating the rule. `ndloop.c` is untouched, which keeps the walk itself comparable with numo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
