### PR TITLE
Say so when a view holds an index array nobody owns

### DIFF
--- a/ext/cumo/include/cumo/intern.h
+++ b/ext/cumo/include/cumo/intern.h
@@ -80,6 +80,7 @@ void cumo_na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep);
 
 // used in aref, aset
 int cumo_na_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);
+void cumo_na_index_check_stray(cumo_narray_view_t *nv);
 void cumo_na_index_mark_filled(cumo_narray_view_t *nv);
 void cumo_na_index_wait_fill(cumo_narray_view_t *nv);
 VALUE cumo_na_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int result_nd, size_t pos);

--- a/ext/cumo/include/cumo/narray.h
+++ b/ext/cumo/include/cumo/narray.h
@@ -558,6 +558,7 @@ cumo_na_index_mark_derived(cumo_narray_view_t *nv, cumo_narray_view_t *nv1)
     if (nv->index_owned != 0) {
         cumo_na_index_mark_filled(nv);
     } else {
+        cumo_na_index_check_stray(nv);
         nv->index_sync_epoch = nv1->index_sync_epoch;
     }
 }

--- a/ext/cumo/narray/data.c
+++ b/ext/cumo/narray/data.c
@@ -256,6 +256,8 @@ cumo_na_swapaxes(VALUE self, VALUE a1, VALUE a2)
     cumo_narray_view_t *na;
     volatile VALUE view;
 
+    // cumo_na_make_view borrows, so index_owned is zero and the swap below
+    // has no ownership bits to carry with the strides.
     view = cumo_na_make_view(self);
     CumoGetNArrayView(view,na);
 

--- a/ext/cumo/narray/index.c
+++ b/ext/cumo/narray/index.c
@@ -118,9 +118,41 @@ cumo_na_range_check(ssize_t pos, ssize_t size, int dim)
 // rather than correctness.
 static uint64_t cumo_na_sync_epoch = 0;
 
+// An index array a view holds is freed only through index_owned and kept alive
+// only through index_owner, so one that has neither leaks when this view is its
+// last reference and dangles when it is not. The free hook cannot tell those
+// apart, and never sees a view that is held for the life of the program, so ask
+// here instead: every constructor passes through on its way out.
+void
+cumo_na_index_check_stray(cumo_narray_view_t *nv)
+{
+    static uint64_t warned = 0;
+    uint64_t bit;
+    int i;
+
+    for (i = 0; i < nv->base.ndim; i++) {
+        bit = (uint64_t)1 << i;
+        if ((warned & bit) || !CUMO_SDX_IS_INDEX(nv->stridx[i])) {
+            continue;
+        }
+        if (CUMO_SDX_GET_INDEX(nv->stridx[i]) == NULL) {
+            continue;
+        }
+        if ((nv->index_owned & bit) || RTEST(nv->index_owner)) {
+            continue;
+        }
+        warned |= bit;
+        rb_warn("cumo: dimension %d of a view holds an index array it neither "
+                "owns nor borrows. Its constructor set stridx without "
+                "cumo_na_index_own or cumo_na_index_borrow, so the array leaks "
+                "if nothing else holds it, and dangles if something does.", i);
+    }
+}
+
 void
 cumo_na_index_mark_filled(cumo_narray_view_t *nv)
 {
+    cumo_na_index_check_stray(nv);
     nv->index_sync_epoch = cumo_na_sync_epoch;
 }
 

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -4760,6 +4760,25 @@ class NArrayTest < Test::Unit::TestCase
     end
   end
 
+  test "no view holds an index array nobody owns" do
+    out = run_child(<<~RUBY)
+      require "cumo/narray"
+      a = Cumo::DFloat.new(64, 4).seq
+      idx = Array.new(64) { |i| 63 - i }
+      v = a[idx, true]
+      cube = Cumo::DFloat.new(64, 3, 3).seq[idx, true, true]
+      col = a[true, 0]
+      [v, v.reverse, v.reverse(1), v.transpose, v.view, v.swapaxes(0, 1),
+       v.expand_dims(0), v.flatten, cube.diagonal, col[col > 30],
+       a[Cumo::Int32.cast(idx), true], a.at([idx, [0] * 64])].each(&:to_a)
+      5.times { GC.start }
+      puts "done"
+    RUBY
+    assert_match(/^done$/, out)
+    assert_no_match(/neither owns nor borrows/, out)
+    assert_no_match(/failed to free device memory/, out)
+  end
+
   test "a view that only passes an index through allocates nothing for it" do
     pool = Cumo::CUDA::MemoryPool
     a = Cumo::DFloat.new(1024, 4).seq


### PR DESCRIPTION
An index array a view holds is freed only through `index_owned` and kept alive only through `index_owner`. A constructor that sets `stridx` directly gets neither, and nothing says so. The array leaks when that view is the last reference to it, and dangles when it is not.

Every view constructor passes through `cumo_na_index_mark_filled` or `cumo_na_index_mark_derived` on its way out, so the check sits there rather than in the free hook. It reports once per dimension, at construction, with the Ruby line that built the view. The free hook would see neither a view that is held for the life of the program, nor which of the two failures it is looking at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
