### PR TITLE
Drop the branch that calls a view with no strides contiguous

### DIFF
--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -459,6 +459,8 @@ cumo_na_reshape_bang(int argc, VALUE *argv, VALUE self)
     if (OBJ_FROZEN(self)) {
         rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
     }
+    // A contiguous view has every dimension on a stride, so overwriting them
+    // below drops no index array this view owns.
     if (cumo_na_check_contiguous(self)==Qfalse) {
         rb_raise(rb_eStandardError, "cannot change shape of non-contiguous NArray");
     }

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1154,9 +1154,6 @@ cumo_na_check_contiguous(VALUE self)
     case CUMO_NARRAY_FILEMAP_T:
         return Qtrue;
     case CUMO_NARRAY_VIEW_T:
-        if (CUMO_NA_VIEW_STRIDX(na)==0) {
-            return Qtrue;
-        }
         if (CUMO_NA_NDIM(na)==0) {
             return Qtrue;
         }


### PR DESCRIPTION
`cumo_na_check_contiguous` answered `true` for a view whose `stridx` is still NULL. A view is only in that state between `cumo_na_s_allocate_view` and the line that fills `stridx` in, and Ruby never sees one.

The answer was not free. `cumo_na_reshape_bang` trusts it and writes strides through that NULL pointer. Its neighbour `cumo_na_check_fortran_contiguous` reads the same field with no guard, so only one of the two treated the state as reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
