### PR TITLE
Borrow the index arrays a view only passes through

### DIFF
--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -501,33 +501,6 @@ cumo_na_has_idx_p(VALUE obj)
     return false;
 }
 
-// An index array a view holds is freed only if it was set through here, so a
-// view that puts one in stridx any other way leaks it.
-static inline void
-cumo_na_index_own(cumo_narray_view_t *nv, int i, size_t *idx)
-{
-    CUMO_SDX_SET_INDEX(nv->stridx[i], idx);
-    nv->index_owned |= (uint64_t)1 << i;
-}
-
-// Every dimension of nv now points at an index array that from reaches, so from
-// has to outlive nv. A lender that owns nothing itself is skipped for its own
-// lender, which keeps the common chain one link long. A lender that owns even
-// one dimension is named directly, since only it keeps that one alive.
-static inline void
-cumo_na_index_borrow_all(cumo_narray_view_t *nv, VALUE from)
-{
-    cumo_narray_view_t *nv1;
-
-    CumoGetNArrayView(from, nv1);
-    nv->index_sync_epoch = nv1->index_sync_epoch;
-    if (!cumo_na_has_idx_p(from)) {
-        return;
-    }
-    nv->index_owner = (nv1->index_owned == 0 && RTEST(nv1->index_owner))
-        ? nv1->index_owner : from;
-}
-
 #define CUMO_NUM2REAL(v)  NUM2DBL( rb_funcall((v),cumo_na_id_real,0) )
 #define CUMO_NUM2IMAG(v)  NUM2DBL( rb_funcall((v),cumo_na_id_imag,0) )
 
@@ -543,6 +516,51 @@ typedef unsigned int CUMO_BIT_DIGIT;
 
 #include "cumo/ndloop.h"
 #include "cumo/intern.h"
+
+// An index array a view holds is freed only if it was set through here, so a
+// view that puts one in stridx any other way leaks it. The bit names the slot,
+// so code that permutes stridx has to permute index_owned with it.
+static inline void
+cumo_na_index_own(cumo_narray_view_t *nv, int i, size_t *idx)
+{
+    CUMO_SDX_SET_INDEX(nv->stridx[i], idx);
+    nv->index_owned |= (uint64_t)1 << i;
+}
+
+// One dimension of nv now points at an index array that from reaches, so from
+// has to outlive nv. A lender that owns nothing itself is skipped for its own
+// lender, which keeps the common chain one link long. A lender that owns even
+// one dimension is named directly, since only it keeps that one alive.
+//
+// A view borrows every index array or none. Borrowing some while building
+// others holds the lender for arrays this view has already replaced, which
+// costs more memory than the copy it saves. One lender is recorded, so a view
+// may not borrow from two.
+static inline void
+cumo_na_index_borrow(cumo_narray_view_t *nv, VALUE from)
+{
+    cumo_narray_view_t *nv1;
+
+    if (RTEST(nv->index_owner)) {
+        return;
+    }
+    CumoGetNArrayView(from, nv1);
+    nv->index_owner = (nv1->index_owned == 0 && RTEST(nv1->index_owner))
+        ? nv1->index_owner : from;
+}
+
+// Called once a view built from another one has all its dimensions. A view that
+// owns index arrays built them here, so a fill is in flight and the first read
+// waits. One that borrows them all is as settled as the view it borrowed from.
+static inline void
+cumo_na_index_mark_derived(cumo_narray_view_t *nv, cumo_narray_view_t *nv1)
+{
+    if (nv->index_owned != 0) {
+        cumo_na_index_mark_filled(nv);
+    } else {
+        nv->index_sync_epoch = nv1->index_sync_epoch;
+    }
+}
 
 // for Ractor support code
 #ifndef HAVE_RB_EXT_RACTOR_SAFE

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -528,11 +528,11 @@ VALUE
 cumo_na_flatten_dim(VALUE self, int sd)
 {
     int i, nd, fd;
-    size_t *idx1, *idx2;
+    size_t *idx2;
     size_t stride;
     size_t  *shape, size;
     cumo_narray_t *na;
-    cumo_narray_view_t *na1, *na2;
+    cumo_narray_view_t *na1 = NULL, *na2;
     volatile VALUE view;
 
     CumoGetNArray(self,na);
@@ -580,14 +580,11 @@ cumo_na_flatten_dim(VALUE self, int sd)
         CumoGetNArrayView(self, na1);
         na2->data = na1->data;
         na2->offset = na1->offset;
+        // Every caller passes sd == 0 today, so this loop does not run.
         for (i=0; i<sd; i++) {
+            na2->stridx[i] = na1->stridx[i];
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
-                idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*shape[i]);
-                cumo_na_index_own(na2,i,idx2);
-                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*shape[i],cudaMemcpyDeviceToDevice,0));
-            } else {
-                na2->stridx[i] = na1->stridx[i];
+                cumo_na_index_borrow(na2, self);
             }
         }
         // flat dimension == last dimension that advances. A length-1 dimension
@@ -618,7 +615,11 @@ cumo_na_flatten_dim(VALUE self, int sd)
         }
         break;
     }
-    cumo_na_index_mark_filled(na2);
+    if (na1 != NULL) {
+        cumo_na_index_mark_derived(na2, na1);
+    } else {
+        cumo_na_index_mark_filled(na2);
+    }
     return view;
 }
 
@@ -676,13 +677,13 @@ void cumo_na_diagonal_stride_index_kernel_launch(size_t *idx, ssize_t s0, size_t
 static VALUE
 cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
 {
-    int  i, k, nd;
+    int  i, k, nd, borrow;
     size_t *idx0, *idx1, *diag_idx;
     size_t *shape;
     size_t  diag_size;
     ssize_t stride, stride0, stride1;
     cumo_narray_t *na;
-    cumo_narray_view_t *na1, *na2;
+    cumo_narray_view_t *na1 = NULL, *na2;
     VALUE view;
     VALUE vofs=0, vaxes=0;
     ssize_t kofs;
@@ -808,19 +809,19 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
         CumoGetNArrayView(self, na1);
         na2->data = na1->data;
         na2->offset = na1->offset;
+        borrow = !CUMO_SDX_IS_INDEX(na1->stridx[ax[0]]) && !CUMO_SDX_IS_INDEX(na1->stridx[ax[1]]);
         for (i=k=0; i<nd; i++) {
             if (i != ax[0] && i != ax[1]) {
-                if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
+                if (borrow || !CUMO_SDX_IS_INDEX(na1->stridx[i])) {
+                    na2->stridx[k] = na1->stridx[i];
+                    if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
+                        cumo_na_index_borrow(na2, self);
+                    }
+                } else {
                     idx0 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                    // idx1 = ALLOC_N(size_t, na->shape[i]);
-                    // for (j=0; j<na->shape[i]; j++) {
-                    //     idx1[j] = idx0[j];
-                    // }
                     idx1 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*na->shape[i]);
                     cumo_na_index_own(na2,k,idx1);
                     cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx1,idx0,sizeof(size_t)*na->shape[i],cudaMemcpyDeviceToDevice,0));
-                } else {
-                    na2->stridx[k] = na1->stridx[i];
                 }
                 k++;
             }
@@ -853,7 +854,11 @@ cumo_na_diagonal(int argc, VALUE *argv, VALUE self)
         }
         break;
     }
-    cumo_na_index_mark_filled(na2);
+    if (na1 != NULL) {
+        cumo_na_index_mark_derived(na2, na1);
+    } else {
+        cumo_na_index_mark_filled(na2);
+    }
     return view;
 }
 

--- a/ext/cumo/narray/narray.c
+++ b/ext/cumo/narray/narray.c
@@ -1256,7 +1256,7 @@ cumo_na_make_view(VALUE self)
     int i, nd;
     ssize_t stride;
     cumo_narray_t *na;
-    cumo_narray_view_t *na1, *na2;
+    cumo_narray_view_t *na1 = NULL, *na2;
     volatile VALUE view;
 
     CumoGetNArray(self,na);
@@ -1285,14 +1285,17 @@ cumo_na_make_view(VALUE self)
         CumoGetNArrayView(self, na1);
         for (i=0; i<nd; i++) {
             na2->stridx[i] = na1->stridx[i];
+            if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
+                cumo_na_index_borrow(na2, self);
+            }
         }
         na2->offset = na1->offset;
         na2->data = na1->data;
         break;
     }
 
-    if (na->type == CUMO_NARRAY_VIEW_T) {
-        cumo_na_index_borrow_all(na2, self);
+    if (na1 != NULL) {
+        cumo_na_index_mark_derived(na2, na1);
     } else {
         cumo_na_index_mark_filled(na2);
     }
@@ -1381,14 +1384,14 @@ void cumo_na_index_reverse_kernel_launch(size_t *idx, size_t *idx1, uint64_t n);
 static VALUE
 cumo_na_reverse(int argc, VALUE *argv, VALUE self)
 {
-    int i, nd;
+    int i, nd, borrow;
     size_t  n;
     size_t  offset;
     size_t *idx1, *idx2;
     ssize_t stride;
     ssize_t sign;
     cumo_narray_t *na;
-    cumo_narray_view_t *na1, *na2;
+    cumo_narray_view_t *na1 = NULL, *na2;
     VALUE view;
     VALUE reduce;
 
@@ -1426,15 +1429,28 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
     case CUMO_NARRAY_VIEW_T:
         CumoGetNArrayView(self, na1);
         offset = na1->offset;
+        borrow = 1;
+        for (i=0; i<nd; i++) {
+            if (CUMO_SDX_IS_INDEX(na1->stridx[i]) && cumo_na_test_reduce(reduce,i)) {
+                borrow = 0;
+                break;
+            }
+        }
         for (i=0; i<nd; i++) {
             n = na1->base.shape[i];
             if (CUMO_SDX_IS_INDEX(na1->stridx[i])) {
-                idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
-                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-                cumo_na_index_own(na2,i,idx2);
-                if (cumo_na_test_reduce(reduce,i)) {
+                if (borrow) {
+                    na2->stridx[i] = na1->stridx[i];
+                    cumo_na_index_borrow(na2, self);
+                } else if (cumo_na_test_reduce(reduce,i)) {
+                    idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
+                    idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
+                    cumo_na_index_own(na2,i,idx2);
                     cumo_na_index_reverse_kernel_launch(idx2,idx1,n);
                 } else {
+                    idx1 = CUMO_SDX_GET_INDEX(na1->stridx[i]);
+                    idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
+                    cumo_na_index_own(na2,i,idx2);
                     cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
                 }
             } else {
@@ -1452,7 +1468,11 @@ cumo_na_reverse(int argc, VALUE *argv, VALUE self)
         break;
     }
 
-    cumo_na_index_mark_filled(na2);
+    if (na1 != NULL) {
+        cumo_na_index_mark_derived(na2, na1);
+    } else {
+        cumo_na_index_mark_filled(na2);
+    }
     return view;
 }
 

--- a/ext/cumo/narray/struct.c
+++ b/ext/cumo/narray/struct.c
@@ -76,14 +76,12 @@ void cumo_na_copy_array_structure(VALUE self, VALUE view);
 static VALUE
 cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
 {
-    size_t n;
     int j, k, ndim;
     size_t *shape;
-    size_t *idx1, *idx2;
     ssize_t stride;
     cumo_stridx_t *stridx;
     cumo_narray_t *na, *nt;
-    cumo_narray_view_t *na1, *na2;
+    cumo_narray_view_t *na1 = NULL, *na2;
     VALUE klass;
     volatile VALUE view;
 
@@ -144,18 +142,9 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
     case CUMO_NARRAY_VIEW_T:
         CumoGetNArrayView(self, na1);
         for (j=na1->base.ndim; j--; ) {
+            na2->stridx[j] = na1->stridx[j];
             if (CUMO_SDX_IS_INDEX(na1->stridx[j])) {
-                n = na1->base.shape[j];
-                idx1 = CUMO_SDX_GET_INDEX(na1->stridx[j]);
-                // idx2 = ALLOC_N(size_t, na1->base.shape[j]);
-                // for (i=0; i<n; i++) {
-                //     idx2[i] = idx1[i];
-                // }
-                idx2 = (size_t*)cumo_cuda_runtime_malloc(sizeof(size_t)*n);
-                cumo_na_index_own(na2,j,idx2);
-                cumo_cuda_runtime_check_status(cudaMemcpyAsync(idx2,idx1,sizeof(size_t)*n,cudaMemcpyDeviceToDevice,0));
-            } else {
-                na2->stridx[j] = na1->stridx[j];
+                cumo_na_index_borrow(na2, self);
             }
         }
         na2->offset = na1->offset;
@@ -167,7 +156,11 @@ cumo_na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
         na2->offset += NUM2SIZET(offset);
     }
 
-    cumo_na_index_mark_filled(na2);
+    if (na1 != NULL) {
+        cumo_na_index_mark_derived(na2, na1);
+    } else {
+        cumo_na_index_mark_filled(na2);
+    }
     return view;
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4760,6 +4760,37 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  test "a view that only passes an index through allocates nothing for it" do
+    pool = Cumo::CUDA::MemoryPool
+    a = Cumo::DFloat.new(1024, 4).seq
+    idx = Array.new(1024) { |i| 1023 - i }
+    v = a[idx, true]
+    cube = Cumo::DFloat.new(1024, 3, 3).seq[idx, true, true]
+
+    {
+      "reverse(1)" => -> { v.reverse(1) },
+      "diagonal" => -> { cube.diagonal },
+      "transpose" => -> { v.transpose },
+      "view" => -> { v.view },
+    }.each do |name, op|
+      3.times { op.call }
+      3.times { GC.start }
+      held = []
+      before = pool.used_bytes
+      20.times { held << op.call }
+      assert_equal(0, pool.used_bytes - before, name)
+    end
+
+    # a view borrows every index or none, so one that turns a dimension around
+    # builds the rest rather than holding the view it came from
+    3.times { v.reverse(0) }
+    3.times { GC.start }
+    held = []
+    before = pool.used_bytes
+    20.times { held << v.reverse(0) }
+    assert_operator(pool.used_bytes - before, :>, 0)
+  end
+
   test "a view frees the index arrays it owns" do
     pool = Cumo::CUDA::MemoryPool
     a = Cumo::DFloat.new(1024, 4).seq
@@ -4793,6 +4824,7 @@ class NArrayTest < Test::Unit::TestCase
     out = run_child(<<~RUBY, env: { "CUMO_MEMORY_POOL" => "OFF" })
       require "cumo/narray"
       want = Cumo::DFloat.new(8, 4).seq[[3, 1, 0, 2, 3, 1, 0, 2], true].to_a
+      diag = Cumo::DFloat.new(4, 3, 3).seq[[3, 1, 0, 2], true, true].diagonal.to_a
       held = {}
       5.times do
         v = Cumo::DFloat.new(8, 4).seq[[3, 1, 0, 2, 3, 1, 0, 2], true]
@@ -4801,6 +4833,9 @@ class NArrayTest < Test::Unit::TestCase
         held["swapaxes"] = v.swapaxes(0, 1)
         held["expand_dims"] = v.expand_dims(0)
         held["chain"] = v.transpose.view.transpose
+        held["reverse"] = v.reverse(1)
+        held["diagonal"] = Cumo::DFloat.new(4, 3, 3).seq[[3, 1, 0, 2], true, true].diagonal
+        held["mixed"] = Cumo::DFloat.new(4, 3).seq[[3, 1, 0], [2, 0, 1]].reverse(0)
       end
       5.times { GC.start }
       Cumo::DFloat.new(1 << 16).seq
@@ -4810,6 +4845,9 @@ class NArrayTest < Test::Unit::TestCase
       raise "swapaxes" unless held["swapaxes"].to_a == want.transpose
       raise "expand_dims" unless held["expand_dims"].to_a == [want]
       raise "chain" unless held["chain"].to_a == want
+      raise "reverse" unless held["reverse"].to_a == want.map(&:reverse)
+      raise "diagonal" unless held["diagonal"].to_a == diag
+      raise "mixed" unless held["mixed"].to_a == [[2.0, 0.0, 1.0], [5.0, 3.0, 4.0], [11.0, 9.0, 10.0]]
       puts "ok"
     RUBY
     assert_match(/^ok$/, out)


### PR DESCRIPTION
#410 taught a view to point at the index arrays of the one it was made from. `reverse` still copied the dimensions it does not turn around, and `diagonal` copied the ones it passes through. Both borrow them now. On a 2^20 index `reverse(1)` costs 0.2us rather than 327us, and `diagonal` 0.1us rather than 329us.

A view borrows every index array or none. Borrowing some while building others would hold the lender for arrays the view has already replaced, which costs more memory than the copy it saves. So a `reverse` that turns a dimension around still copies the rest.

`flatten_dim` and the struct view take the same shape, though neither has a pass-through dimension to borrow today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
